### PR TITLE
Add bundled sp CLI with socket ping control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,12 @@ The app uses **The Composable Architecture (TCA)** with a feature-based folder s
 
 - `App/` — App entry point (`SupatermApp`), `ContentView`, `AppDelegate`, `TerminalCommands`
 - `Features/App/` — Root `AppFeature` reducer: composes child features, manages terminal tab selection
+- `Features/Socket/` — App-global socket control runtime, dependency client, and reducer-driven request handling
 - `Features/Terminal/` — Terminal shell UI: sidebar, detail pane, split view, tab catalog, resize handles
 - `Features/Update/` — `UpdateFeature` reducer + `UpdateClient` dependency wrapping Sparkle (SPU) for in-app updates
 
 **Dependency pattern**: External services are modeled as TCA `DependencyKey` structs with closure-based interfaces (see `UpdateClient`). Live implementations wrap platform SDKs; test implementations return inert defaults.
+
+**Socket control**: Read `docs/SOCKET_CONTROL.md` before changing the bundled `sp` CLI, socket protocol, or socket runtime.
 
 **Tests** (`supatermTests/`) use Swift Testing (`@Test`, `@Suite`) with TCA's `TestStore`. Tests cover reducer logic; UI views are not snapshot-tested.

--- a/Project.swift
+++ b/Project.swift
@@ -21,6 +21,46 @@ let project = Project(
   ),
   targets: [
     .target(
+      name: "SupatermCLIShared",
+      destinations: .macOS,
+      product: .staticLibrary,
+      bundleId: "app.supabit.supaterm.cli-shared",
+      deploymentTargets: .macOS("26.0"),
+      infoPlist: .default,
+      sources: [
+        "SupatermCLIShared/**",
+      ],
+      settings: .settings(
+        base: [
+          "SWIFT_DEFAULT_ACTOR_ISOLATION": "nonisolated",
+          "SWIFT_STRICT_CONCURRENCY": "complete",
+        ],
+        defaultSettings: .essential
+      )
+    ),
+    .target(
+      name: "sp",
+      destinations: .macOS,
+      product: .commandLineTool,
+      bundleId: "app.supabit.sp",
+      deploymentTargets: .macOS("26.0"),
+      infoPlist: .default,
+      sources: [
+        "sp/**",
+      ],
+      dependencies: [
+        .target(name: "SupatermCLIShared"),
+        .external(name: "ArgumentParser"),
+      ],
+      settings: .settings(
+        base: [
+          "SWIFT_DEFAULT_ACTOR_ISOLATION": "nonisolated",
+          "SWIFT_STRICT_CONCURRENCY": "complete",
+        ],
+        defaultSettings: .essential
+      )
+    ),
+    .target(
       name: "supaterm",
       destinations: .macOS,
       product: .app,
@@ -58,7 +98,33 @@ let project = Project(
         "supaterm/App",
         "supaterm/Features",
       ],
+      scripts: [
+        .post(
+          script: """
+            set -eu
+
+            source_path="${BUILT_PRODUCTS_DIR}/sp"
+            destination_path="${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/MacOS/sp"
+
+            if [ ! -x "${source_path}" ]; then
+              echo "error: missing built sp executable at ${source_path}" >&2
+              exit 1
+            fi
+
+            /bin/cp -f "${source_path}" "${destination_path}"
+            """,
+          name: "Embed sp CLI",
+          inputPaths: [
+            "$(BUILT_PRODUCTS_DIR)/sp",
+          ],
+          outputPaths: [
+            "$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/MacOS/sp",
+          ]
+        ),
+      ],
       dependencies: [
+        .target(name: "SupatermCLIShared"),
+        .target(name: "sp"),
         .xcframework(path: "Frameworks/GhosttyKit.xcframework"),
         .external(name: "ComposableArchitecture"),
         .external(name: "Sparkle"),
@@ -91,6 +157,7 @@ let project = Project(
       ],
       dependencies: [
         .target(name: "supaterm"),
+        .target(name: "SupatermCLIShared"),
         .external(name: "ComposableArchitecture"),
       ],
       settings: .settings(

--- a/SupatermCLIShared/SupatermCLIContext.swift
+++ b/SupatermCLIShared/SupatermCLIContext.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public enum SupatermCLIEnvironment {
+  public static let surfaceIDKey = "SUPATERM_SURFACE_ID"
+  public static let tabIDKey = "SUPATERM_TAB_ID"
+  public static let socketPathKey = "SUPATERM_SOCKET_PATH"
+}
+
+public struct SupatermCLIEnvironmentVariable: Equatable, Sendable {
+  public let key: String
+  public let value: String
+
+  public init(key: String, value: String) {
+    self.key = key
+    self.value = value
+  }
+}
+
+public struct SupatermCLIContext: Equatable, Sendable {
+  public let surfaceID: UUID
+  public let tabID: UUID
+
+  public init(surfaceID: UUID, tabID: UUID) {
+    self.surfaceID = surfaceID
+    self.tabID = tabID
+  }
+
+  public init?(environment: [String: String]) {
+    guard
+      let surfaceID = environment[SupatermCLIEnvironment.surfaceIDKey]
+        .flatMap(UUID.init(uuidString:)),
+      let tabID = environment[SupatermCLIEnvironment.tabIDKey]
+        .flatMap(UUID.init(uuidString:))
+    else {
+      return nil
+    }
+
+    self.init(surfaceID: surfaceID, tabID: tabID)
+  }
+
+  public static var current: Self? {
+    Self(environment: ProcessInfo.processInfo.environment)
+  }
+
+  public var environmentVariables: [SupatermCLIEnvironmentVariable] {
+    [
+      .init(
+        key: SupatermCLIEnvironment.surfaceIDKey,
+        value: surfaceID.uuidString
+      ),
+      .init(
+        key: SupatermCLIEnvironment.tabIDKey,
+        value: tabID.uuidString
+      ),
+    ]
+  }
+}

--- a/SupatermCLIShared/SupatermSocketPath.swift
+++ b/SupatermCLIShared/SupatermSocketPath.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum SupatermSocketPath {
+  public static let directoryName = "Supaterm"
+  public static let fileName = "supaterm.sock"
+
+  public static func defaultURL(
+    appSupportDirectory: URL? = nil,
+    fileManager: FileManager = .default
+  ) -> URL? {
+    let resolvedAppSupportDirectory: URL
+    if let appSupportDirectory {
+      resolvedAppSupportDirectory = appSupportDirectory
+    } else if let discovered = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+      resolvedAppSupportDirectory = discovered
+    } else {
+      return nil
+    }
+
+    return resolvedAppSupportDirectory
+      .appendingPathComponent(directoryName, isDirectory: true)
+      .appendingPathComponent(fileName, isDirectory: false)
+  }
+
+  public static func resolve(
+    explicitPath: String? = nil,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    appSupportDirectory: URL? = nil,
+    fileManager: FileManager = .default
+  ) -> String? {
+    if let explicitPath = normalized(explicitPath) {
+      return explicitPath
+    }
+
+    if let environmentPath = normalized(environment[SupatermCLIEnvironment.socketPathKey]) {
+      return environmentPath
+    }
+
+    return defaultURL(
+      appSupportDirectory: appSupportDirectory,
+      fileManager: fileManager
+    )?.path
+  }
+
+  public static func normalized(_ path: String?) -> String? {
+    guard let path else { return nil }
+    let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return trimmed
+  }
+}

--- a/SupatermCLIShared/SupatermSocketProtocol.swift
+++ b/SupatermCLIShared/SupatermSocketProtocol.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+public enum SupatermSocketMethod {
+  public static let systemPing = "system.ping"
+}
+
+public enum SupatermSocketValue: Equatable, Sendable, Codable {
+  case array([Self])
+  case bool(Bool)
+  case null
+  case number(Double)
+  case object([String: Self])
+  case string(String)
+
+  public var boolValue: Bool? {
+    guard case .bool(let value) = self else { return nil }
+    return value
+  }
+
+  public var objectValue: [String: Self]? {
+    guard case .object(let value) = self else { return nil }
+    return value
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+    } else if let boolValue = try? container.decode(Bool.self) {
+      self = .bool(boolValue)
+    } else if let doubleValue = try? container.decode(Double.self) {
+      self = .number(doubleValue)
+    } else if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let arrayValue = try? container.decode([Self].self) {
+      self = .array(arrayValue)
+    } else {
+      self = .object(try container.decode([String: Self].self))
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .array(let value):
+      try container.encode(value)
+    case .bool(let value):
+      try container.encode(value)
+    case .null:
+      try container.encodeNil()
+    case .number(let value):
+      try container.encode(value)
+    case .object(let value):
+      try container.encode(value)
+    case .string(let value):
+      try container.encode(value)
+    }
+  }
+}
+
+public struct SupatermSocketRequest: Equatable, Sendable, Codable {
+  public let id: String
+  public let method: String
+  public let params: [String: SupatermSocketValue]
+
+  public init(
+    id: String,
+    method: String,
+    params: [String: SupatermSocketValue] = [:]
+  ) {
+    self.id = id
+    self.method = method
+    self.params = params
+  }
+
+  public static func ping(id: String = UUID().uuidString) -> Self {
+    Self(id: id, method: SupatermSocketMethod.systemPing)
+  }
+}
+
+public struct SupatermSocketResponse: Equatable, Sendable, Codable {
+  public struct ErrorPayload: Equatable, Sendable, Codable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+      self.code = code
+      self.message = message
+    }
+  }
+
+  public let id: String?
+  public let ok: Bool
+  public let result: [String: SupatermSocketValue]?
+  public let error: ErrorPayload?
+
+  public init(
+    id: String?,
+    ok: Bool,
+    result: [String: SupatermSocketValue]? = nil,
+    error: ErrorPayload? = nil
+  ) {
+    self.id = id
+    self.ok = ok
+    self.result = result
+    self.error = error
+  }
+
+  public static func ok(
+    id: String,
+    result: [String: SupatermSocketValue] = [:]
+  ) -> Self {
+    Self(id: id, ok: true, result: result)
+  }
+
+  public static func error(
+    id: String? = nil,
+    code: String,
+    message: String
+  ) -> Self {
+    Self(id: id, ok: false, error: .init(code: code, message: message))
+  }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f267c41f2bfffa4da8460651d05ce706fea3a476f4a6b91feb3a5cf1da1959ed",
+  "originHash" : "e03ad5fb3aa1b5d24954e452a1ed3761d86a77db3913d2fff0c77976dc8ee2cf",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
         "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
+        "version" : "1.6.2"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -15,6 +15,7 @@ let packageSettings = PackageSettings(
 let package = Package(
   name: "supaterm",
   dependencies: [
+    .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.6.2"),
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.23.1"),
     .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.0"),
   ]

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -1,0 +1,80 @@
+# Socket Control
+
+Supaterm exposes a local Unix domain socket so the bundled `sp` CLI can talk to the running app.
+
+## Path and lifetime
+
+- The socket path is computed in `SupatermCLIShared/SupatermSocketPath.swift`.
+- Resolution order is:
+  - an explicit CLI `--socket` override
+  - `SUPATERM_SOCKET_PATH` from the environment
+  - `~/Library/Application Support/Supaterm/supaterm.sock`
+- The app does not persist alternate socket paths. The default path is computed when needed.
+- When the app starts the socket runtime:
+  - creates `~/Library/Application Support/Supaterm` with `0700`
+  - removes any stale socket file at the resolved path
+  - binds and listens on `supaterm.sock`
+  - sets the socket file permissions to `0600`
+- When the app stops the runtime, it closes the listener and removes the socket file.
+
+## Architecture
+
+- `SupatermCLIShared` owns the shared contract:
+  - environment keys such as `SUPATERM_SOCKET_PATH`
+  - socket path resolution
+  - request and response payload types
+- `SocketControlRuntime` owns the Unix socket server:
+  - `socket`, `bind`, `listen`, `accept`, `read`, and `write`
+  - directory creation and socket-file cleanup
+  - malformed request handling before anything reaches TCA
+- `SocketControlClient` is the dependency boundary between the runtime and the reducer.
+- `SocketControlFeature` owns request semantics:
+  - starts the runtime
+  - consumes decoded requests as an `AsyncStream`
+  - turns methods into responses
+- `AppFeature` hosts `SocketControlFeature`, so socket requests enter the normal reducer graph.
+
+This split is intentional. Transport details stay out of reducers, while actual command behavior remains testable with `TestStore`.
+
+## Protocol
+
+- Transport is newline-delimited UTF-8 JSON.
+- One request line produces one response line.
+- Requests use:
+  - `id`: caller-generated correlation id
+  - `method`: command name
+  - `params`: method arguments
+- Responses use:
+  - `id`: copied from the request when available
+  - `ok`: success flag
+  - `result`: payload for successful calls
+  - `error`: `{ code, message }` for failures
+- Unknown methods return `method_not_found`.
+- Invalid JSON never reaches the reducer. The runtime replies with `invalid_request`.
+
+## Current command surface
+
+- `system.ping` is the only socket method today.
+- The reducer answers with:
+
+```json
+{"id":"...","ok":true,"result":{"pong":true}}
+```
+
+- `sp ping` resolves the socket path, sends `system.ping`, and prints `pong` on success.
+
+## Pane environment
+
+Supaterm injects the following values into terminal panes:
+
+- `SUPATERM_SOCKET_PATH`
+- `SUPATERM_SURFACE_ID`
+- `SUPATERM_TAB_ID`
+
+That gives `sp` enough context to find the local app socket from inside a pane without extra shell setup.
+
+## Tests
+
+- Shared protocol and path logic live under `supatermTests` and should be covered with direct unit tests.
+- Reducer behavior belongs in `SocketControlFeatureTests`.
+- Runtime tests should stay focused on transport behavior only.

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -1,6 +1,15 @@
 # Socket Control
 
-This document is a code map. The source is authoritative.
+This document is a short map of the socket path. The source is authoritative.
+
+## Overview
+
+- `SupatermApp` starts the socket feature when the app launches. See `supaterm/App/supatermApp.swift`.
+- `SocketControlFeature` owns command semantics and turns decoded requests into responses. See `supaterm/Features/Socket/SocketControlFeature.swift`.
+- `SocketControlRuntime` owns the Unix socket transport, including listening, accepting, decoding, and writing replies. See `supaterm/Features/Socket/SocketControlRuntime.swift`.
+- `SupatermCLIShared` owns the shared contract between app and CLI: environment keys, socket path resolution, and request/response types. See `SupatermCLIShared/SupatermCLIContext.swift`, `SupatermCLIShared/SupatermSocketPath.swift`, and `SupatermCLIShared/SupatermSocketProtocol.swift`.
+- `sp ping` resolves the socket path, sends a request through `SPSocketClient`, and prints the reducer's response. See `sp/main.swift` and `sp/SPSocketClient.swift`.
+- Terminal panes receive the socket path and pane context through the environment. See `supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift`.
 
 ## Flow
 

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -14,36 +14,39 @@ This document is a short map of the socket path. The source is authoritative.
 ## Flow
 
 ```text
-SupatermApp
-  |
-  v
-AppFeature
-  |
-  v
-SocketControlFeature
-  |
-  v
-SocketControlClient
-  |
-  v
-SocketControlRuntime
-  ^
-  |
-SPSocketClient
-  ^
-  |
-sp ping
+App side
 
-GhosttySurfaceView
-  |
-  v
-SupatermCLIContext + SUPATERM_SOCKET_PATH
-  |
-  v
-terminal pane
-  |
-  v
-sp
++------------------+      +------------------------+      +----------------------+
+| SupatermApp      | ---> | AppFeature             | ---> | SocketControlFeature |
++------------------+      +------------------------+      +-----------+----------+
+                                                                     |
+                                                                     v
+                                                          +----------------------+
+                                                          | SocketControlClient  |
+                                                          +-----------+----------+
+                                                                      |
+                                                                      v
+                                                          +----------------------+
+                                                          | SocketControlRuntime |
+                                                          +----------------------+
+                                                                      ^
+                                                                      |
+CLI side                                                              |
+
++------------------+      +------------------+                        |
+| sp ping          | ---> | SPSocketClient   +------------------------+
++------------------+      +------------------+
+
+Pane path
+
++------------------------+      +-----------------------------------+      +------------------+
+| GhosttySurfaceView     | ---> | SupatermCLIShared                 | ---> | terminal pane    |
++------------------------+      | - SupatermCLIContext              |      +---------+--------+
+                                | - SupatermSocketPath              |                |
+                                | - SupatermSocketProtocol          |                v
+                                +-----------------------------------+             +------+
+                                                                                  |  sp  |
+                                                                                  +------+
 ```
 
 ## Code Map

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -11,6 +11,14 @@ This document is a short map of the socket path. The source is authoritative.
 - `sp ping` resolves the socket path, sends a request through `SPSocketClient`, and prints the reducer's response. See `sp/main.swift` and `sp/SPSocketClient.swift`.
 - Terminal panes receive the socket path and pane context through the environment. See `supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift`.
 
+## Environment
+
+- `SUPATERM_SOCKET_PATH`: socket path override and pane-provided socket location
+- `SUPATERM_SURFACE_ID`: pane surface identifier
+- `SUPATERM_TAB_ID`: pane tab identifier
+
+Definitions live in `SupatermCLIShared/SupatermCLIContext.swift`.
+
 ## Flow
 
 ```text

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -1,80 +1,58 @@
 # Socket Control
 
-Supaterm exposes a local Unix domain socket so the bundled `sp` CLI can talk to the running app.
+This document is a code map. The source is authoritative.
 
-## Path and lifetime
+## Flow
 
-- The socket path is computed in `SupatermCLIShared/SupatermSocketPath.swift`.
-- Resolution order is:
-  - an explicit CLI `--socket` override
-  - `SUPATERM_SOCKET_PATH` from the environment
-  - `~/Library/Application Support/Supaterm/supaterm.sock`
-- The app does not persist alternate socket paths. The default path is computed when needed.
-- When the app starts the socket runtime:
-  - creates `~/Library/Application Support/Supaterm` with `0700`
-  - removes any stale socket file at the resolved path
-  - binds and listens on `supaterm.sock`
-  - sets the socket file permissions to `0600`
-- When the app stops the runtime, it closes the listener and removes the socket file.
+```text
+SupatermApp
+  |
+  v
+AppFeature
+  |
+  v
+SocketControlFeature
+  |
+  v
+SocketControlClient
+  |
+  v
+SocketControlRuntime
+  ^
+  |
+SPSocketClient
+  ^
+  |
+sp ping
 
-## Architecture
-
-- `SupatermCLIShared` owns the shared contract:
-  - environment keys such as `SUPATERM_SOCKET_PATH`
-  - socket path resolution
-  - request and response payload types
-- `SocketControlRuntime` owns the Unix socket server:
-  - `socket`, `bind`, `listen`, `accept`, `read`, and `write`
-  - directory creation and socket-file cleanup
-  - malformed request handling before anything reaches TCA
-- `SocketControlClient` is the dependency boundary between the runtime and the reducer.
-- `SocketControlFeature` owns request semantics:
-  - starts the runtime
-  - consumes decoded requests as an `AsyncStream`
-  - turns methods into responses
-- `AppFeature` hosts `SocketControlFeature`, so socket requests enter the normal reducer graph.
-
-This split is intentional. Transport details stay out of reducers, while actual command behavior remains testable with `TestStore`.
-
-## Protocol
-
-- Transport is newline-delimited UTF-8 JSON.
-- One request line produces one response line.
-- Requests use:
-  - `id`: caller-generated correlation id
-  - `method`: command name
-  - `params`: method arguments
-- Responses use:
-  - `id`: copied from the request when available
-  - `ok`: success flag
-  - `result`: payload for successful calls
-  - `error`: `{ code, message }` for failures
-- Unknown methods return `method_not_found`.
-- Invalid JSON never reaches the reducer. The runtime replies with `invalid_request`.
-
-## Current command surface
-
-- `system.ping` is the only socket method today.
-- The reducer answers with:
-
-```json
-{"id":"...","ok":true,"result":{"pong":true}}
+GhosttySurfaceView
+  |
+  v
+SupatermCLIContext + SUPATERM_SOCKET_PATH
+  |
+  v
+terminal pane
+  |
+  v
+sp
 ```
 
-- `sp ping` resolves the socket path, sends `system.ping`, and prints `pong` on success.
+## Code Map
 
-## Pane environment
-
-Supaterm injects the following values into terminal panes:
-
-- `SUPATERM_SOCKET_PATH`
-- `SUPATERM_SURFACE_ID`
-- `SUPATERM_TAB_ID`
-
-That gives `sp` enough context to find the local app socket from inside a pane without extra shell setup.
+- App startup: `supaterm/App/supatermApp.swift`
+- Root reducer wiring: `supaterm/Features/App/AppFeature.swift`
+- Socket feature semantics: `supaterm/Features/Socket/SocketControlFeature.swift`
+- Dependency boundary: `supaterm/Features/Socket/SocketControlClient.swift`
+- Unix socket transport: `supaterm/Features/Socket/SocketControlRuntime.swift`
+- Shared path resolution: `SupatermCLIShared/SupatermSocketPath.swift`
+- Shared protocol types: `SupatermCLIShared/SupatermSocketProtocol.swift`
+- Pane environment contract: `SupatermCLIShared/SupatermCLIContext.swift`
+- Pane environment injection: `supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift`
+- CLI entrypoint: `sp/main.swift`
+- CLI socket client: `sp/SPSocketClient.swift`
 
 ## Tests
 
-- Shared protocol and path logic live under `supatermTests` and should be covered with direct unit tests.
-- Reducer behavior belongs in `SocketControlFeatureTests`.
-- Runtime tests should stay focused on transport behavior only.
+- Reducer tests: `supatermTests/SocketControlFeatureTests.swift`
+- Shared contract tests: `supatermTests/SupatermSocketProtocolTests.swift`
+- Pane environment tests: `supatermTests/SupatermCLIContextTests.swift`

--- a/docs/SOCKET_CONTROL.md
+++ b/docs/SOCKET_CONTROL.md
@@ -1,6 +1,6 @@
 # Socket Control
 
-This document is a short map of the socket path. The source is authoritative.
+This document is a short map of how the socket work. The source is authoritative.
 
 ## Overview
 

--- a/sp/SPSocketClient.swift
+++ b/sp/SPSocketClient.swift
@@ -1,0 +1,149 @@
+import Darwin
+import Foundation
+import SupatermCLIShared
+
+struct SPSocketClient {
+  private enum SocketClientError: LocalizedError {
+    case connectFailed(String)
+    case invalidResponse
+    case pathTooLong(String)
+    case readFailed
+    case socketCreationFailed
+    case writeFailed
+
+    var errorDescription: String? {
+      switch self {
+      case .connectFailed(let path):
+        return "Failed to connect to Supaterm at \(path)."
+      case .invalidResponse:
+        return "Supaterm returned an invalid socket response."
+      case .pathTooLong(let path):
+        return "Supaterm socket path is too long: \(path)"
+      case .readFailed:
+        return "Failed to read a response from Supaterm."
+      case .socketCreationFailed:
+        return "Failed to create a local socket client."
+      case .writeFailed:
+        return "Failed to write a request to Supaterm."
+      }
+    }
+  }
+
+  private let path: String
+  private let decoder = JSONDecoder()
+  private let encoder = JSONEncoder()
+
+  init(path: String) throws {
+    guard let normalized = SupatermSocketPath.normalized(path) else {
+      throw SocketClientError.connectFailed(path)
+    }
+    self.path = normalized
+  }
+
+  func send(_ request: SupatermSocketRequest) throws -> SupatermSocketResponse {
+    let socket = try openSocket()
+    defer { Darwin.close(socket) }
+
+    let timeout = timeval(tv_sec: 5, tv_usec: 0)
+    var receiveTimeout = timeout
+    _ = setsockopt(
+      socket,
+      SOL_SOCKET,
+      SO_RCVTIMEO,
+      &receiveTimeout,
+      socklen_t(MemoryLayout<timeval>.size)
+    )
+
+    let requestData = try encoder.encode(request) + Data([0x0A])
+    try writeAll(requestData, to: socket)
+
+    guard let responseLine = readLine(from: socket) else {
+      throw SocketClientError.readFailed
+    }
+    guard let responseData = responseLine.data(using: .utf8) else {
+      throw SocketClientError.invalidResponse
+    }
+    return try decoder.decode(SupatermSocketResponse.self, from: responseData)
+  }
+
+  private func openSocket() throws -> Int32 {
+    let socket = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socket >= 0 else {
+      throw SocketClientError.socketCreationFailed
+    }
+
+    do {
+      var address = try socketAddress(path: path)
+      let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+          Darwin.connect(socket, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+      }
+      guard result == 0 else {
+        throw SocketClientError.connectFailed(path)
+      }
+      return socket
+    } catch {
+      Darwin.close(socket)
+      throw error
+    }
+  }
+
+  private func socketAddress(path: String) throws -> sockaddr_un {
+    var address = sockaddr_un()
+    memset(&address, 0, MemoryLayout<sockaddr_un>.size)
+    address.sun_family = sa_family_t(AF_UNIX)
+
+    let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+    guard path.utf8.count < maxLength else {
+      throw SocketClientError.pathTooLong(path)
+    }
+
+    path.withCString { pointer in
+      withUnsafeMutablePointer(to: &address.sun_path) { pathPointer in
+        let buffer = UnsafeMutableRawPointer(pathPointer).assumingMemoryBound(to: CChar.self)
+        strncpy(buffer, pointer, maxLength - 1)
+      }
+    }
+
+    return address
+  }
+
+  private func writeAll(_ data: Data, to socket: Int32) throws {
+    try data.withUnsafeBytes { buffer in
+      guard let baseAddress = buffer.baseAddress else { return }
+      var offset = 0
+      while offset < buffer.count {
+        let bytesWritten = Darwin.write(
+          socket,
+          baseAddress.advanced(by: offset),
+          buffer.count - offset
+        )
+        guard bytesWritten > 0 else {
+          throw SocketClientError.writeFailed
+        }
+        offset += bytesWritten
+      }
+    }
+  }
+
+  private func readLine(from socket: Int32) -> String? {
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1024)
+
+    while true {
+      let bytesRead = Darwin.read(socket, &buffer, buffer.count)
+      guard bytesRead >= 0 else { return nil }
+      guard bytesRead > 0 else { break }
+
+      data.append(buffer, count: bytesRead)
+      if let newlineIndex = data.firstIndex(of: 0x0A) {
+        data = Data(data[..<newlineIndex])
+        break
+      }
+    }
+
+    guard !data.isEmpty else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}

--- a/sp/main.swift
+++ b/sp/main.swift
@@ -4,16 +4,50 @@ import SupatermCLIShared
 struct SP: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "sp",
-    abstract: "Supaterm pane command-line interface."
+    abstract: "Supaterm pane command-line interface.",
+    subcommands: [Ping.self]
   )
 
   mutating func run() throws {
     if SupatermCLIContext.current == nil {
-      print("sp is bundled for Supaterm terminal panes. Commands are not implemented yet.")
+      print("sp is bundled for Supaterm terminal panes. Run 'sp --help' to see available commands.")
       return
     }
 
-    print("sp is available in this Supaterm pane. Commands are not implemented yet.")
+    print("sp is available in this Supaterm pane. Run 'sp --help' to see available commands.")
+  }
+}
+
+extension SP {
+  struct Ping: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "ping",
+      abstract: "Ping the running Supaterm socket server."
+    )
+
+    @Option(name: .long, help: "Override the Unix socket path.")
+    var socket: String?
+
+    mutating func run() throws {
+      let client = try SPSocketClient(
+        path: resolvedSocketPath()
+      )
+      let response = try client.send(.ping())
+      guard response.ok else {
+        throw ValidationError(response.error?.message ?? "Supaterm socket request failed.")
+      }
+      guard response.result?["pong"]?.boolValue == true else {
+        throw ValidationError("Supaterm socket ping returned an unexpected response.")
+      }
+      print("pong")
+    }
+
+    private func resolvedSocketPath() throws -> String {
+      guard let path = SupatermSocketPath.resolve(explicitPath: socket) else {
+        throw ValidationError("Unable to resolve a Supaterm socket path.")
+      }
+      return path
+    }
   }
 }
 

--- a/sp/main.swift
+++ b/sp/main.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+import SupatermCLIShared
+
+struct SP: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "sp",
+    abstract: "Supaterm pane command-line interface."
+  )
+
+  mutating func run() throws {
+    if SupatermCLIContext.current == nil {
+      print("sp is bundled for Supaterm terminal panes. Commands are not implemented yet.")
+      return
+    }
+
+    print("sp is available in this Supaterm pane. Commands are not implemented yet.")
+  }
+}
+
+SP.main()

--- a/supaterm/App/supatermApp.swift
+++ b/supaterm/App/supatermApp.swift
@@ -27,6 +27,9 @@ struct SupatermApp: App {
     _ghosttyShortcuts = State(initialValue: GhosttyShortcutManager(runtime: runtime))
     _terminal = State(initialValue: terminal)
     _store = State(initialValue: store)
+    Task { @MainActor [store] in
+      store.send(.socket(.task))
+    }
   }
 
   var body: some Scene {

--- a/supaterm/App/supatermApp.swift
+++ b/supaterm/App/supatermApp.swift
@@ -17,6 +17,7 @@ struct SupatermApp: App {
     let terminal = TerminalHostState(runtime: runtime)
     let store = Store(initialState: AppFeature.State()) {
       AppFeature()
+        ._printChanges(.actionLabels)
     } withDependencies: {
       $0.terminalClient = .live(host: terminal)
     }

--- a/supaterm/Features/App/AppFeature.swift
+++ b/supaterm/Features/App/AppFeature.swift
@@ -5,17 +5,23 @@ import ComposableArchitecture
 struct AppFeature {
   @ObservableState
   struct State: Equatable {
+    var socket = SocketControlFeature.State()
     var terminal = TerminalSceneFeature.State()
     var update = UpdateFeature.State()
   }
 
   enum Action {
     case quitRequested(ObjectIdentifier)
+    case socket(SocketControlFeature.Action)
     case terminal(TerminalSceneFeature.Action)
     case update(UpdateFeature.Action)
   }
 
   var body: some Reducer<State, Action> {
+    Scope(state: \.socket, action: \.socket) {
+      SocketControlFeature()
+    }
+
     Scope(state: \.terminal, action: \.terminal) {
       TerminalSceneFeature()
     }
@@ -35,6 +41,9 @@ struct AppFeature {
           }
         }
         return .send(.terminal(.quitRequested(windowID: windowID)))
+
+      case .socket:
+        return .none
 
       case .terminal:
         return .none

--- a/supaterm/Features/Socket/SocketControlClient.swift
+++ b/supaterm/Features/Socket/SocketControlClient.swift
@@ -1,0 +1,55 @@
+import ComposableArchitecture
+import Foundation
+import SupatermCLIShared
+
+struct SocketControlClient: Sendable {
+  struct Request: Equatable, Sendable {
+    nonisolated let handle: UUID
+    nonisolated let payload: SupatermSocketRequest
+  }
+
+  var requests: @Sendable () async -> AsyncStream<Request>
+  var reply: @Sendable (UUID, SupatermSocketResponse) async -> Void
+  var start: @Sendable () async throws -> String
+  var stop: @Sendable () async -> Void
+}
+
+extension SocketControlClient: DependencyKey {
+  static let liveValue: Self = {
+    let runtime = SocketControlRuntime.shared
+    return Self(
+      requests: {
+        await runtime.requests()
+      },
+      reply: { handle, response in
+        await runtime.reply(response, to: handle)
+      },
+      start: {
+        try await runtime.start()
+      },
+      stop: {
+        await runtime.stop()
+      }
+    )
+  }()
+
+  static let testValue = Self(
+    requests: {
+      AsyncStream { continuation in
+        continuation.finish()
+      }
+    },
+    reply: { _, _ in },
+    start: {
+      "/tmp/supaterm-test.sock"
+    },
+    stop: {}
+  )
+}
+
+extension DependencyValues {
+  var socketControlClient: SocketControlClient {
+    get { self[SocketControlClient.self] }
+    set { self[SocketControlClient.self] = newValue }
+  }
+}

--- a/supaterm/Features/Socket/SocketControlFeature.swift
+++ b/supaterm/Features/Socket/SocketControlFeature.swift
@@ -1,0 +1,74 @@
+import ComposableArchitecture
+import Foundation
+import SupatermCLIShared
+
+private enum SocketControlCancelID {
+  static let requests = "SocketControlFeature.requests"
+}
+
+@Reducer
+struct SocketControlFeature {
+  @ObservableState
+  struct State: Equatable {
+    var socketPath: String?
+    var startErrorMessage: String?
+  }
+
+  enum Action {
+    case requestReceived(SocketControlClient.Request)
+    case started(String)
+    case startFailed(String)
+    case task
+  }
+
+  @Dependency(SocketControlClient.self) var socketControlClient
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .requestReceived(let request):
+        let response =
+          if request.payload.method == SupatermSocketMethod.systemPing {
+            SupatermSocketResponse.ok(
+              id: request.payload.id,
+              result: ["pong": .bool(true)]
+            )
+          } else {
+            SupatermSocketResponse.error(
+              id: request.payload.id,
+              code: "method_not_found",
+              message: "Unknown method '\(request.payload.method)'."
+            )
+          }
+
+        return .run { [socketControlClient] _ in
+          await socketControlClient.reply(request.handle, response)
+        }
+
+      case .started(let socketPath):
+        state.socketPath = socketPath
+        state.startErrorMessage = nil
+        return .none
+
+      case .startFailed(let message):
+        state.startErrorMessage = message
+        return .none
+
+      case .task:
+        return .run { [socketControlClient] send in
+          do {
+            let socketPath = try await socketControlClient.start()
+            await send(.started(socketPath))
+            let requests = await socketControlClient.requests()
+            for await request in requests {
+              await send(.requestReceived(request))
+            }
+          } catch {
+            await send(.startFailed(error.localizedDescription))
+          }
+        }
+        .cancellable(id: SocketControlCancelID.requests, cancelInFlight: true)
+      }
+    }
+  }
+}

--- a/supaterm/Features/Socket/SocketControlRuntime.swift
+++ b/supaterm/Features/Socket/SocketControlRuntime.swift
@@ -1,0 +1,287 @@
+import Darwin
+import Foundation
+import SupatermCLIShared
+
+actor SocketControlRuntime {
+  enum RuntimeError: LocalizedError {
+    case bindFailed(String)
+    case createDirectoryFailed(String)
+    case listenFailed(String)
+    case missingSocketPath
+    case pathTooLong(String)
+    case socketCreationFailed
+
+    var errorDescription: String? {
+      switch self {
+      case .bindFailed(let path):
+        return "Failed to bind the Supaterm socket at \(path)."
+      case .createDirectoryFailed(let path):
+        return "Failed to create the Supaterm socket directory at \(path)."
+      case .listenFailed(let path):
+        return "Failed to listen on the Supaterm socket at \(path)."
+      case .missingSocketPath:
+        return "Unable to resolve a Supaterm socket path."
+      case .pathTooLong(let path):
+        return "Supaterm socket path is too long: \(path)"
+      case .socketCreationFailed:
+        return "Failed to create the Supaterm socket server."
+      }
+    }
+  }
+
+  private struct PendingReply: Sendable {
+    let clientSocket: Int32
+  }
+
+  static let shared = SocketControlRuntime()
+
+  private let pathProvider: @Sendable () -> String?
+  private var bufferedRequests: [SocketControlClient.Request] = []
+  private var listenerTask: Task<Void, Never>?
+  private var pendingReplies: [UUID: PendingReply] = [:]
+  private var requestsContinuation: AsyncStream<SocketControlClient.Request>.Continuation?
+  private var serverSocket: Int32 = -1
+  private var socketPath: String?
+
+  init(
+    pathProvider: @escaping @Sendable () -> String? = {
+      SupatermSocketPath.resolve()
+    }
+  ) {
+    self.pathProvider = pathProvider
+  }
+
+  func requests() -> AsyncStream<SocketControlClient.Request> {
+    requestsContinuation?.finish()
+    let (stream, continuation) = AsyncStream.makeStream(of: SocketControlClient.Request.self)
+    requestsContinuation = continuation
+    if !bufferedRequests.isEmpty {
+      let pending = bufferedRequests
+      bufferedRequests.removeAll()
+      for request in pending {
+        continuation.yield(request)
+      }
+    }
+    return stream
+  }
+
+  func start() throws -> String {
+    if let socketPath {
+      return socketPath
+    }
+
+    guard let socketPath = pathProvider() else {
+      throw RuntimeError.missingSocketPath
+    }
+
+    let socketURL = URL(fileURLWithPath: socketPath)
+    let directoryURL = socketURL.deletingLastPathComponent()
+    do {
+      try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: [.posixPermissions: 0o700]
+      )
+    } catch {
+      throw RuntimeError.createDirectoryFailed(directoryURL.path)
+    }
+
+    _ = socketPath.withCString(unlink)
+
+    let serverSocket = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard serverSocket >= 0 else {
+      throw RuntimeError.socketCreationFailed
+    }
+
+    do {
+      var address = try Self.socketAddress(path: socketPath)
+      let bindResult = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+          Darwin.bind(serverSocket, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+      }
+      guard bindResult == 0 else {
+        throw RuntimeError.bindFailed(socketPath)
+      }
+
+      try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: socketPath
+      )
+
+      guard listen(serverSocket, 16) == 0 else {
+        throw RuntimeError.listenFailed(socketPath)
+      }
+
+      self.serverSocket = serverSocket
+      self.socketPath = socketPath
+
+      let runtime = self
+      listenerTask = Task.detached(priority: .utility) {
+        Self.acceptLoop(serverSocket: serverSocket, runtime: runtime)
+      }
+
+      return socketPath
+    } catch {
+      Darwin.close(serverSocket)
+      _ = socketPath.withCString(unlink)
+      throw error
+    }
+  }
+
+  func stop() {
+    let listenerTask = listenerTask
+    self.listenerTask = nil
+    listenerTask?.cancel()
+
+    if serverSocket >= 0 {
+      Darwin.close(serverSocket)
+      serverSocket = -1
+    }
+
+    for pendingReply in pendingReplies.values {
+      Darwin.close(pendingReply.clientSocket)
+    }
+    pendingReplies.removeAll()
+    bufferedRequests.removeAll()
+    requestsContinuation?.finish()
+    requestsContinuation = nil
+
+    if let socketPath {
+      _ = socketPath.withCString(unlink)
+    }
+    socketPath = nil
+  }
+
+  func reply(_ response: SupatermSocketResponse, to handle: UUID) {
+    guard let pendingReply = pendingReplies.removeValue(forKey: handle) else { return }
+    Self.writeResponse(response, to: pendingReply.clientSocket)
+  }
+
+  private func handleRequestLine(_ requestLine: String?, clientSocket: Int32) {
+    guard
+      let requestLine = requestLine?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !requestLine.isEmpty
+    else {
+      Darwin.close(clientSocket)
+      return
+    }
+
+    guard let requestData = requestLine.data(using: .utf8) else {
+      Self.writeResponse(
+        .error(code: "invalid_request", message: "Request must be valid UTF-8 JSON."),
+        to: clientSocket
+      )
+      return
+    }
+
+    let decoder = JSONDecoder()
+    guard let request = try? decoder.decode(SupatermSocketRequest.self, from: requestData) else {
+      Self.writeResponse(
+        .error(code: "invalid_request", message: "Request must be a valid Supaterm socket payload."),
+        to: clientSocket
+      )
+      return
+    }
+
+    let handle = UUID()
+    pendingReplies[handle] = PendingReply(clientSocket: clientSocket)
+    emit(.init(handle: handle, payload: request))
+  }
+
+  private func emit(_ request: SocketControlClient.Request) {
+    guard let requestsContinuation else {
+      bufferedRequests.append(request)
+      return
+    }
+    requestsContinuation.yield(request)
+  }
+
+  private nonisolated static func acceptLoop(
+    serverSocket: Int32,
+    runtime: SocketControlRuntime
+  ) {
+    while !Task.isCancelled {
+      let clientSocket = Darwin.accept(serverSocket, nil, nil)
+      guard clientSocket >= 0 else {
+        if errno == EBADF || errno == EINVAL {
+          return
+        }
+        continue
+      }
+
+      Task.detached(priority: .utility) {
+        let requestLine = Self.readLine(from: clientSocket)
+        await runtime.handleRequestLine(requestLine, clientSocket: clientSocket)
+      }
+    }
+  }
+
+  private nonisolated static func socketAddress(path: String) throws -> sockaddr_un {
+    var address = sockaddr_un()
+    memset(&address, 0, MemoryLayout<sockaddr_un>.size)
+    address.sun_family = sa_family_t(AF_UNIX)
+
+    let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+    guard path.utf8.count < maxLength else {
+      throw RuntimeError.pathTooLong(path)
+    }
+
+    path.withCString { pointer in
+      withUnsafeMutablePointer(to: &address.sun_path) { pathPointer in
+        let buffer = UnsafeMutableRawPointer(pathPointer).assumingMemoryBound(to: CChar.self)
+        strncpy(buffer, pointer, maxLength - 1)
+      }
+    }
+
+    return address
+  }
+
+  private nonisolated static func readLine(from socket: Int32) -> String? {
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1024)
+
+    while true {
+      let bytesRead = Darwin.read(socket, &buffer, buffer.count)
+      guard bytesRead >= 0 else { return nil }
+      guard bytesRead > 0 else { break }
+
+      data.append(buffer, count: bytesRead)
+      if let newlineIndex = data.firstIndex(of: 0x0A) {
+        data = Data(data[..<newlineIndex])
+        break
+      }
+    }
+
+    guard !data.isEmpty else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private nonisolated static func writeResponse(
+    _ response: SupatermSocketResponse,
+    to socket: Int32
+  ) {
+    let encoder = JSONEncoder()
+    guard let encoded = try? encoder.encode(response) else {
+      Darwin.close(socket)
+      return
+    }
+    let data = encoded + Data([0x0A])
+
+    data.withUnsafeBytes { buffer in
+      guard let baseAddress = buffer.baseAddress else { return }
+      var offset = 0
+      while offset < buffer.count {
+        let bytesWritten = Darwin.write(
+          socket,
+          baseAddress.advanced(by: offset),
+          buffer.count - offset
+        )
+        guard bytesWritten > 0 else { return }
+        offset += bytesWritten
+      }
+    }
+
+    Darwin.close(socket)
+  }
+}

--- a/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -166,10 +166,19 @@ final class GhosttySurfaceView: NSView, Identifiable {
     self.runtime = runtime
     self.id = surfaceID
     self.bridge = GhosttySurfaceBridge()
-    self.environmentVariables = SupatermCLIContext(
+    var environmentVariables = SupatermCLIContext(
       surfaceID: surfaceID,
       tabID: tabID
     ).environmentVariables
+    if let socketPath = SupatermSocketPath.resolve() {
+      environmentVariables.append(
+        .init(
+          key: SupatermCLIEnvironment.socketPathKey,
+          value: socketPath
+        )
+      )
+    }
+    self.environmentVariables = environmentVariables
     self.fontSize = fontSize ?? 0
     self.context = context
     self.managesWindowAppearance = managesWindowAppearance

--- a/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -3,6 +3,7 @@ import Carbon
 import CoreText
 import GhosttyKit
 import QuartzCore
+import SupatermCLIShared
 
 final class GhosttySurfaceView: NSView, Identifiable {
   private struct ScrollbarState {
@@ -46,12 +47,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private let runtime: GhosttyRuntime
-  let id = UUID()
+  let id: UUID
   let bridge: GhosttySurfaceBridge
   private(set) var surface: ghostty_surface_t?
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
   private let workingDirectoryCString: UnsafeMutablePointer<CChar>?
   private let initialInputCString: UnsafeMutablePointer<CChar>?
+  private let environmentVariables: [SupatermCLIEnvironmentVariable]
   private let fontSize: Float32
   private let context: ghostty_surface_context_e
   private let managesWindowAppearance: Bool
@@ -153,14 +155,21 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   init(
     runtime: GhosttyRuntime,
+    tabID: UUID,
     workingDirectory: URL?,
     initialInput: String? = nil,
     fontSize: Float32? = nil,
     context: ghostty_surface_context_e,
     managesWindowAppearance: Bool = false
   ) {
+    let surfaceID = UUID()
     self.runtime = runtime
+    self.id = surfaceID
     self.bridge = GhosttySurfaceBridge()
+    self.environmentVariables = SupatermCLIContext(
+      surfaceID: surfaceID,
+      tabID: tabID
+    ).environmentVariables
     self.fontSize = fontSize ?? 0
     self.context = context
     self.managesWindowAppearance = managesWindowAppearance
@@ -845,11 +854,45 @@ final class GhosttySurfaceView: NSView, Identifiable {
     config.working_directory = workingDirectoryCString.map { UnsafePointer($0) }
     config.initial_input = initialInputCString.map { UnsafePointer($0) }
     config.context = context
-    surface = ghostty_surface_new(app, &config)
+    Self.withEnvironmentVariables(environmentVariables) { envVars, count in
+      config.env_vars = envVars
+      config.env_var_count = count
+      surface = ghostty_surface_new(app, &config)
+    }
     bridge.surface = surface
     lastOcclusion = nil
     lastSurfaceFocus = nil
     updateSurfaceSize()
+  }
+
+  private static func withEnvironmentVariables<Result>(
+    _ environmentVariables: [SupatermCLIEnvironmentVariable],
+    _ body: (UnsafeMutablePointer<ghostty_env_var_s>?, Int) -> Result
+  ) -> Result {
+    guard !environmentVariables.isEmpty else {
+      return body(nil, 0)
+    }
+
+    var envVars = environmentVariables.map { variable in
+      ghostty_env_var_s(
+        key: strdup(variable.key),
+        value: strdup(variable.value)
+      )
+    }
+    defer {
+      for envVar in envVars {
+        if let key = envVar.key {
+          free(UnsafeMutableRawPointer(mutating: key))
+        }
+        if let value = envVar.value {
+          free(UnsafeMutableRawPointer(mutating: value))
+        }
+      }
+    }
+
+    return envVars.withUnsafeMutableBufferPointer { buffer in
+      body(buffer.baseAddress, buffer.count)
+    }
   }
 
   private func updateContentScale() {

--- a/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/supaterm/Features/Terminal/TerminalHostState.swift
@@ -595,6 +595,7 @@ final class TerminalHostState {
     let inherited = inheritedSurfaceConfig(fromSurfaceID: inheritingFromSurfaceID, context: context)
     let view = GhosttySurfaceView(
       runtime: runtime,
+      tabID: tabID.rawValue,
       workingDirectory: inherited.workingDirectory,
       initialInput: initialInput,
       fontSize: inherited.fontSize,

--- a/supatermTests/SocketControlFeatureTests.swift
+++ b/supatermTests/SocketControlFeatureTests.swift
@@ -1,0 +1,114 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+@testable import supaterm
+
+@MainActor
+struct SocketControlFeatureTests {
+  @Test
+  func taskStartsSocketObservationAndStoresSocketPath() async {
+    let (stream, continuation) = AsyncStream.makeStream(of: SocketControlClient.Request.self)
+
+    let store = TestStore(initialState: SocketControlFeature.State()) {
+      SocketControlFeature()
+    } withDependencies: {
+      $0.socketControlClient.requests = { stream }
+      $0.socketControlClient.start = { "/tmp/supaterm.sock" }
+    }
+
+    await store.send(.task)
+    await store.receive(\.started) {
+      $0.socketPath = "/tmp/supaterm.sock"
+      $0.startErrorMessage = nil
+    }
+
+    continuation.finish()
+    await store.finish()
+  }
+
+  @Test
+  func pingRequestRepliesWithPong() async {
+    let recorder = SocketReplyRecorder()
+    let handle = UUID(uuidString: "4C6584B8-0282-4E52-B294-76FA9E934E83")!
+    let request = SocketControlClient.Request(
+      handle: handle,
+      payload: .ping(id: "ping-1")
+    )
+
+    let store = TestStore(initialState: SocketControlFeature.State()) {
+      SocketControlFeature()
+    } withDependencies: {
+      $0.socketControlClient.reply = { handle, response in
+        await recorder.record(handle: handle, response: response)
+      }
+    }
+
+    await store.send(.requestReceived(request))
+
+    let records = await recorder.snapshot()
+    #expect(records.count == 1)
+    #expect(
+      records.first
+        == .init(
+          handle: handle,
+          response: .ok(id: "ping-1", result: ["pong": .bool(true)])
+        )
+    )
+  }
+
+  @Test
+  func unknownMethodRepliesWithStructuredError() async {
+    let recorder = SocketReplyRecorder()
+    let handle = UUID(uuidString: "B12602E1-5D37-470E-9388-55CD09D400CA")!
+    let request = SocketControlClient.Request(
+      handle: handle,
+      payload: .init(id: "request-2", method: "workspace.list")
+    )
+
+    let store = TestStore(initialState: SocketControlFeature.State()) {
+      SocketControlFeature()
+    } withDependencies: {
+      $0.socketControlClient.reply = { handle, response in
+        await recorder.record(handle: handle, response: response)
+      }
+    }
+
+    await store.send(.requestReceived(request))
+
+    let records = await recorder.snapshot()
+    #expect(records.count == 1)
+    #expect(
+      records.first
+        == .init(
+          handle: handle,
+          response: .error(
+            id: "request-2",
+            code: "method_not_found",
+            message: "Unknown method 'workspace.list'."
+          )
+        )
+    )
+  }
+}
+
+private actor SocketReplyRecorder {
+  struct Record: Equatable {
+    let handle: UUID
+    let response: SupatermSocketResponse
+  }
+
+  private var records: [Record] = []
+
+  func record(
+    handle: UUID,
+    response: SupatermSocketResponse
+  ) {
+    records.append(.init(handle: handle, response: response))
+  }
+
+  func snapshot() -> [Record] {
+    records
+  }
+}

--- a/supatermTests/SupatermCLIContextTests.swift
+++ b/supatermTests/SupatermCLIContextTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+
+struct SupatermCLIContextTests {
+  @Test
+  func environmentKeysStayStable() {
+    #expect(SupatermCLIEnvironment.surfaceIDKey == "SUPATERM_SURFACE_ID")
+    #expect(SupatermCLIEnvironment.tabIDKey == "SUPATERM_TAB_ID")
+    #expect(SupatermCLIEnvironment.socketPathKey == "SUPATERM_SOCKET_PATH")
+  }
+
+  @Test
+  func environmentVariablesExportCurrentPaneIdentifiers() {
+    let surfaceID = UUID(uuidString: "A72F7A7D-B5E8-497E-A5D5-D26A77A0A4C7")!
+    let tabID = UUID(uuidString: "9F4EB4BE-9216-4DCA-A866-C8276D9EF2AA")!
+    let context = SupatermCLIContext(surfaceID: surfaceID, tabID: tabID)
+
+    #expect(
+      context.environmentVariables == [
+        .init(key: "SUPATERM_SURFACE_ID", value: surfaceID.uuidString),
+        .init(key: "SUPATERM_TAB_ID", value: tabID.uuidString),
+      ]
+    )
+  }
+
+  @Test
+  func environmentParsingRestoresPaneContext() {
+    let surfaceID = UUID(uuidString: "D9130D56-7B15-4C76-8A1A-CF4BC0B31155")!
+    let tabID = UUID(uuidString: "D556A7EB-6B68-4B90-8948-12FC1871B4AE")!
+    let environment = [
+      SupatermCLIEnvironment.surfaceIDKey: surfaceID.uuidString,
+      SupatermCLIEnvironment.tabIDKey: tabID.uuidString,
+    ]
+
+    #expect(SupatermCLIContext(environment: environment) == .init(surfaceID: surfaceID, tabID: tabID))
+  }
+
+  @Test
+  func environmentParsingRejectsMissingOrInvalidIdentifiers() {
+    let validID = UUID().uuidString
+
+    #expect(
+      SupatermCLIContext(environment: [
+        SupatermCLIEnvironment.surfaceIDKey: validID,
+      ]) == nil
+    )
+    #expect(
+      SupatermCLIContext(environment: [
+        SupatermCLIEnvironment.surfaceIDKey: "not-a-uuid",
+        SupatermCLIEnvironment.tabIDKey: validID,
+      ]) == nil
+    )
+  }
+}

--- a/supatermTests/SupatermCLIContextTests.swift
+++ b/supatermTests/SupatermCLIContextTests.swift
@@ -43,7 +43,7 @@ struct SupatermCLIContextTests {
 
     #expect(
       SupatermCLIContext(environment: [
-        SupatermCLIEnvironment.surfaceIDKey: validID,
+        SupatermCLIEnvironment.surfaceIDKey: validID
       ]) == nil
     )
     #expect(

--- a/supatermTests/SupatermSocketProtocolTests.swift
+++ b/supatermTests/SupatermSocketProtocolTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+
+struct SupatermSocketProtocolTests {
+  @Test
+  func defaultSocketURLUsesApplicationSupportDirectory() {
+    let appSupportDirectory = URL(fileURLWithPath: "/tmp/SupatermTests/Application Support", isDirectory: true)
+
+    #expect(
+      SupatermSocketPath.defaultURL(appSupportDirectory: appSupportDirectory)
+        == appSupportDirectory
+        .appendingPathComponent("Supaterm", isDirectory: true)
+        .appendingPathComponent("supaterm.sock", isDirectory: false)
+    )
+  }
+
+  @Test
+  func socketPathResolutionPrefersExplicitPathThenEnvironmentThenDefault() {
+    let appSupportDirectory = URL(fileURLWithPath: "/tmp/SupatermTests/Application Support", isDirectory: true)
+    let environmentPath = "/tmp/supaterm.environment.sock"
+    let explicitPath = "/tmp/supaterm.explicit.sock"
+
+    #expect(
+      SupatermSocketPath.resolve(
+        explicitPath: explicitPath,
+        environment: [SupatermCLIEnvironment.socketPathKey: environmentPath],
+        appSupportDirectory: appSupportDirectory
+      ) == explicitPath
+    )
+    #expect(
+      SupatermSocketPath.resolve(
+        environment: [SupatermCLIEnvironment.socketPathKey: environmentPath],
+        appSupportDirectory: appSupportDirectory
+      ) == environmentPath
+    )
+    #expect(
+      SupatermSocketPath.resolve(appSupportDirectory: appSupportDirectory)
+        == appSupportDirectory
+        .appendingPathComponent("Supaterm", isDirectory: true)
+        .appendingPathComponent("supaterm.sock", isDirectory: false)
+        .path
+    )
+  }
+
+  @Test
+  func requestAndResponseRoundTripAsJSON() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    let request = SupatermSocketRequest(
+      id: "request-1",
+      method: SupatermSocketMethod.systemPing,
+      params: [
+        "nested": .object(["pong": .bool(true)]),
+        "null": .null,
+      ]
+    )
+    let response = SupatermSocketResponse.ok(
+      id: "request-1",
+      result: ["pong": .bool(true)]
+    )
+
+    #expect(
+      try decoder.decode(
+        SupatermSocketRequest.self,
+        from: encoder.encode(request)
+      ) == request
+    )
+    #expect(
+      try decoder.decode(
+        SupatermSocketResponse.self,
+        from: encoder.encode(response)
+      ) == response
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- bundle a new `sp` CLI into the app using `swift-argument-parser`
- add an app-global Unix socket control channel with JSON request/response support and `sp ping`
- stream root TCA action labels in Debug so `make run-app` shows incoming actions live

## Validation
- `make check`
- `make build-app`
- `xcodebuild test -workspace supaterm.xcworkspace -scheme supaterm -destination "platform=macOS" -only-testing:supatermTests/SocketControlFeatureTests -only-testing:supatermTests/SupatermSocketProtocolTests -only-testing:supatermTests/SupatermCLIContextTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- manual smoke: bundled `sp ping` returned `pong`
- manual smoke: PTY-launched app streamed TCA action labels
