### PR TITLE
Fix settings window clipping

### DIFF
--- a/apps/mac/supaterm/App/SettingsWindowController.swift
+++ b/apps/mac/supaterm/App/SettingsWindowController.swift
@@ -4,6 +4,9 @@ import SwiftUI
 
 @MainActor
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
+  static let defaultContentSize = NSSize(width: 760, height: 560)
+  static let minimumContentSize = NSSize(width: defaultContentSize.width, height: 360)
+
   let store: StoreOf<SettingsFeature>
   private let restoresSavedFrame: Bool
   private let tabViewController: SettingsTabViewController
@@ -17,13 +20,13 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     self.tabViewController = tabViewController
 
     let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 760, height: 560),
+      contentRect: NSRect(origin: .zero, size: Self.defaultContentSize),
       styleMask: [.closable, .miniaturizable, .resizable, .titled],
       backing: .buffered,
       defer: false
     )
     window.contentViewController = tabViewController
-    window.contentMinSize = NSSize(width: 520, height: 360)
+    window.contentMinSize = Self.minimumContentSize
     window.identifier = NSUserInterfaceItemIdentifier("app.supabit.supaterm.window.settings")
     window.isReleasedWhenClosed = false
     let restoresSavedFrame = window.setFrameUsingName("SupatermSettingsWindow")

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -5,12 +5,30 @@ struct SettingsTabContentView: View {
   let tab: SettingsFeature.Tab
 
   var body: some View {
-    switch tab {
-    case .general:
-      SettingsGeneralView()
-    case .updates, .about:
-      SettingsPlaceholderView(tab: tab)
+    SettingsDetailContainer {
+      switch tab {
+      case .general:
+        SettingsGeneralView()
+      case .updates, .about:
+        SettingsPlaceholderView(tab: tab)
+      }
     }
+  }
+}
+
+private struct SettingsDetailContainer<Content: View>: View {
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .scenePadding(.top)
+      .scenePadding(.horizontal)
+      .scenePadding(.bottom)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
   }
 }
 
@@ -151,6 +169,5 @@ private struct SettingsPlaceholderView: View {
         .foregroundStyle(.secondary)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .padding(24)
   }
 }

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -16,7 +16,6 @@ struct SettingsTabContentView: View {
 
 private struct SettingsGeneralView: View {
   @Shared(.appPrefs) private var appPrefs = .default
-  @Environment(\.colorScheme) private var colorScheme
 
   private var appearanceMode: Binding<AppearanceMode> {
     Binding(
@@ -30,11 +29,8 @@ private struct SettingsGeneralView: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 22) {
-      Text("Appearance")
-        .font(.title2.weight(.semibold))
-
-      VStack(alignment: .leading, spacing: 20) {
+    Form {
+      Section("Appearance") {
         HStack(spacing: 16) {
           let selectedMode = appearanceMode.wrappedValue
           ForEach(AppearanceMode.allCases) { mode in
@@ -48,38 +44,22 @@ private struct SettingsGeneralView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
 
-        Rectangle()
-          .fill(dividerColor)
-          .frame(height: 1)
-
         VStack(alignment: .leading, spacing: 8) {
           Text("Terminal theming follows Ghostty config")
           Text("For example, add the following line to `~/.config/ghostty/config`")
-          Text("theme = light:Monokai Pro Light Sun,dark:Dimmed Monokai")
+          Text("theme = light:Monokai Pro Light Sun,\ndark:Dimmed Monokai")
             .monospaced()
         }
         .font(.body.weight(.semibold))
         .foregroundStyle(.secondary)
         .textSelection(.enabled)
+        .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(20)
-      .background(sectionBackground)
-      .clipShape(.rect(cornerRadius: 24))
     }
+    .formStyle(.grouped)
+    .scrollContentBackground(.hidden)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    .padding(24)
-  }
-
-  private var dividerColor: Color {
-    colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.08)
-  }
-
-  private var sectionBackground: Color {
-    colorScheme == .dark
-      ? Color(red: 0.18, green: 0.19, blue: 0.2)
-      : Color.white
   }
 }
 

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -46,6 +46,7 @@ private struct SettingsGeneralView: View {
             }
           }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
 
         Rectangle()
           .fill(dividerColor)
@@ -60,7 +61,9 @@ private struct SettingsGeneralView: View {
         .font(.body.weight(.semibold))
         .foregroundStyle(.secondary)
         .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
       .padding(20)
       .background(sectionBackground)
       .clipShape(.rect(cornerRadius: 24))
@@ -116,7 +119,7 @@ private struct AppearanceOptionCardView: View {
 
             RoundedRectangle(cornerRadius: 6)
               .fill(mode.previewAccent)
-              .frame(width: 128, height: 14)
+              .frame(maxWidth: 128, minHeight: 14, maxHeight: 14, alignment: .leading)
           }
           .padding(32)
         }

--- a/apps/mac/supatermTests/SettingsWindowControllerTests.swift
+++ b/apps/mac/supatermTests/SettingsWindowControllerTests.swift
@@ -49,4 +49,33 @@ struct SettingsWindowControllerTests {
 
     #expect(frame == savedFrame)
   }
+
+  @Test
+  func windowUsesSupportedMinimumContentSize() throws {
+    NSWindow.removeFrame(usingName: "SupatermSettingsWindow")
+    defer { NSWindow.removeFrame(usingName: "SupatermSettingsWindow") }
+
+    let controller = SettingsWindowController()
+    let window = try #require(controller.window)
+
+    #expect(window.contentMinSize == SettingsWindowController.minimumContentSize)
+  }
+
+  @Test
+  func restoredFrameClampsToMinimumContentSizeWhenSavedFrameIsTooNarrow() throws {
+    NSWindow.removeFrame(usingName: "SupatermSettingsWindow")
+    defer { NSWindow.removeFrame(usingName: "SupatermSettingsWindow") }
+
+    let seedController = SettingsWindowController()
+    let seedWindow = try #require(seedController.window)
+    let savedFrame = NSRect(x: 111, y: 222, width: 520, height: 690)
+    seedWindow.setFrame(savedFrame, display: false)
+    seedWindow.saveFrame(usingName: "SupatermSettingsWindow")
+
+    let controller = SettingsWindowController()
+    let window = try #require(controller.window)
+    let restoredContentWidth = window.contentRect(forFrameRect: window.frame).width
+
+    #expect(restoredContentWidth >= SettingsWindowController.minimumContentSize.width)
+  }
 }


### PR DESCRIPTION
## Summary
- fix the settings general layout so the appearance section expands to the available width instead of clipping its cards
- clamp the settings window to the minimum width that supports the three-card appearance layout
- add regression coverage for the settings window minimum content size and narrow saved-frame restoration

## Testing
- `make mac-check`
- `xcodebuild test -workspace apps/mac/supaterm.xcworkspace -scheme supaterm -destination "platform=macOS" -only-testing:supatermTests/SettingsWindowControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation` *(currently blocked by unrelated existing build failures in `apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift`: `Invalid redeclaration of 'TerminalSidebarTabRow'` and `Missing argument for parameter 'terminalProgress' in call`)*
