### PR TITLE
SUP-47: Add GitHub PR surfaces to sidebar and pane topbar

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettings.swift
@@ -4,6 +4,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
+  public var githubPullRequestsEnabled: Bool
   public var glowingPaneRingEnabled: Bool
   public var restoreTerminalLayoutEnabled: Bool
   public var systemNotificationsEnabled: Bool
@@ -13,6 +14,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     appearanceMode: AppearanceMode,
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
+    githubPullRequestsEnabled: Bool = true,
     glowingPaneRingEnabled: Bool = true,
     restoreTerminalLayoutEnabled: Bool = true,
     systemNotificationsEnabled: Bool = false,
@@ -21,6 +23,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     self.appearanceMode = appearanceMode
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
+    self.githubPullRequestsEnabled = githubPullRequestsEnabled
     self.glowingPaneRingEnabled = glowingPaneRingEnabled
     self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
     self.systemNotificationsEnabled = systemNotificationsEnabled
@@ -31,6 +34,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     appearanceMode: .system,
     analyticsEnabled: true,
     crashReportsEnabled: true,
+    githubPullRequestsEnabled: true,
     glowingPaneRingEnabled: true,
     restoreTerminalLayoutEnabled: true,
     systemNotificationsEnabled: false,
@@ -48,6 +52,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     case appearanceMode
     case analyticsEnabled
     case crashReportsEnabled
+    case githubPullRequestsEnabled
     case glowingPaneRingEnabled
     case restoreTerminalLayoutEnabled
     case systemNotificationsEnabled
@@ -61,6 +66,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
         return "Allow anonymous telemetry."
       case .crashReportsEnabled:
         return "Allow crash reports."
+      case .githubPullRequestsEnabled:
+        return "Show GitHub pull request surfaces in the terminal UI."
       case .glowingPaneRingEnabled:
         return "Show a glowing ring around panes with unread attention."
       case .restoreTerminalLayoutEnabled:
@@ -94,6 +101,9 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
         try container.decodeIfPresent(Bool.self, forKey: .analyticsEnabled) ?? defaults.analyticsEnabled,
       crashReportsEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .crashReportsEnabled) ?? defaults.crashReportsEnabled,
+      githubPullRequestsEnabled:
+        try container.decodeIfPresent(Bool.self, forKey: .githubPullRequestsEnabled)
+          ?? defaults.githubPullRequestsEnabled,
       glowingPaneRingEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .glowingPaneRingEnabled)
           ?? defaults.glowingPaneRingEnabled,
@@ -130,6 +140,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
       return .bool(analyticsEnabled)
     case .crashReportsEnabled:
       return .bool(crashReportsEnabled)
+    case .githubPullRequestsEnabled:
+      return .bool(githubPullRequestsEnabled)
     case .glowingPaneRingEnabled:
       return .bool(glowingPaneRingEnabled)
     case .restoreTerminalLayoutEnabled:

--- a/apps/mac/supaterm/Features/Github/GithubClient.swift
+++ b/apps/mac/supaterm/Features/Github/GithubClient.swift
@@ -1,0 +1,701 @@
+import ComposableArchitecture
+import Darwin
+import Foundation
+
+nonisolated struct GithubRepositoryIdentity: Equatable, Sendable {
+  let branch: String
+  let repoRoot: String
+}
+
+nonisolated struct GithubPullRequestSnapshot: Equatable, Sendable {
+  let number: Int
+  let repositoryIdentity: GithubRepositoryIdentity
+  let url: URL
+}
+
+nonisolated struct GithubPullRequestPresentation: Equatable, Sendable {
+  let label: String
+  let url: URL
+
+  init(snapshot: GithubPullRequestSnapshot) {
+    label = "PR #\(snapshot.number)"
+    url = snapshot.url
+  }
+}
+
+nonisolated struct GithubPullRequestLookupRequest: Equatable, Sendable {
+  let surfaceID: UUID
+  let workingDirectory: String
+}
+
+nonisolated enum GithubPullRequestLookupResponse: Equatable, Sendable {
+  case resolved(GithubPullRequestSnapshot?)
+  case failure(String)
+}
+
+nonisolated enum GithubBinaryStatus: Equatable, Sendable {
+  case available(String)
+  case unavailable(String)
+
+  var detail: String {
+    switch self {
+    case .available(let detail), .unavailable(let detail):
+      return detail
+    }
+  }
+
+  var isAvailable: Bool {
+    switch self {
+    case .available:
+      return true
+    case .unavailable:
+      return false
+    }
+  }
+}
+
+nonisolated enum GithubAuthenticationStatus: Equatable, Sendable {
+  case authenticated(String)
+  case unavailable(String)
+  case unauthenticated(String)
+
+  var detail: String {
+    switch self {
+    case .authenticated(let detail), .unavailable(let detail), .unauthenticated(let detail):
+      return detail
+    }
+  }
+
+  var isAuthenticated: Bool {
+    switch self {
+    case .authenticated:
+      return true
+    case .unavailable, .unauthenticated:
+      return false
+    }
+  }
+}
+
+nonisolated struct GithubDiagnostics: Equatable, Sendable {
+  let authenticationStatus: GithubAuthenticationStatus
+  let ghStatus: GithubBinaryStatus
+  let gitStatus: GithubBinaryStatus
+}
+
+nonisolated struct GithubClient: Sendable {
+  var diagnostics: @Sendable () async -> GithubDiagnostics
+  var lookupPullRequests: @Sendable ([GithubPullRequestLookupRequest]) async -> [UUID: GithubPullRequestLookupResponse]
+}
+
+extension GithubClient {
+  static func live(
+    batchSize: Int = 20,
+    runner: GithubCommandRunner
+  ) -> Self {
+    let service = GithubLookupService(
+      batchSize: batchSize,
+      runner: runner
+    )
+    return Self(
+      diagnostics: {
+        await service.diagnostics()
+      },
+      lookupPullRequests: { requests in
+        await service.lookupPullRequests(requests)
+      }
+    )
+  }
+}
+
+extension GithubClient: DependencyKey {
+  static let liveValue = Self.live(
+    runner: .live()
+  )
+
+  static let testValue = Self(
+    diagnostics: {
+      .init(
+        authenticationStatus: .unavailable("GitHub diagnostics are unavailable in tests."),
+        ghStatus: .unavailable("GitHub CLI is unavailable."),
+        gitStatus: .unavailable("Git is unavailable.")
+      )
+    },
+    lookupPullRequests: { _ in [:] }
+  )
+}
+
+extension DependencyValues {
+  var githubClient: GithubClient {
+    get { self[GithubClient.self] }
+    set { self[GithubClient.self] = newValue }
+  }
+}
+
+private actor GithubLookupService {
+  private let batchSize: Int
+  private let runner: GithubCommandRunner
+
+  private var cachedGhPath: String?
+  private var cachedGitPath: String?
+
+  init(
+    batchSize: Int = 20,
+    runner: GithubCommandRunner = .live()
+  ) {
+    self.batchSize = batchSize
+    self.runner = runner
+  }
+
+  func diagnostics() -> GithubDiagnostics {
+    let gitPath = try? resolveGitPath()
+    let ghPath = try? resolveGhPath()
+
+    let gitStatus: GithubBinaryStatus =
+      if let gitPath {
+        .available("Found at \(gitPath)")
+      } else {
+        .unavailable("Git must be installed and available in your login shell.")
+      }
+
+    let ghStatus: GithubBinaryStatus =
+      if let ghPath {
+        .available("Found at \(ghPath)")
+      } else {
+        .unavailable("GitHub CLI must be installed and available in your login shell.")
+      }
+
+    let authenticationStatus: GithubAuthenticationStatus
+    if let ghPath {
+      do {
+        let result = try runner.run(ghPath, ["auth", "status", "--hostname", "github.com"], nil)
+        if result.status == 0 {
+          authenticationStatus = .authenticated(
+            nonEmptyMessage(from: result, defaultDetail: "Authenticated with GitHub CLI.")
+          )
+        } else {
+          authenticationStatus = .unauthenticated(
+            nonEmptyMessage(from: result, defaultDetail: "GitHub CLI is not authenticated.")
+          )
+        }
+      } catch {
+        authenticationStatus = .unauthenticated(error.localizedDescription)
+      }
+    } else {
+      authenticationStatus = .unavailable("GitHub CLI is unavailable, so authentication could not be checked.")
+    }
+
+    return .init(
+      authenticationStatus: authenticationStatus,
+      ghStatus: ghStatus,
+      gitStatus: gitStatus
+    )
+  }
+
+  func lookupPullRequests(
+    _ requests: [GithubPullRequestLookupRequest]
+  ) -> [UUID: GithubPullRequestLookupResponse] {
+    guard !requests.isEmpty else { return [:] }
+
+    let gitPath: String
+    let ghPath: String
+    do {
+      guard let resolvedGitPath = try resolveGitPath() else {
+        return Dictionary(
+          uniqueKeysWithValues: requests.map {
+            ($0.surfaceID, .failure("Git must be installed and available in your login shell."))
+          }
+        )
+      }
+      guard let resolvedGhPath = try resolveGhPath() else {
+        return Dictionary(
+          uniqueKeysWithValues: requests.map {
+            ($0.surfaceID, .failure("GitHub CLI must be installed and available in your login shell."))
+          }
+        )
+      }
+      gitPath = resolvedGitPath
+      ghPath = resolvedGhPath
+    } catch {
+      return Dictionary(
+        uniqueKeysWithValues: requests.map {
+          ($0.surfaceID, .failure(error.localizedDescription))
+        }
+      )
+    }
+
+    var responses: [UUID: GithubPullRequestLookupResponse] = [:]
+
+    for chunkStart in stride(from: 0, to: requests.count, by: batchSize) {
+      let chunkEnd = min(chunkStart + batchSize, requests.count)
+      for request in requests[chunkStart..<chunkEnd] {
+        responses[request.surfaceID] = resolvePullRequest(
+          for: request,
+          gitPath: gitPath,
+          ghPath: ghPath
+        )
+      }
+    }
+
+    return responses
+  }
+
+  private func resolvePullRequest(
+    for request: GithubPullRequestLookupRequest,
+    gitPath: String,
+    ghPath: String
+  ) -> GithubPullRequestLookupResponse {
+    do {
+      guard
+        let context = try resolveRepositoryContext(
+          for: request.workingDirectory,
+          gitPath: gitPath
+        )
+      else {
+        return .resolved(nil)
+      }
+
+      var successfulQuery = false
+      var failureMessage: String?
+
+      for repository in context.candidateRepositories {
+        let result = try runner.run(
+          ghPath,
+          [
+            "pr",
+            "list",
+            "--repo",
+            repository.ghRepositoryIdentifier,
+            "--state",
+            "open",
+            "--head",
+            context.repositoryIdentity.branch,
+            "--json",
+            "headRefName,headRepositoryOwner,number,url",
+          ],
+          context.repositoryIdentity.repoRoot
+        )
+
+        guard result.status == 0 else {
+          failureMessage = nonEmptyMessage(
+            from: result,
+            defaultDetail: "GitHub CLI could not query pull requests."
+          )
+          continue
+        }
+
+        successfulQuery = true
+        let pullRequests = try JSONDecoder().decode(
+          [GithubPullRequestCandidate].self,
+          from: Data(result.standardOutput.utf8)
+        )
+
+        if let pullRequest = bestMatch(
+          in: pullRequests,
+          expectedHeadOwner: context.expectedHeadOwner
+        ) {
+          return .resolved(
+            .init(
+              number: pullRequest.number,
+              repositoryIdentity: context.repositoryIdentity,
+              url: pullRequest.url
+            )
+          )
+        }
+      }
+
+      if successfulQuery {
+        return .resolved(nil)
+      }
+
+      if let failureMessage {
+        return .failure(failureMessage)
+      }
+
+      return .resolved(nil)
+    } catch {
+      return .failure(error.localizedDescription)
+    }
+  }
+
+  private func resolveRepositoryContext(
+    for workingDirectory: String,
+    gitPath: String
+  ) throws -> GithubRepositoryContext? {
+    let repoRootResult = try runner.run(gitPath, ["-C", workingDirectory, "rev-parse", "--show-toplevel"], nil)
+    guard repoRootResult.status == 0 else { return nil }
+    guard let repoRoot = trimmedNonEmpty(repoRootResult.standardOutput) else { return nil }
+
+    let branchResult = try runner.run(gitPath, ["-C", repoRoot, "symbolic-ref", "--quiet", "--short", "HEAD"], nil)
+    guard branchResult.status == 0 else { return nil }
+    guard let branch = trimmedNonEmpty(branchResult.standardOutput) else { return nil }
+
+    let upstreamResult = try runner.run(
+      gitPath,
+      [
+        "-C",
+        repoRoot,
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+      ],
+      nil
+    )
+    let upstreamReference = upstreamResult.status == 0 ? trimmedNonEmpty(upstreamResult.standardOutput) : nil
+
+    let remotesResult = try runner.run(gitPath, ["-C", repoRoot, "remote", "-v"], nil)
+    guard remotesResult.status == 0 else { return nil }
+
+    let remotes = parseRemotes(remotesResult.standardOutput)
+    guard !remotes.isEmpty else { return nil }
+
+    let trackingRemoteName = upstreamReference.flatMap(Self.remoteName(fromUpstreamReference:))
+    let candidateRepositories = orderedRepositories(
+      from: remotes,
+      trackingRemoteName: trackingRemoteName
+    )
+
+    guard !candidateRepositories.isEmpty else { return nil }
+
+    let expectedHeadOwner = trackingRemoteName
+      .flatMap { name in remotes.first(where: { $0.name == name }) }
+      .map { $0.repository.owner }
+
+    return .init(
+      candidateRepositories: candidateRepositories,
+      expectedHeadOwner: expectedHeadOwner,
+      repositoryIdentity: .init(
+        branch: branch,
+        repoRoot: repoRoot
+      )
+    )
+  }
+
+  private func orderedRepositories(
+    from remotes: [GithubRemote],
+    trackingRemoteName: String?
+  ) -> [GithubRepositoryReference] {
+    var orderedNames: [String] = []
+
+    if let trackingRemoteName {
+      orderedNames.append(trackingRemoteName)
+    }
+    orderedNames.append("upstream")
+    orderedNames.append("origin")
+    orderedNames.append(
+      contentsOf: remotes
+        .map(\.name)
+        .sorted()
+    )
+
+    var seenRepositories = Set<GithubRepositoryReference>()
+    var repositories: [GithubRepositoryReference] = []
+
+    for name in orderedNames {
+      guard let remote = remotes.first(where: { $0.name == name }) else { continue }
+      if seenRepositories.insert(remote.repository).inserted {
+        repositories.append(remote.repository)
+      }
+    }
+
+    return repositories
+  }
+
+  private func bestMatch(
+    in pullRequests: [GithubPullRequestCandidate],
+    expectedHeadOwner: String?
+  ) -> GithubPullRequestCandidate? {
+    if let expectedHeadOwner,
+      let preferred = pullRequests.first(where: {
+        $0.headRepositoryOwner?.login.caseInsensitiveCompare(expectedHeadOwner) == .orderedSame
+      })
+    {
+      return preferred
+    }
+
+    return pullRequests.first
+  }
+
+  private func parseRemotes(
+    _ output: String
+  ) -> [GithubRemote] {
+    output
+      .split(whereSeparator: \.isNewline)
+      .compactMap { line in
+        let parts = line.split(whereSeparator: \.isWhitespace)
+        guard parts.count >= 3 else { return nil }
+        guard parts[2] == "(fetch)" else { return nil }
+        guard
+          let repository = GithubRepositoryReference(
+            remoteURL: String(parts[1])
+          )
+        else {
+          return nil
+        }
+        return GithubRemote(
+          name: String(parts[0]),
+          repository: repository
+        )
+      }
+  }
+
+  private func resolveGitPath() throws -> String? {
+    if let cachedGitPath {
+      return cachedGitPath
+    }
+    let resolvedGitPath = try runner.resolveCommandPath("git")
+    cachedGitPath = resolvedGitPath
+    return resolvedGitPath
+  }
+
+  private func resolveGhPath() throws -> String? {
+    if let cachedGhPath {
+      return cachedGhPath
+    }
+    let resolvedGhPath = try runner.resolveCommandPath("gh")
+    cachedGhPath = resolvedGhPath
+    return resolvedGhPath
+  }
+
+  private static func remoteName(
+    fromUpstreamReference upstreamReference: String
+  ) -> String? {
+    let components = upstreamReference.split(separator: "/", maxSplits: 1)
+    guard let remoteName = components.first else { return nil }
+    let trimmed = remoteName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private func nonEmptyMessage(
+    from result: GithubCommandResult,
+    defaultDetail: String
+  ) -> String {
+    trimmedNonEmpty(result.standardError)
+      ?? trimmedNonEmpty(result.standardOutput)
+      ?? defaultDetail
+  }
+}
+
+private nonisolated struct GithubRepositoryContext: Sendable {
+  let candidateRepositories: [GithubRepositoryReference]
+  let expectedHeadOwner: String?
+  let repositoryIdentity: GithubRepositoryIdentity
+}
+
+private nonisolated struct GithubRemote: Equatable, Sendable {
+  let name: String
+  let repository: GithubRepositoryReference
+}
+
+private nonisolated struct GithubRepositoryReference: Equatable, Hashable, Sendable {
+  let host: String
+  let name: String
+  let owner: String
+
+  init(
+    host: String,
+    name: String,
+    owner: String
+  ) {
+    self.host = host
+    self.name = name
+    self.owner = owner
+  }
+
+  init?(
+    remoteURL: String
+  ) {
+    let trimmedRemoteURL = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedRemoteURL.isEmpty else { return nil }
+
+    if let parsed = Self.parseSCPStyleRemote(trimmedRemoteURL) {
+      self = parsed
+      return
+    }
+
+    guard let components = URLComponents(string: trimmedRemoteURL) else { return nil }
+    guard let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
+      return nil
+    }
+    let pathComponents = components.path
+      .split(separator: "/")
+      .map(String.init)
+    guard pathComponents.count >= 2 else { return nil }
+    let owner = pathComponents[pathComponents.count - 2]
+    let repositoryName = pathComponents[pathComponents.count - 1]
+    guard let normalized = Self.normalized(host: host, owner: owner, repositoryName: repositoryName) else {
+      return nil
+    }
+    self = normalized
+  }
+
+  var ghRepositoryIdentifier: String {
+    if host.caseInsensitiveCompare("github.com") == .orderedSame {
+      return "\(owner)/\(name)"
+    }
+    return "\(host)/\(owner)/\(name)"
+  }
+
+  private static func parseSCPStyleRemote(
+    _ remoteURL: String
+  ) -> Self? {
+    guard !remoteURL.contains("://") else { return nil }
+    guard let colonIndex = remoteURL.lastIndex(of: ":") else { return nil }
+
+    let hostSegment = remoteURL[..<colonIndex]
+    let pathSegment = remoteURL[remoteURL.index(after: colonIndex)...]
+    let host = hostSegment.split(separator: "@").last.map(String.init) ?? String(hostSegment)
+    let pathComponents = pathSegment.split(separator: "/").map(String.init)
+    guard pathComponents.count >= 2 else { return nil }
+    let owner = pathComponents[pathComponents.count - 2]
+    let repositoryName = pathComponents[pathComponents.count - 1]
+    return normalized(host: host, owner: owner, repositoryName: repositoryName)
+  }
+
+  private static func normalized(
+    host: String,
+    owner: String,
+    repositoryName: String
+  ) -> Self? {
+    let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let normalizedOwner = owner.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedRepositoryName = repositoryName
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: ".git", with: "", options: [.anchored, .backwards])
+
+    guard !normalizedHost.isEmpty, !normalizedOwner.isEmpty, !normalizedRepositoryName.isEmpty else {
+      return nil
+    }
+
+    return .init(
+      host: normalizedHost,
+      name: normalizedRepositoryName,
+      owner: normalizedOwner
+    )
+  }
+}
+
+private nonisolated struct GithubPullRequestCandidate: Decodable, Equatable, Sendable {
+  nonisolated struct RepositoryOwner: Decodable, Equatable, Sendable {
+    let login: String
+  }
+
+  let headRefName: String
+  let headRepositoryOwner: RepositoryOwner?
+  let number: Int
+  let url: URL
+}
+
+nonisolated struct GithubCommandResult: Equatable, Sendable {
+  let standardError: String
+  let standardOutput: String
+  let status: Int32
+}
+
+nonisolated struct GithubCommandRunner: Sendable {
+  let resolveCommandPath: @Sendable (_ commandName: String) throws -> String?
+  let run:
+    @Sendable (_ executablePath: String, _ arguments: [String], _ currentDirectoryPath: String?) throws ->
+      GithubCommandResult
+
+  static func live(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    currentUserShellPath: String? = currentUserShellPath()
+  ) -> Self {
+    let loginShellURL = loginShellURL(
+      environment: environment,
+      currentUserShellPath: currentUserShellPath
+    )
+    return Self(
+      resolveCommandPath: { commandName in
+        let result = try runProcess(
+          executablePath: loginShellURL.path,
+          arguments: ["-l", "-c", "command -v \(commandName)"],
+          currentDirectoryPath: nil,
+          environment: environment
+        )
+        guard result.status == 0 else { return nil }
+        return trimmedNonEmpty(result.standardOutput)
+      },
+      run: { executablePath, arguments, currentDirectoryPath in
+        try runProcess(
+          executablePath: executablePath,
+          arguments: arguments,
+          currentDirectoryPath: currentDirectoryPath,
+          environment: environment
+        )
+      }
+    )
+  }
+
+  private static func loginShellURL(
+    environment: [String: String],
+    currentUserShellPath: String?
+  ) -> URL {
+    let shellPath =
+      normalizedShellPath(currentUserShellPath)
+      ?? normalizedShellPath(environment["SHELL"])
+      ?? "/bin/zsh"
+    return URL(fileURLWithPath: shellPath)
+  }
+
+  private static func currentUserShellPath() -> String? {
+    guard let entry = getpwuid(getuid()), let shell = entry.pointee.pw_shell else {
+      return nil
+    }
+    return String(cString: shell)
+  }
+
+  private static func normalizedShellPath(_ path: String?) -> String? {
+    guard let trimmedPath = trimmedNonEmpty(path) else { return nil }
+    return trimmedPath
+  }
+
+  private static func runProcess(
+    executablePath: String,
+    arguments: [String],
+    currentDirectoryPath: String?,
+    environment: [String: String]
+  ) throws -> GithubCommandResult {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executablePath)
+    process.arguments = arguments
+    process.environment = environment
+    if let currentDirectoryPath {
+      process.currentDirectoryURL = URL(fileURLWithPath: currentDirectoryPath, isDirectory: true)
+    }
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    return .init(
+      standardError: normalizedPipeOutput(errorPipe),
+      standardOutput: normalizedPipeOutput(outputPipe),
+      status: process.terminationStatus
+    )
+  }
+
+  private static func normalizedPipeOutput(
+    _ pipe: Pipe
+  ) -> String {
+    String(
+      bytes: pipe.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    )?
+    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+}
+
+private nonisolated func trimmedNonEmpty(
+  _ value: String?
+) -> String? {
+  guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+    return nil
+  }
+  return trimmed
+}

--- a/apps/mac/supaterm/Features/Github/GithubPullRequestRefreshCoordinator.swift
+++ b/apps/mac/supaterm/Features/Github/GithubPullRequestRefreshCoordinator.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+@MainActor
+final class GithubPullRequestRefreshCoordinator {
+  private let client: GithubClient
+  private let onResolvedPullRequests: @MainActor ([UUID: GithubPullRequestSnapshot?]) -> Void
+  private let sleep: @Sendable (Duration) async throws -> Void
+
+  private var isEnabled = true
+  private var isRefreshing = false
+  private var pendingDirtySurfaceIDs: Set<UUID> = []
+  private var requestsBySurfaceID: [UUID: GithubPullRequestLookupRequest] = [:]
+  private var scheduledRefreshTask: Task<Void, Never>?
+  private var windowActivity = WindowActivityState.inactive
+
+  init<C: Clock<Duration>>(
+    client: GithubClient,
+    clock: C = ContinuousClock(),
+    onResolvedPullRequests: @escaping @MainActor ([UUID: GithubPullRequestSnapshot?]) -> Void
+  ) {
+    self.client = client
+    self.onResolvedPullRequests = onResolvedPullRequests
+    sleep = { duration in
+      try await clock.sleep(for: duration)
+    }
+  }
+
+  init(
+    client: GithubClient,
+    sleep: @escaping @Sendable (Duration) async throws -> Void,
+    onResolvedPullRequests: @escaping @MainActor ([UUID: GithubPullRequestSnapshot?]) -> Void
+  ) {
+    self.client = client
+    self.sleep = sleep
+    self.onResolvedPullRequests = onResolvedPullRequests
+  }
+
+  func markDirty(surfaceIDs: some Sequence<UUID>) {
+    for surfaceID in surfaceIDs {
+      guard requestsBySurfaceID[surfaceID] != nil else { continue }
+      pendingDirtySurfaceIDs.insert(surfaceID)
+    }
+    scheduleImmediateRefreshIfPossible()
+  }
+
+  func replaceRequests(
+    _ requestsBySurfaceID: [UUID: GithubPullRequestLookupRequest]
+  ) {
+    let previousRequests = self.requestsBySurfaceID
+    self.requestsBySurfaceID = requestsBySurfaceID
+
+    let removedSurfaceIDs = Set(previousRequests.keys).subtracting(requestsBySurfaceID.keys)
+    pendingDirtySurfaceIDs.subtract(removedSurfaceIDs)
+
+    let changedSurfaceIDs = requestsBySurfaceID.compactMap { surfaceID, request in
+      previousRequests[surfaceID] == request ? nil : surfaceID
+    }
+    for surfaceID in changedSurfaceIDs {
+      pendingDirtySurfaceIDs.insert(surfaceID)
+    }
+
+    if requestsBySurfaceID.isEmpty {
+      cancelScheduledRefresh()
+      return
+    }
+
+    scheduleImmediateRefreshIfPossible()
+  }
+
+  func setEnabled(
+    _ isEnabled: Bool
+  ) {
+    self.isEnabled = isEnabled
+    if !isEnabled {
+      pendingDirtySurfaceIDs.removeAll()
+      cancelScheduledRefresh()
+      return
+    }
+    scheduleImmediateRefreshIfPossible()
+  }
+
+  func updateWindowActivity(
+    _ windowActivity: WindowActivityState
+  ) {
+    self.windowActivity = windowActivity
+    cancelScheduledRefresh()
+    scheduleRefreshIfNeeded()
+  }
+
+  private func scheduleImmediateRefreshIfPossible() {
+    guard !pendingDirtySurfaceIDs.isEmpty else {
+      scheduleRefreshIfNeeded()
+      return
+    }
+    guard isActive else {
+      cancelScheduledRefresh()
+      return
+    }
+    guard !isRefreshing else {
+      cancelScheduledRefresh()
+      return
+    }
+
+    cancelScheduledRefresh()
+    refresh(surfaceIDs: pendingDirtySurfaceIDs)
+  }
+
+  private func scheduleRefreshIfNeeded() {
+    guard isEnabled else {
+      cancelScheduledRefresh()
+      return
+    }
+    guard !requestsBySurfaceID.isEmpty else {
+      cancelScheduledRefresh()
+      return
+    }
+    guard isActive else {
+      cancelScheduledRefresh()
+      return
+    }
+    guard !isRefreshing else {
+      cancelScheduledRefresh()
+      return
+    }
+    if pendingDirtySurfaceIDs.isEmpty {
+      scheduleTimedRefreshIfNeeded()
+    } else {
+      scheduleImmediateRefreshIfPossible()
+    }
+  }
+
+  private func scheduleTimedRefreshIfNeeded() {
+    guard scheduledRefreshTask == nil else { return }
+
+    let interval = refreshInterval
+    scheduledRefreshTask = Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await self.sleep(interval)
+      } catch {
+        return
+      }
+      await MainActor.run {
+        self.scheduledRefreshTask = nil
+        self.refresh(surfaceIDs: Set(self.requestsBySurfaceID.keys))
+      }
+    }
+  }
+
+  private func refresh(
+    surfaceIDs: Set<UUID>
+  ) {
+    guard isEnabled else { return }
+    guard isActive else { return }
+    guard !surfaceIDs.isEmpty else {
+      scheduleTimedRefreshIfNeeded()
+      return
+    }
+    guard !isRefreshing else { return }
+
+    let refreshRequests = surfaceIDs.compactMap { requestsBySurfaceID[$0] }
+    guard !refreshRequests.isEmpty else {
+      pendingDirtySurfaceIDs.subtract(surfaceIDs)
+      scheduleTimedRefreshIfNeeded()
+      return
+    }
+    let refreshRequestsBySurfaceID = Dictionary(
+      uniqueKeysWithValues: refreshRequests.map { ($0.surfaceID, $0) }
+    )
+
+    isRefreshing = true
+    pendingDirtySurfaceIDs.subtract(surfaceIDs)
+    cancelScheduledRefresh()
+
+    Task { [weak self] in
+      guard let self else { return }
+      let responses = await self.client.lookupPullRequests(refreshRequests)
+      await MainActor.run {
+        self.isRefreshing = false
+        guard self.isEnabled else { return }
+
+        let resolvedPullRequests = responses.reduce(into: [UUID: GithubPullRequestSnapshot?]()) {
+          partialResult,
+          element in
+          guard self.requestsBySurfaceID[element.key] == refreshRequestsBySurfaceID[element.key] else {
+            return
+          }
+          switch element.value {
+          case .resolved(let snapshot):
+            partialResult[element.key] = snapshot
+          case .failure:
+            break
+          }
+        }
+
+        if !resolvedPullRequests.isEmpty {
+          self.onResolvedPullRequests(resolvedPullRequests)
+        }
+
+        if !self.pendingDirtySurfaceIDs.isEmpty {
+          self.scheduleImmediateRefreshIfPossible()
+        } else {
+          self.scheduleTimedRefreshIfNeeded()
+        }
+      }
+    }
+  }
+
+  private func cancelScheduledRefresh() {
+    scheduledRefreshTask?.cancel()
+    scheduledRefreshTask = nil
+  }
+
+  private var isActive: Bool {
+    isEnabled && windowActivity.isVisible
+  }
+
+  private var refreshInterval: Duration {
+    windowActivity.isKeyWindow ? .seconds(30) : .seconds(60)
+  }
+}

--- a/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
@@ -40,6 +40,12 @@ struct SettingsAgentIntegrationState: Equatable {
   }
 }
 
+struct SettingsGithubState: Equatable {
+  var diagnostics: GithubDiagnostics?
+  var isLoadingDiagnostics = false
+  var pullRequestsEnabled = SupatermSettings.default.githubPullRequestsEnabled
+}
+
 enum SettingsAgentIntegrationResult: Equatable {
   case unavailable(String)
   case failure(String)
@@ -63,6 +69,7 @@ struct SettingsFeature {
       settingsPath: SupatermAgentKind.pi.settingsPathDescription
     )
     var crashReportsEnabled = SupatermSettings.default.crashReportsEnabled
+    var github = SettingsGithubState()
     var glowingPaneRingEnabled = SupatermSettings.default.glowingPaneRingEnabled
     var restoreTerminalLayoutEnabled = SupatermSettings.default.restoreTerminalLayoutEnabled
     var selectedTab = Tab.general
@@ -83,6 +90,9 @@ struct SettingsFeature {
     case analyticsEnabledChanged(Bool)
     case checkForUpdatesButtonTapped
     case crashReportsEnabledChanged(Bool)
+    case githubDiagnosticsRefreshRequested
+    case githubDiagnosticsResponse(GithubDiagnostics)
+    case githubPullRequestsEnabledChanged(Bool)
     case glowingPaneRingEnabledChanged(Bool)
     case restoreTerminalLayoutEnabledChanged(Bool)
     case settingsLoaded(SupatermSettings)
@@ -116,6 +126,7 @@ struct SettingsFeature {
     case general
     case terminal
     case notifications
+    case github
     case codingAgents
     case about
 
@@ -127,6 +138,8 @@ struct SettingsFeature {
       switch self {
       case .codingAgents:
         "hammer"
+      case .github:
+        "point.3.connected.trianglepath.dotted"
       case .general:
         "gearshape"
       case .terminal:
@@ -142,6 +155,8 @@ struct SettingsFeature {
       switch self {
       case .codingAgents:
         "Coding Agents"
+      case .github:
+        "GitHub"
       case .general:
         "General"
       case .terminal:
@@ -160,6 +175,7 @@ struct SettingsFeature {
   @Dependency(AnalyticsClient.self) var analyticsClient
   @Dependency(DesktopNotificationClient.self) var desktopNotificationClient
   @Dependency(GhosttyTerminalSettingsClient.self) var ghosttyTerminalSettingsClient
+  @Dependency(GithubClient.self) var githubClient
   @Dependency(UpdateClient.self) var updateClient
 
   var body: some Reducer<State, Action> {
@@ -170,6 +186,7 @@ struct SettingsFeature {
         return .merge(
           .send(.settingsLoaded(supatermSettings)),
           .send(.terminalSettingsLoadRequested),
+          .send(.githubDiagnosticsRefreshRequested),
           .send(.agentIntegrationStatusRefreshRequested(.claude)),
           .send(.agentIntegrationStatusRefreshRequested(.codex)),
           .send(.agentIntegrationStatusRefreshRequested(.pi)),
@@ -187,6 +204,7 @@ struct SettingsFeature {
         state.appearanceMode = supatermSettings.appearanceMode
         state.analyticsEnabled = supatermSettings.analyticsEnabled
         state.crashReportsEnabled = supatermSettings.crashReportsEnabled
+        state.github.pullRequestsEnabled = supatermSettings.githubPullRequestsEnabled
         state.glowingPaneRingEnabled = supatermSettings.glowingPaneRingEnabled
         state.restoreTerminalLayoutEnabled = supatermSettings.restoreTerminalLayoutEnabled
         state.systemNotificationsEnabled = supatermSettings.systemNotificationsEnabled
@@ -400,6 +418,24 @@ struct SettingsFeature {
         state.crashReportsEnabled = isEnabled
         return persist(state)
 
+      case .githubDiagnosticsRefreshRequested:
+        guard !state.github.isLoadingDiagnostics else {
+          return .none
+        }
+        state.github.isLoadingDiagnostics = true
+        return .run { [githubClient] send in
+          await send(.githubDiagnosticsResponse(await githubClient.diagnostics()))
+        }
+
+      case .githubDiagnosticsResponse(let diagnostics):
+        state.github.diagnostics = diagnostics
+        state.github.isLoadingDiagnostics = false
+        return .none
+
+      case .githubPullRequestsEnabledChanged(let isEnabled):
+        state.github.pullRequestsEnabled = isEnabled
+        return persist(state)
+
       case .glowingPaneRingEnabledChanged(let isEnabled):
         state.glowingPaneRingEnabled = isEnabled
         return persist(state)
@@ -454,6 +490,9 @@ struct SettingsFeature {
 
       case .tabSelected(let tab):
         state.selectedTab = tab
+        if tab == .github {
+          return .send(.githubDiagnosticsRefreshRequested)
+        }
         return .none
 
       case .updateChannelSelected(let updateChannel):
@@ -491,6 +530,7 @@ struct SettingsFeature {
       appearanceMode: state.appearanceMode,
       analyticsEnabled: state.analyticsEnabled,
       crashReportsEnabled: state.crashReportsEnabled,
+      githubPullRequestsEnabled: state.github.pullRequestsEnabled,
       glowingPaneRingEnabled: state.glowingPaneRingEnabled,
       restoreTerminalLayoutEnabled: state.restoreTerminalLayoutEnabled,
       systemNotificationsEnabled: state.systemNotificationsEnabled,

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -46,6 +46,8 @@ private struct SettingsTabContentView: View {
     switch tab {
     case .codingAgents:
       SettingsCodingAgentsView(store: store)
+    case .github:
+      SettingsGithubView(store: store)
     case .general:
       SettingsGeneralView(store: store)
     case .terminal:
@@ -55,6 +57,72 @@ private struct SettingsTabContentView: View {
     case .about:
       SettingsAboutView(store: store)
     }
+  }
+}
+
+private struct SettingsGithubView: View {
+  let store: StoreOf<SettingsFeature>
+
+  private var pullRequestsEnabled: Binding<Bool> {
+    Binding(
+      get: { store.github.pullRequestsEnabled },
+      set: { newValue in
+        _ = store.send(.githubPullRequestsEnabledChanged(newValue))
+      }
+    )
+  }
+
+  var body: some View {
+    Form {
+      Section {
+        SettingsToggleRow(
+          title: "Pull request surfaces",
+          subtitle:
+            "Show pull request links in the sidebar and selected pane top bar "
+            + "when the active repository has an open GitHub pull request.",
+          isOn: pullRequestsEnabled
+        )
+      } footer: {
+        Text("Supaterm checks the current repository and branch through git and GitHub CLI.")
+      }
+
+      Section {
+        HStack {
+          Text("Diagnostics")
+            .font(.callout.weight(.semibold))
+          Spacer(minLength: 12)
+          Button("Refresh") {
+            _ = store.send(.githubDiagnosticsRefreshRequested)
+          }
+          .disabled(store.github.isLoadingDiagnostics)
+        }
+
+        if let diagnostics = store.github.diagnostics {
+          SettingsGithubDiagnosticRow(
+            title: "Git",
+            status: diagnostics.gitStatus
+          )
+          SettingsGithubDiagnosticRow(
+            title: "GitHub CLI",
+            status: diagnostics.ghStatus
+          )
+          SettingsGithubAuthenticationRow(
+            status: diagnostics.authenticationStatus
+          )
+        } else if store.github.isLoadingDiagnostics {
+          ProgressView()
+            .controlSize(.small)
+        } else {
+          Text("Diagnostics have not been loaded yet.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+      } footer: {
+        Text("If pull request surfaces do not appear, start here.")
+      }
+    }
+    .navigationTitle("GitHub")
+    .settingsFormLayout()
   }
 }
 
@@ -645,6 +713,71 @@ private struct SettingsToggleRow: View {
         title: title,
         subtitle: subtitle
       )
+    }
+  }
+}
+
+private struct SettingsGithubDiagnosticRow: View {
+  let title: String
+  let status: GithubBinaryStatus
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: status.isAvailable ? "checkmark.circle.fill" : "xmark.circle.fill")
+        .foregroundStyle(status.isAvailable ? .green : .red)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.callout.weight(.semibold))
+        Text(status.detail)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+private struct SettingsGithubAuthenticationRow: View {
+  let status: GithubAuthenticationStatus
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: symbolName)
+        .foregroundStyle(symbolColor)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Authentication")
+          .font(.callout.weight(.semibold))
+        Text(status.detail)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(.vertical, 2)
+  }
+
+  private var symbolColor: Color {
+    switch status {
+    case .authenticated:
+      return .green
+    case .unavailable:
+      return .orange
+    case .unauthenticated:
+      return .red
+    }
+  }
+
+  private var symbolName: String {
+    switch status {
+    case .authenticated:
+      return "checkmark.circle.fill"
+    case .unavailable:
+      return "exclamationmark.circle.fill"
+    case .unauthenticated:
+      return "xmark.circle.fill"
     }
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -182,7 +182,14 @@ final class TerminalHostState {
   @ObservationIgnored
   private let managesTerminalSurfaces: Bool
   @ObservationIgnored
+  private var githubRefreshCoordinator: GithubPullRequestRefreshCoordinator! = nil
+  @ObservationIgnored
   private var eventContinuation: AsyncStream<TerminalClient.Event>.Continuation?
+  @ObservationIgnored
+  @Shared(.supatermSettings)
+  private var supatermSettings = SupatermSettings.default
+  @ObservationIgnored
+  private var supatermSettingsObservationTask: Task<Void, Never>?
   @ObservationIgnored
   @Shared(.terminalSpaceCatalog)
   private var spaceCatalog = TerminalSpaceCatalog.default
@@ -211,6 +218,7 @@ final class TerminalHostState {
   private var lastEmittedFocusSurfaceID: UUID?
   private var runtimeConfigGeneration = 0
   private var suppressesSessionChanges = 0
+  private var githubPullRequestBySurfaceID: [UUID: GithubPullRequestSnapshot] = [:]
   @ObservationIgnored
   private var recentStructuredNotificationsBySurfaceID: [UUID: RecentStructuredNotification] = [:]
 
@@ -218,10 +226,15 @@ final class TerminalHostState {
 
   init(
     runtime: GhosttyRuntime? = nil,
+    githubClient: GithubClient = .liveValue,
     managesTerminalSurfaces: Bool = true
   ) {
     self.managesTerminalSurfaces = managesTerminalSurfaces
     self.runtime = managesTerminalSurfaces ? (runtime ?? GhosttyRuntime()) : runtime
+    githubRefreshCoordinator = GithubPullRequestRefreshCoordinator(client: githubClient) { [weak self] snapshots in
+      guard let self else { return }
+      self.applyResolvedGithubPullRequests(snapshots)
+    }
 
     let initialSpaceCatalog = TerminalSpaceCatalog.sanitized(spaceCatalog)
     if initialSpaceCatalog != spaceCatalog {
@@ -233,10 +246,13 @@ final class TerminalHostState {
       initialSelectedSpaceID: initialSpaceCatalog.defaultSelectedSpaceID
     )
     observeRuntimeConfig()
+    observeSupatermSettings()
     observeSpaceCatalog()
+    applyObservedSupatermSettings(supatermSettings)
   }
 
   isolated deinit {
+    supatermSettingsObservationTask?.cancel()
     spaceCatalogObservationTask?.cancel()
     if let runtimeConfigObserver {
       NotificationCenter.default.removeObserver(runtimeConfigObserver)
@@ -364,6 +380,19 @@ final class TerminalHostState {
     ) { [weak self] _ in
       MainActor.assumeIsolated {
         self?.runtimeConfigGeneration &+= 1
+      }
+    }
+  }
+
+  private func observeSupatermSettings() {
+    supatermSettingsObservationTask?.cancel()
+    supatermSettingsObservationTask = Task { @MainActor [weak self] in
+      let observations = Observations { [weak self] in
+        self?.supatermSettings ?? .default
+      }
+      for await supatermSettings in observations {
+        guard let self else { return }
+        self.applyObservedSupatermSettings(supatermSettings)
       }
     }
   }
@@ -611,6 +640,14 @@ final class TerminalHostState {
     )
   }
 
+  var selectedPaneGithubPullRequestPresentation: GithubPullRequestPresentation? {
+    let surfaceID =
+      currentFocusedSurfaceID()
+      ?? selectedTree?.root?.leftmostLeaf().id
+    guard let surfaceID else { return nil }
+    return githubPullRequestBySurfaceID[surfaceID].map(GithubPullRequestPresentation.init(snapshot:))
+  }
+
   func contextSurfaceID(for tabID: TerminalTabID) -> UUID? {
     if let focusedSurfaceID = focusedSurfaceIDByTab[tabID], surfaces[focusedSurfaceID] != nil {
       return focusedSurfaceID
@@ -623,6 +660,13 @@ final class TerminalHostState {
       in: splitTree(for: tabID),
       pwd: { $0.bridge.state.pwd }
     )
+  }
+
+  func githubPullRequestPresentation(
+    for tabID: TerminalTabID
+  ) -> GithubPullRequestPresentation? {
+    guard let surfaceID = contextSurfaceID(for: tabID) else { return nil }
+    return githubPullRequestBySurfaceID[surfaceID].map(GithubPullRequestPresentation.init(snapshot:))
   }
 
   var terminalBackgroundColor: Color {
@@ -1057,6 +1101,7 @@ final class TerminalHostState {
 
   private func updateWindowActivity(_ activity: WindowActivityState) {
     windowActivity = activity
+    githubRefreshCoordinator.updateWindowActivity(activity)
     syncFocus(activity)
     clearUnreadOnFocusedSurfaceIfNeeded()
   }
@@ -2382,6 +2427,7 @@ final class TerminalHostState {
     let newTree = tree.removing(node)
     surface.closeSurface()
     surfaces.removeValue(forKey: surfaceID)
+    githubPullRequestBySurfaceID.removeValue(forKey: surfaceID)
     paneNotifications.removeValue(forKey: surfaceID)
     recentStructuredNotificationsBySurfaceID.removeValue(forKey: surfaceID)
 
@@ -2400,6 +2446,7 @@ final class TerminalHostState {
         focusSurface(in: selectedTabID)
       }
       syncFocus(windowActivity)
+      syncGithubRefreshRequests()
       sessionDidChange()
       return
     }
@@ -2420,6 +2467,7 @@ final class TerminalHostState {
       }
     }
     syncFocus(windowActivity)
+    syncGithubRefreshRequests()
     sessionDidChange()
   }
 
@@ -2448,6 +2496,7 @@ final class TerminalHostState {
     configureBridgeCallbacks(for: view, tabID: tabID)
     configureSurfaceCallbacks(for: view, tabID: tabID)
     surfaces[view.id] = view
+    syncGithubRefreshRequests()
     return view
   }
 
@@ -2455,14 +2504,17 @@ final class TerminalHostState {
     for view: GhosttySurfaceView,
     tabID: TerminalTabID
   ) {
+    let surfaceID = view.id
     view.bridge.onTitleChange = { [weak self] _ in
       guard let self else { return }
       self.updateTabTitle(for: tabID)
+      self.handleGithubTitleChange(for: surfaceID)
       self.sessionDidChange()
     }
     view.bridge.onPathChange = { [weak self] in
       guard let self else { return }
       self.updateTabTitle(for: tabID)
+      self.handleGithubPathChange(for: surfaceID)
       self.sessionDidChange()
     }
     view.bridge.onTabTitleChange = { [weak self] title in
@@ -2909,6 +2961,7 @@ final class TerminalHostState {
   private func removeTree(for tabID: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabID) else { return }
     for surface in tree.leaves() {
+      githubPullRequestBySurfaceID.removeValue(forKey: surface.id)
       paneNotifications.removeValue(forKey: surface.id)
       recentStructuredNotificationsBySurfaceID.removeValue(forKey: surface.id)
       surface.closeSurface()
@@ -2919,6 +2972,7 @@ final class TerminalHostState {
     focusedSurfaceIDByTab.removeValue(forKey: tabID)
     previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
     previousSelectedTabIDBySpace = previousSelectedTabIDBySpace.filter { $0.value != tabID }
+    syncGithubRefreshRequests()
   }
 
   private func notifications(for tabID: TerminalTabID) -> [UUID: [PaneNotification]] {
@@ -3304,6 +3358,99 @@ final class TerminalHostState {
     }
     guard isDirectory.boolValue else { return nil }
     return URL(fileURLWithPath: normalizedPath, isDirectory: true)
+  }
+
+  private func applyObservedSupatermSettings(
+    _ supatermSettings: SupatermSettings
+  ) {
+    if !supatermSettings.githubPullRequestsEnabled {
+      githubPullRequestBySurfaceID.removeAll()
+    }
+    githubRefreshCoordinator.setEnabled(supatermSettings.githubPullRequestsEnabled)
+    syncGithubRefreshRequests()
+  }
+
+  private func applyResolvedGithubPullRequests(
+    _ pullRequestsBySurfaceID: [UUID: GithubPullRequestSnapshot?]
+  ) {
+    for (surfaceID, snapshot) in pullRequestsBySurfaceID {
+      guard surfaces[surfaceID] != nil else { continue }
+      if let snapshot {
+        githubPullRequestBySurfaceID[surfaceID] = snapshot
+      } else {
+        githubPullRequestBySurfaceID.removeValue(forKey: surfaceID)
+      }
+    }
+  }
+
+  private func handleGithubPathChange(
+    for surfaceID: UUID
+  ) {
+    clearGithubPullRequestIfRepositoryChanged(for: surfaceID)
+    syncGithubRefreshRequests()
+    githubRefreshCoordinator.markDirty(surfaceIDs: [surfaceID])
+  }
+
+  private func handleGithubTitleChange(
+    for surfaceID: UUID
+  ) {
+    githubRefreshCoordinator.markDirty(surfaceIDs: [surfaceID])
+  }
+
+  private func clearGithubPullRequestIfRepositoryChanged(
+    for surfaceID: UUID
+  ) {
+    guard let snapshot = githubPullRequestBySurfaceID[surfaceID] else { return }
+    guard let workingDirectory = surfaces[surfaceID]?.bridge.state.pwd else {
+      githubPullRequestBySurfaceID.removeValue(forKey: surfaceID)
+      return
+    }
+
+    let normalizedWorkingDirectory = GhosttySurfaceView.normalizedWorkingDirectoryPath(workingDirectory)
+    let normalizedRepositoryRoot = GhosttySurfaceView.normalizedWorkingDirectoryPath(
+      snapshot.repositoryIdentity.repoRoot
+    )
+
+    guard normalizedWorkingDirectory.hasPrefix(normalizedRepositoryRoot) else {
+      githubPullRequestBySurfaceID.removeValue(forKey: surfaceID)
+      return
+    }
+
+    let boundaryIndex = normalizedWorkingDirectory.index(
+      normalizedWorkingDirectory.startIndex,
+      offsetBy: normalizedRepositoryRoot.count,
+      limitedBy: normalizedWorkingDirectory.endIndex
+    )
+    guard let boundaryIndex else { return }
+    guard boundaryIndex == normalizedWorkingDirectory.endIndex
+      || normalizedWorkingDirectory[boundaryIndex] == "/"
+    else {
+      githubPullRequestBySurfaceID.removeValue(forKey: surfaceID)
+      return
+    }
+  }
+
+  private func syncGithubRefreshRequests() {
+    guard supatermSettings.githubPullRequestsEnabled else {
+      githubRefreshCoordinator.replaceRequests([:])
+      return
+    }
+    githubRefreshCoordinator.replaceRequests(githubLookupRequests())
+  }
+
+  private func githubLookupRequests() -> [UUID: GithubPullRequestLookupRequest] {
+    Dictionary(
+      uniqueKeysWithValues: surfaces.compactMap { surfaceID, surface in
+        guard let workingDirectory = Self.trimmedNonEmpty(surface.bridge.state.pwd) else { return nil }
+        return (
+          surfaceID,
+          .init(
+            surfaceID: surfaceID,
+            workingDirectory: GhosttySurfaceView.normalizedWorkingDirectoryPath(workingDirectory)
+          )
+        )
+      }
+    )
   }
 
   private func observeSpaceCatalog() {

--- a/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
@@ -284,6 +284,7 @@ struct TerminalSidebarChromeView: View {
   ) -> some View {
     let notificationPresentation = terminal.latestSidebarNotificationPresentation(for: tab.id)
     let paneWorkingDirectories = terminal.paneWorkingDirectories(for: tab.id)
+    let githubPullRequest = terminal.githubPullRequestPresentation(for: tab.id)
     let unreadCount = terminal.unreadNotificationCount(for: tab.id)
     let terminalProgress = terminal.sidebarTerminalProgress(for: tab.id)
     let preview = TerminalSidebarDragPreviewItem(
@@ -306,6 +307,7 @@ struct TerminalSidebarChromeView: View {
         store: store,
         terminal: terminal,
         tab: tab,
+        githubPullRequest: githubPullRequest,
         notificationPresentation: notificationPresentation,
         paneWorkingDirectories: paneWorkingDirectories,
         unreadCount: unreadCount,
@@ -824,6 +826,7 @@ struct TerminalSidebarTabRow: View {
 
   private struct AnimatedPresentation: Equatable {
     let agentActivity: TerminalHostState.AgentActivity?
+    let githubPullRequestLabel: String?
     let showsAgentActivityDetail: Bool
     let notificationPreviewMarkdown: String?
     let notificationMarkdown: String?
@@ -835,6 +838,7 @@ struct TerminalSidebarTabRow: View {
   let store: StoreOf<TerminalWindowFeature>
   let terminal: TerminalHostState
   let tab: TerminalTabItem
+  let githubPullRequest: GithubPullRequestPresentation?
   let notificationPresentation: TerminalHostState.SidebarNotificationPresentation?
   let paneWorkingDirectories: [String]
   let unreadCount: Int
@@ -862,6 +866,7 @@ struct TerminalSidebarTabRow: View {
   }
 
   @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.openURL) private var openURL
   @State private var isHovering = false
   @State private var isCloseHovering = false
 
@@ -883,63 +888,84 @@ struct TerminalSidebarTabRow: View {
   }
 
   var body: some View {
-    Button(action: select) {
-      HStack(spacing: 8) {
-        let summary = TerminalSidebarTabSummaryView(
-          tab: tab,
-          palette: palette,
-          isSelected: isSelected,
-          notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
-          paneWorkingDirectories: paneWorkingDirectories,
-          unreadCount: unreadCount,
-          agentActivity: terminal.agentActivity(for: tab.id),
-          showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
-          terminalProgress: terminalProgress,
-          shortcutHint: shortcutHint,
-          showsShortcutHint: showsShortcutHint,
-          isRowHovering: isHovering
-        )
-        .lineLimit(8)
-        if let helpText = TerminalSidebarTabSummaryView.helpText(
-          paneWorkingDirectories: paneWorkingDirectories
-        ) {
-          summary.help(helpText)
-        } else {
-          summary
+    HStack(alignment: .top, spacing: 8) {
+      VStack(alignment: .leading, spacing: 4) {
+        Button(action: select) {
+          let summary = TerminalSidebarTabSummaryView(
+            tab: tab,
+            palette: palette,
+            isSelected: isSelected,
+            notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
+            paneWorkingDirectories: paneWorkingDirectories,
+            unreadCount: unreadCount,
+            agentActivity: terminal.agentActivity(for: tab.id),
+            showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
+            terminalProgress: terminalProgress,
+            shortcutHint: shortcutHint,
+            showsShortcutHint: showsShortcutHint,
+            isRowHovering: isHovering
+          )
+          .lineLimit(8)
+          if let helpText = TerminalSidebarTabSummaryView.helpText(
+            paneWorkingDirectories: paneWorkingDirectories
+          ) {
+            summary.help(helpText)
+          } else {
+            summary
+          }
         }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
 
-        if isHovering && !showsShortcutHint {
-          Button(action: close) {
-            Image(systemName: "xmark")
-              .font(.system(size: 12, weight: .heavy))
-              .foregroundStyle(isSelected ? palette.selectedText : palette.primaryText)
-              .frame(width: 24, height: 24)
+        if let githubPullRequest {
+          Button {
+            openURL(githubPullRequest.url)
+          } label: {
+            Text(githubPullRequest.label)
+              .font(.system(size: 11, weight: .semibold))
+              .foregroundStyle(isSelected ? palette.selectedText : Color.accentColor)
+              .lineLimit(1)
+              .truncationMode(.tail)
+              .frame(maxWidth: .infinity, alignment: .leading)
               .accessibilityHidden(true)
-              .background(
-                isCloseHovering
-                  ? (isSelected ? palette.clearFill : palette.rowFill)
-                  : .clear,
-                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-              )
           }
           .buttonStyle(.plain)
-          .onHover { isCloseHovering = $0 }
+          .help("Open \(githubPullRequest.label)")
+          .accessibilityLabel("Open \(githubPullRequest.label)")
         }
       }
-      .padding(.horizontal, TerminalSidebarLayout.tabRowHorizontalPadding)
-      .padding(.vertical, TerminalSidebarLayout.tabRowVerticalPadding)
-      .frame(minHeight: TerminalSidebarLayout.tabRowMinHeight)
-      .frame(maxWidth: .infinity)
-      .background(backgroundColor)
-      .clipShape(
-        RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
-      )
-      .shadow(color: isSelected ? palette.shadow : .clear, radius: isSelected ? 2 : 0, y: 1.5)
-      .contentShape(
-        RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
-      )
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      if isHovering && !showsShortcutHint {
+        Button(action: close) {
+          Image(systemName: "xmark")
+            .font(.system(size: 12, weight: .heavy))
+            .foregroundStyle(isSelected ? palette.selectedText : palette.primaryText)
+            .frame(width: 24, height: 24)
+            .accessibilityHidden(true)
+            .background(
+              isCloseHovering
+                ? (isSelected ? palette.clearFill : palette.rowFill)
+                : .clear,
+              in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isCloseHovering = $0 }
+      }
     }
-    .buttonStyle(.plain)
+    .padding(.horizontal, TerminalSidebarLayout.tabRowHorizontalPadding)
+    .padding(.vertical, TerminalSidebarLayout.tabRowVerticalPadding)
+    .frame(minHeight: TerminalSidebarLayout.tabRowMinHeight)
+    .frame(maxWidth: .infinity)
+    .background(backgroundColor)
+    .clipShape(
+      RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
+    )
+    .shadow(color: isSelected ? palette.shadow : .clear, radius: isSelected ? 2 : 0, y: 1.5)
+    .contentShape(
+      RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
+    )
     .animation(rowAnimation, value: animatedPresentation)
     .background {
       SidebarPopoverPresenter(
@@ -1032,6 +1058,7 @@ struct TerminalSidebarTabRow: View {
   private var animatedPresentation: AnimatedPresentation {
     .init(
       agentActivity: terminal.agentActivity(for: tab.id),
+      githubPullRequestLabel: githubPullRequest?.label,
       showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
       notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
       notificationMarkdown: notificationPresentation?.markdown,

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
@@ -14,6 +14,7 @@ struct TerminalDetailView: View {
       TerminalDetailTopBar(
         canEqualize: terminal.selectedTree?.isSplit ?? false,
         canSplit: terminal.selectedSurfaceView != nil,
+        githubPullRequest: terminal.selectedPaneGithubPullRequestPresentation,
         isPaneZoomed: terminal.selectedPaneIsZoomed,
         isSidebarCollapsed: store.isSidebarCollapsed,
         palette: palette,
@@ -53,6 +54,7 @@ struct TerminalDetailView: View {
 private struct TerminalDetailTopBar: View {
   let canEqualize: Bool
   let canSplit: Bool
+  let githubPullRequest: GithubPullRequestPresentation?
   let isPaneZoomed: Bool
   let isSidebarCollapsed: Bool
   let palette: TerminalPalette
@@ -63,6 +65,8 @@ private struct TerminalDetailTopBar: View {
   let splitDown: () -> Void
   let splitRight: () -> Void
   let togglePaneZoom: () -> Void
+
+  @Environment(\.openURL) private var openURL
 
   var body: some View {
     HStack(spacing: 0) {
@@ -80,6 +84,32 @@ private struct TerminalDetailTopBar: View {
         .lineLimit(1)
         .truncationMode(.middle)
         .padding(.leading, 8)
+
+      if let githubPullRequest {
+        Button {
+          openURL(githubPullRequest.url)
+        } label: {
+          Text(githubPullRequest.label)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(Color.accentColor)
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            .frame(height: 22)
+            .background(
+              Color.accentColor.opacity(0.12),
+              in: Capsule(style: .continuous)
+            )
+            .overlay {
+              Capsule(style: .continuous)
+                .stroke(Color.accentColor.opacity(0.22), lineWidth: 1)
+            }
+            .accessibilityHidden(true)
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, 8)
+        .help("Open \(githubPullRequest.label)")
+        .accessibilityLabel("Open \(githubPullRequest.label)")
+      }
 
       Spacer(minLength: 8)
       HStack(spacing: 4) {

--- a/apps/mac/supatermTests/GithubClientTests.swift
+++ b/apps/mac/supatermTests/GithubClientTests.swift
@@ -1,0 +1,361 @@
+import Foundation
+import Testing
+
+@testable import supaterm
+
+@MainActor
+struct GithubClientTests {
+  @Test
+  func lookupPullRequestsPrefersTrackingRemoteBeforeUpstream() async {
+    let recorder = GithubCommandRecorder()
+    let client = GithubClient.live(
+      runner: .init(
+        resolveCommandPath: { commandName in
+          switch commandName {
+          case "git":
+            return "/usr/bin/git"
+          case "gh":
+            return "/opt/homebrew/bin/gh"
+          default:
+            return nil
+          }
+        },
+        run: { executablePath, arguments, currentDirectoryPath in
+          recorder.record(
+            executablePath: executablePath,
+            arguments: arguments,
+            currentDirectoryPath: currentDirectoryPath
+          )
+          return try githubCommandResult(
+            executablePath: executablePath,
+            arguments: arguments
+          )
+        }
+      )
+    )
+
+    let surfaceID = UUID()
+    let responses = await client.lookupPullRequests(
+      [
+        .init(
+          surfaceID: surfaceID,
+          workingDirectory: "/tmp/project/subdir",
+        ),
+      ]
+    )
+
+    #expect(
+      responses[surfaceID] == .resolved(
+        .init(
+          number: 123,
+          repositoryIdentity: .init(
+            branch: "feature",
+            repoRoot: "/tmp/project"
+          ),
+          url: URL(string: "https://github.com/supabitapp/supaterm/pull/123")!
+        )
+      )
+    )
+    #expect(
+      recorder.recordedGithubRepositories() == [
+        "acme/supaterm",
+        "supabitapp/supaterm",
+      ]
+    )
+  }
+
+  @Test
+  func lookupPullRequestsPrefersForkOwnerWhenMultiplePullRequestsShareTheBranchName() async {
+    let client = GithubClient.live(
+      runner: .init(
+        resolveCommandPath: { commandName in
+          switch commandName {
+          case "git":
+            return "/usr/bin/git"
+          case "gh":
+            return "/opt/homebrew/bin/gh"
+          default:
+            return nil
+          }
+        },
+        run: { executablePath, arguments, _ in
+          try githubCommandResult(
+            executablePath: executablePath,
+            arguments: arguments,
+            upstreamPullRequests: """
+              [
+                {
+                  "headRefName": "feature",
+                  "headRepositoryOwner": { "login": "someone-else" },
+                  "number": 98,
+                  "url": "https://github.com/supabitapp/supaterm/pull/98"
+                },
+                {
+                  "headRefName": "feature",
+                  "headRepositoryOwner": { "login": "acme" },
+                  "number": 456,
+                  "url": "https://github.com/supabitapp/supaterm/pull/456"
+                }
+              ]
+              """
+          )
+        }
+      )
+    )
+
+    let surfaceID = UUID()
+    let responses = await client.lookupPullRequests(
+      [
+        .init(
+          surfaceID: surfaceID,
+          workingDirectory: "/tmp/project/subdir",
+        ),
+      ]
+    )
+
+    #expect(
+      responses[surfaceID] == .resolved(
+        .init(
+          number: 456,
+          repositoryIdentity: .init(
+            branch: "feature",
+            repoRoot: "/tmp/project"
+          ),
+          url: URL(string: "https://github.com/supabitapp/supaterm/pull/456")!
+        )
+      )
+    )
+  }
+
+  @Test
+  func lookupPullRequestsProcessesRequestsAcrossMultipleChunks() async {
+    let recorder = GithubCommandRecorder()
+    let client = GithubClient.live(
+      batchSize: 2,
+      runner: .init(
+        resolveCommandPath: { commandName in
+          switch commandName {
+          case "git":
+            return "/usr/bin/git"
+          case "gh":
+            return "/opt/homebrew/bin/gh"
+          default:
+            return nil
+          }
+        },
+        run: { executablePath, arguments, currentDirectoryPath in
+          recorder.record(
+            executablePath: executablePath,
+            arguments: arguments,
+            currentDirectoryPath: currentDirectoryPath
+          )
+          return try chunkedGithubCommandResult(
+            executablePath: executablePath,
+            arguments: arguments
+          )
+        }
+      )
+    )
+
+    let requests = (1...5).map { index in
+      GithubPullRequestLookupRequest(
+        surfaceID: UUID(),
+        workingDirectory: "/tmp/project\(index)"
+      )
+    }
+    let responses = await client.lookupPullRequests(requests)
+
+    #expect(responses.count == 5)
+    for (index, request) in requests.enumerated() {
+      #expect(
+        responses[request.surfaceID] == .resolved(
+          .init(
+            number: index + 1,
+            repositoryIdentity: .init(
+              branch: "feature\(index + 1)",
+              repoRoot: "/tmp/project\(index + 1)"
+            ),
+            url: URL(string: "https://github.com/acme/project\(index + 1)/pull/\(index + 1)")!
+          )
+        )
+      )
+    }
+    #expect(recorder.recordedGithubRepositories() == [
+      "acme/project1",
+      "acme/project2",
+      "acme/project3",
+      "acme/project4",
+      "acme/project5",
+    ])
+  }
+}
+
+private nonisolated func githubCommandResult(
+  executablePath: String,
+  arguments: [String],
+  upstreamPullRequests: String = """
+    [
+      {
+        "headRefName": "feature",
+        "headRepositoryOwner": { "login": "acme" },
+        "number": 123,
+        "url": "https://github.com/supabitapp/supaterm/pull/123"
+      }
+    ]
+    """
+) throws -> GithubCommandResult {
+  if executablePath.hasSuffix("/git") {
+    switch arguments {
+    case ["-C", "/tmp/project/subdir", "rev-parse", "--show-toplevel"]:
+      return .init(standardError: "", standardOutput: "/tmp/project", status: 0)
+    case ["-C", "/tmp/project", "symbolic-ref", "--quiet", "--short", "HEAD"]:
+      return .init(standardError: "", standardOutput: "feature", status: 0)
+    case ["-C", "/tmp/project", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]:
+      return .init(standardError: "", standardOutput: "origin/feature", status: 0)
+    case ["-C", "/tmp/project", "remote", "-v"]:
+      return .init(
+        standardError: "",
+        standardOutput: """
+          origin	git@github.com:acme/supaterm.git (fetch)
+          origin	git@github.com:acme/supaterm.git (push)
+          upstream	git@github.com:supabitapp/supaterm.git (fetch)
+          upstream	git@github.com:supabitapp/supaterm.git (push)
+          """,
+        status: 0
+      )
+    default:
+      throw TestFailure("Unexpected git arguments: \(arguments)")
+    }
+  }
+
+  if executablePath.hasSuffix("/gh") {
+    switch arguments {
+    case [
+      "pr",
+      "list",
+      "--repo",
+      "acme/supaterm",
+      "--state",
+      "open",
+      "--head",
+      "feature",
+      "--json",
+      "headRefName,headRepositoryOwner,number,url",
+    ]:
+      return .init(standardError: "", standardOutput: "[]", status: 0)
+    case [
+      "pr",
+      "list",
+      "--repo",
+      "supabitapp/supaterm",
+      "--state",
+      "open",
+      "--head",
+      "feature",
+      "--json",
+      "headRefName,headRepositoryOwner,number,url",
+    ]:
+      return .init(standardError: "", standardOutput: upstreamPullRequests, status: 0)
+    default:
+      throw TestFailure("Unexpected gh arguments: \(arguments)")
+    }
+  }
+
+  throw TestFailure("Unexpected executable path: \(executablePath)")
+}
+
+private nonisolated func chunkedGithubCommandResult(
+  executablePath: String,
+  arguments: [String]
+) throws -> GithubCommandResult {
+  if executablePath.hasSuffix("/git") {
+    guard arguments.count >= 3 else {
+      throw TestFailure("Unexpected git arguments: \(arguments)")
+    }
+    let workingDirectory = arguments[1]
+    let index = try #require(Int(workingDirectory.replacingOccurrences(of: "/tmp/project", with: "")))
+
+    switch Array(arguments.dropFirst(2)) {
+    case ["rev-parse", "--show-toplevel"]:
+      return .init(standardError: "", standardOutput: "/tmp/project\(index)", status: 0)
+    case ["symbolic-ref", "--quiet", "--short", "HEAD"]:
+      return .init(standardError: "", standardOutput: "feature\(index)", status: 0)
+    case ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]:
+      return .init(standardError: "", standardOutput: "origin/feature\(index)", status: 0)
+    case ["remote", "-v"]:
+      return .init(
+        standardError: "",
+        standardOutput: """
+          origin	git@github.com:acme/project\(index).git (fetch)
+          origin	git@github.com:acme/project\(index).git (push)
+          """,
+        status: 0
+      )
+    default:
+      throw TestFailure("Unexpected git arguments: \(arguments)")
+    }
+  }
+
+  if executablePath.hasSuffix("/gh") {
+    guard
+      let repositoryIndex = arguments.firstIndex(of: "--repo"),
+      arguments.indices.contains(repositoryIndex + 1)
+    else {
+      throw TestFailure("Unexpected gh arguments: \(arguments)")
+    }
+    let repository = arguments[repositoryIndex + 1]
+    let index = try #require(Int(repository.replacingOccurrences(of: "acme/project", with: "")))
+    return .init(
+      standardError: "",
+      standardOutput: """
+        [
+          {
+            "headRefName": "feature\(index)",
+            "headRepositoryOwner": { "login": "acme" },
+            "number": \(index),
+            "url": "https://github.com/acme/project\(index)/pull/\(index)"
+          }
+        ]
+        """,
+      status: 0
+    )
+  }
+
+  throw TestFailure("Unexpected executable path: \(executablePath)")
+}
+
+private nonisolated enum TestFailure: Error {
+  case message(String)
+
+  init(_ message: String) {
+    self = .message(message)
+  }
+}
+
+private nonisolated final class GithubCommandRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var commands: [([String], String?)] = []
+
+  func record(
+    executablePath: String,
+    arguments: [String],
+    currentDirectoryPath: String?
+  ) {
+    guard executablePath.hasSuffix("/gh") else { return }
+    lock.lock()
+    commands.append((arguments, currentDirectoryPath))
+    lock.unlock()
+  }
+
+  func recordedGithubRepositories() -> [String] {
+    lock.lock()
+    let commands = commands
+    lock.unlock()
+    return commands.compactMap { arguments, _ in
+      guard let repoIndex = arguments.firstIndex(of: "--repo"), arguments.indices.contains(repoIndex + 1) else {
+        return nil
+      }
+      return arguments[repoIndex + 1]
+    }
+  }
+}

--- a/apps/mac/supatermTests/GithubPullRequestRefreshCoordinatorTests.swift
+++ b/apps/mac/supatermTests/GithubPullRequestRefreshCoordinatorTests.swift
@@ -1,0 +1,270 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supaterm
+
+@MainActor
+struct GithubPullRequestRefreshCoordinatorTests {
+  @Test
+  func replaceRequestsRefreshesImmediatelyWhenWindowIsVisible() async {
+    let recorder = GithubLookupBatchRecorder()
+    var resolvedBatches: [[UUID: GithubPullRequestSnapshot?]] = []
+    let request = GithubPullRequestLookupRequest(
+      surfaceID: UUID(),
+      workingDirectory: "/tmp/project"
+    )
+    let coordinator = GithubPullRequestRefreshCoordinator(
+      client: .init(
+        diagnostics: {
+          .init(
+            authenticationStatus: .authenticated("ok"),
+            ghStatus: .available("ok"),
+            gitStatus: .available("ok")
+          )
+        },
+        lookupPullRequests: { requests in
+          await recorder.record(requests)
+          return Dictionary(
+            uniqueKeysWithValues: requests.map {
+              (
+                $0.surfaceID,
+                .resolved(
+                  .init(
+                    number: 1,
+                    repositoryIdentity: .init(
+                      branch: "feature",
+                      repoRoot: "/tmp/project"
+                    ),
+                    url: URL(string: "https://github.com/supabitapp/supaterm/pull/1")!
+                  )
+                )
+              )
+            }
+          )
+        }
+      ),
+      clock: TestClock()
+    ) { resolved in
+      resolvedBatches.append(resolved)
+    }
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: true, isVisible: true))
+    coordinator.replaceRequests([request.surfaceID: request])
+    await flushCoordinatorEffects()
+
+    #expect(await recorder.recordedBatchSurfaceIDs() == [[request.surfaceID]])
+    #expect(resolvedBatches.count == 1)
+    let snapshot = resolvedBatches[0][request.surfaceID] ?? nil
+    #expect(snapshot?.number == 1)
+  }
+
+  @Test
+  func pollingUsesThirtySecondsForKeyWindowsAndSixtySecondsForVisibleNonKeyWindows() async {
+    let clock = TestClock()
+    let recorder = GithubLookupBatchRecorder()
+    let request = GithubPullRequestLookupRequest(
+      surfaceID: UUID(),
+      workingDirectory: "/tmp/project"
+    )
+    let coordinator = GithubPullRequestRefreshCoordinator(
+      client: .init(
+        diagnostics: {
+          .init(
+            authenticationStatus: .authenticated("ok"),
+            ghStatus: .available("ok"),
+            gitStatus: .available("ok")
+          )
+        },
+        lookupPullRequests: { requests in
+          await recorder.record(requests)
+          return Dictionary(
+            uniqueKeysWithValues: requests.map { ($0.surfaceID, .resolved(nil)) }
+          )
+        }
+      ),
+      clock: clock
+    ) { _ in }
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: true, isVisible: true))
+    coordinator.replaceRequests([request.surfaceID: request])
+    await flushCoordinatorEffects()
+
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 1)
+
+    await clock.advance(by: .seconds(29))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 1)
+
+    await clock.advance(by: .seconds(1))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 2)
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: false, isVisible: true))
+    await flushCoordinatorEffects()
+
+    await clock.advance(by: .seconds(59))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 2)
+
+    await clock.advance(by: .seconds(1))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 3)
+  }
+
+  @Test
+  func hiddenWindowsPausePollingUntilVisibleAgain() async {
+    let clock = TestClock()
+    let recorder = GithubLookupBatchRecorder()
+    let request = GithubPullRequestLookupRequest(
+      surfaceID: UUID(),
+      workingDirectory: "/tmp/project"
+    )
+    let coordinator = GithubPullRequestRefreshCoordinator(
+      client: .init(
+        diagnostics: {
+          .init(
+            authenticationStatus: .authenticated("ok"),
+            ghStatus: .available("ok"),
+            gitStatus: .available("ok")
+          )
+        },
+        lookupPullRequests: { requests in
+          await recorder.record(requests)
+          return Dictionary(
+            uniqueKeysWithValues: requests.map { ($0.surfaceID, .resolved(nil)) }
+          )
+        }
+      ),
+      clock: clock
+    ) { _ in }
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: true, isVisible: true))
+    coordinator.replaceRequests([request.surfaceID: request])
+    await flushCoordinatorEffects()
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: false, isVisible: false))
+    await flushCoordinatorEffects()
+
+    await clock.advance(by: .seconds(120))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 1)
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: false, isVisible: true))
+    await flushCoordinatorEffects()
+
+    await clock.advance(by: .seconds(59))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 1)
+
+    await clock.advance(by: .seconds(1))
+    await flushCoordinatorEffects()
+    #expect(await recorder.recordedBatchSurfaceIDs().count == 2)
+  }
+
+  @Test
+  func dirtyRequestsCoalesceIntoOneFollowUpRefreshAfterAnInFlightLookupFinishes() async {
+    let controller = DelayedGithubLookupController()
+    let request1 = GithubPullRequestLookupRequest(
+      surfaceID: UUID(),
+      workingDirectory: "/tmp/project1"
+    )
+    let request2 = GithubPullRequestLookupRequest(
+      surfaceID: UUID(),
+      workingDirectory: "/tmp/project2"
+    )
+    let coordinator = GithubPullRequestRefreshCoordinator(
+      client: .init(
+        diagnostics: {
+          .init(
+            authenticationStatus: .authenticated("ok"),
+            ghStatus: .available("ok"),
+            gitStatus: .available("ok")
+          )
+        },
+        lookupPullRequests: { requests in
+          await controller.lookup(requests)
+        }
+      ),
+      clock: TestClock()
+    ) { _ in }
+
+    coordinator.updateWindowActivity(.init(isKeyWindow: true, isVisible: true))
+    coordinator.replaceRequests([request1.surfaceID: request1])
+    await flushCoordinatorEffects()
+    #expect(await controller.recordedBatchSurfaceIDs().map(Set.init) == [Set([request1.surfaceID])])
+
+    coordinator.markDirty(surfaceIDs: [request1.surfaceID])
+    coordinator.replaceRequests([
+      request1.surfaceID: request1,
+      request2.surfaceID: request2,
+    ])
+    await flushCoordinatorEffects()
+    #expect(await controller.recordedBatchSurfaceIDs().map(Set.init) == [Set([request1.surfaceID])])
+
+    await controller.finishFirstLookup()
+    await flushCoordinatorEffects()
+    #expect(
+      await controller.recordedBatchSurfaceIDs().map(Set.init) == [
+        Set([request1.surfaceID]),
+        Set([request1.surfaceID, request2.surfaceID]),
+      ]
+    )
+  }
+}
+
+private func flushCoordinatorEffects() async {
+  for _ in 0..<6 {
+    await Task.yield()
+  }
+}
+
+private actor GithubLookupBatchRecorder {
+  private var batches: [[UUID]] = []
+
+  func record(_ requests: [GithubPullRequestLookupRequest]) {
+    batches.append(requests.map(\.surfaceID))
+  }
+
+  func recordedBatchSurfaceIDs() -> [[UUID]] {
+    batches
+  }
+}
+
+private actor DelayedGithubLookupController {
+  private var batches: [[UUID]] = []
+  private var firstLookupContinuation: CheckedContinuation<[UUID: GithubPullRequestLookupResponse], Never>?
+  private var firstLookupRequests: [GithubPullRequestLookupRequest]?
+
+  func finishFirstLookup() {
+    guard let firstLookupContinuation, let firstLookupRequests else { return }
+    self.firstLookupContinuation = nil
+    self.firstLookupRequests = nil
+    firstLookupContinuation.resume(
+      returning: Dictionary(
+        uniqueKeysWithValues: firstLookupRequests.map { ($0.surfaceID, .resolved(nil)) }
+      )
+    )
+  }
+
+  func lookup(
+    _ requests: [GithubPullRequestLookupRequest]
+  ) async -> [UUID: GithubPullRequestLookupResponse] {
+    batches.append(requests.map(\.surfaceID))
+
+    if firstLookupContinuation == nil {
+      firstLookupRequests = requests
+      return await withCheckedContinuation { continuation in
+        firstLookupContinuation = continuation
+      }
+    }
+
+    return Dictionary(
+      uniqueKeysWithValues: requests.map { ($0.surfaceID, .resolved(nil)) }
+    )
+  }
+
+  func recordedBatchSurfaceIDs() -> [[UUID]] {
+    batches
+  }
+}

--- a/apps/mac/supatermTests/SettingsFeatureTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureTests.swift
@@ -19,7 +19,7 @@ struct SettingsFeatureTests {
   func tabOrderEndsWithAbout() {
     #expect(
       SettingsFeature.Tab.allCases
-        == [.general, .terminal, .notifications, .codingAgents, .about]
+        == [.general, .terminal, .notifications, .github, .codingAgents, .about]
     )
   }
 
@@ -34,6 +34,7 @@ struct SettingsFeatureTests {
           appearanceMode: .dark,
           analyticsEnabled: false,
           crashReportsEnabled: true,
+          githubPullRequestsEnabled: false,
           glowingPaneRingEnabled: false,
           restoreTerminalLayoutEnabled: false,
           systemNotificationsEnabled: true,
@@ -46,6 +47,7 @@ struct SettingsFeatureTests {
       } withDependencies: {
         $0.claudeSettingsClient.hasSupatermHooks = { false }
         $0.codexSettingsClient.hasSupatermHooks = { false }
+        $0.githubClient.diagnostics = { githubDiagnostics() }
         $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
         $0.piSettingsClient.hasSupatermIntegration = { false }
       }
@@ -55,6 +57,7 @@ struct SettingsFeatureTests {
         $0.appearanceMode = .dark
         $0.analyticsEnabled = false
         $0.crashReportsEnabled = true
+        $0.github.pullRequestsEnabled = false
         $0.glowingPaneRingEnabled = false
         $0.restoreTerminalLayoutEnabled = false
         $0.systemNotificationsEnabled = true
@@ -62,6 +65,9 @@ struct SettingsFeatureTests {
       }
       await store.receive(.terminalSettingsLoadRequested, timeout: 0) {
         $0.terminal.isLoading = true
+      }
+      await store.receive(.githubDiagnosticsRefreshRequested, timeout: 0) {
+        $0.github.isLoadingDiagnostics = true
       }
       await store.receive(.agentIntegrationStatusRefreshRequested(.claude), timeout: 0) {
         $0.claudeIntegration.isPending = true
@@ -74,6 +80,10 @@ struct SettingsFeatureTests {
       }
       await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
         $0.terminal = terminalSettingsState()
+      }
+      await store.receive(.githubDiagnosticsResponse(githubDiagnostics()), timeout: 0) {
+        $0.github.diagnostics = githubDiagnostics()
+        $0.github.isLoadingDiagnostics = false
       }
       await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
         $0.claudeIntegration.isPending = false
@@ -96,6 +106,7 @@ struct SettingsFeatureTests {
     } withDependencies: {
       $0.claudeSettingsClient.hasSupatermHooks = { false }
       $0.codexSettingsClient.hasSupatermHooks = { false }
+      $0.githubClient.diagnostics = { githubDiagnostics() }
       $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
       $0.piSettingsClient.hasSupatermIntegration = { false }
       $0.updateClient.observe = { stream }
@@ -106,6 +117,9 @@ struct SettingsFeatureTests {
     await store.receive(\.settingsLoaded)
     await store.receive(.terminalSettingsLoadRequested, timeout: 0) {
       $0.terminal.isLoading = true
+    }
+    await store.receive(.githubDiagnosticsRefreshRequested, timeout: 0) {
+      $0.github.isLoadingDiagnostics = true
     }
     await store.receive(.agentIntegrationStatusRefreshRequested(.claude), timeout: 0) {
       $0.claudeIntegration.isPending = true
@@ -118,6 +132,10 @@ struct SettingsFeatureTests {
     }
     await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
       $0.terminal = terminalSettingsState()
+    }
+    await store.receive(.githubDiagnosticsResponse(githubDiagnostics()), timeout: 0) {
+      $0.github.diagnostics = githubDiagnostics()
+      $0.github.isLoadingDiagnostics = false
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
       $0.claudeIntegration.isPending = false
@@ -151,6 +169,8 @@ struct SettingsFeatureTests {
   func tabSelectionUpdatesState() async {
     let store = TestStore(initialState: SettingsFeature.State()) {
       SettingsFeature()
+    } withDependencies: {
+      $0.githubClient.diagnostics = { githubDiagnostics() }
     }
 
     await store.send(.tabSelected(.terminal)) {
@@ -159,6 +179,17 @@ struct SettingsFeatureTests {
 
     await store.send(.tabSelected(.codingAgents)) {
       $0.selectedTab = .codingAgents
+    }
+
+    await store.send(.tabSelected(.github)) {
+      $0.selectedTab = .github
+    }
+    await store.receive(.githubDiagnosticsRefreshRequested, timeout: 0) {
+      $0.github.isLoadingDiagnostics = true
+    }
+    await store.receive(.githubDiagnosticsResponse(githubDiagnostics()), timeout: 0) {
+      $0.github.diagnostics = githubDiagnostics()
+      $0.github.isLoadingDiagnostics = false
     }
 
     await store.send(.tabSelected(.notifications)) {
@@ -208,6 +239,24 @@ struct SettingsFeatureTests {
       @Shared(.supatermSettings) var supatermSettings = .default
       #expect(!supatermSettings.analyticsEnabled)
       #expect(!supatermSettings.crashReportsEnabled)
+    }
+  }
+
+  @Test
+  func githubPullRequestSettingPersistsPrefs() async throws {
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let store = TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+
+      await store.send(.githubPullRequestsEnabledChanged(false)) {
+        $0.github.pullRequestsEnabled = false
+      }
+
+      @Shared(.supatermSettings) var supatermSettings = .default
+      #expect(!supatermSettings.githubPullRequestsEnabled)
     }
   }
 
@@ -502,6 +551,7 @@ struct SettingsFeatureTests {
     } withDependencies: {
       $0.claudeSettingsClient.hasSupatermHooks = { true }
       $0.codexSettingsClient.hasSupatermHooks = { false }
+      $0.githubClient.diagnostics = { githubDiagnostics() }
       $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
       $0.piSettingsClient.hasSupatermIntegration = { true }
     }
@@ -510,6 +560,9 @@ struct SettingsFeatureTests {
     await store.receive(\.settingsLoaded)
     await store.receive(.terminalSettingsLoadRequested, timeout: 0) {
       $0.terminal.isLoading = true
+    }
+    await store.receive(.githubDiagnosticsRefreshRequested, timeout: 0) {
+      $0.github.isLoadingDiagnostics = true
     }
     await store.receive(.agentIntegrationStatusRefreshRequested(.claude), timeout: 0) {
       $0.claudeIntegration.isPending = true
@@ -522,6 +575,10 @@ struct SettingsFeatureTests {
     }
     await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
       $0.terminal = terminalSettingsState()
+    }
+    await store.receive(.githubDiagnosticsResponse(githubDiagnostics()), timeout: 0) {
+      $0.github.diagnostics = githubDiagnostics()
+      $0.github.isLoadingDiagnostics = false
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(true)), timeout: 0) {
       $0.claudeIntegration.confirmedEnabled = true
@@ -832,6 +889,14 @@ private nonisolated func terminalSettingsSnapshot() -> GhosttyTerminalSettingsSn
     fontSize: 15,
     lightTheme: "Zenbones Light",
     warningMessage: nil
+  )
+}
+
+private nonisolated func githubDiagnostics() -> GithubDiagnostics {
+  .init(
+    authenticationStatus: .authenticated("Authenticated with GitHub CLI."),
+    ghStatus: .available("Found at /opt/homebrew/bin/gh"),
+    gitStatus: .available("Found at /usr/bin/git")
   )
 }
 

--- a/apps/mac/supatermTests/SupatermSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsTests.swift
@@ -21,6 +21,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .system)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubPullRequestsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
@@ -44,6 +45,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubPullRequestsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
@@ -63,6 +65,7 @@ struct SupatermSettingsTests {
         "analyticsEnabled",
         "appearanceMode",
         "crashReportsEnabled",
+        "githubPullRequestsEnabled",
         "glowingPaneRingEnabled",
         "restoreTerminalLayoutEnabled",
         "systemNotificationsEnabled",
@@ -94,6 +97,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubPullRequestsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)

--- a/apps/mac/supatermTests/TerminalSidebarChromeViewTests.swift
+++ b/apps/mac/supatermTests/TerminalSidebarChromeViewTests.swift
@@ -136,6 +136,23 @@ struct TerminalSidebarChromeViewTests {
   }
 
   @Test
+  func githubPullRequestPresentationFormatsThePullRequestNumber() {
+    let presentation = GithubPullRequestPresentation(
+      snapshot: .init(
+        number: 123,
+        repositoryIdentity: .init(
+          branch: "feature",
+          repoRoot: "/tmp/project"
+        ),
+        url: URL(string: "https://github.com/supabitapp/supaterm/pull/123")!
+      )
+    )
+
+    #expect(presentation.label == "PR #123")
+    #expect(presentation.url.absoluteString == "https://github.com/supabitapp/supaterm/pull/123")
+  }
+
+  @Test
   func runningCodexDetailTakesSecondaryLinePrecedenceOverNotificationPreview() {
     #expect(
       TerminalSidebarTabSummaryView.secondaryContent(

--- a/apps/supaterm.com/public/data/supaterm-settings.schema.json
+++ b/apps/supaterm.com/public/data/supaterm-settings.schema.json
@@ -26,6 +26,11 @@
       "description": "Allow crash reports.",
       "type": "boolean"
     },
+    "githubPullRequestsEnabled": {
+      "default": true,
+      "description": "Show GitHub pull request surfaces in the terminal UI.",
+      "type": "boolean"
+    },
     "glowingPaneRingEnabled": {
       "default": true,
       "description": "Show a glowing ring around panes with unread attention.",


### PR DESCRIPTION
## Summary
- add a shared GitHub client/coordinator pipeline that discovers git/gh, resolves remotes, looks up PRs, and stores PR snapshots per terminal surface
- add GitHub settings and diagnostics, then render shared PR presentation in the sidebar row and selected pane topbar
- add focused tests for settings persistence, PR lookup behavior, coordinator cadence/coalescing, and sidebar presentation

## Testing
- make -C apps/mac lint
- xcodebuild test -workspace apps/mac/supaterm.xcworkspace -scheme supaterm -destination "platform=macOS" -parallel-testing-enabled NO -only-testing:supatermTests/SettingsFeatureTests -only-testing:supatermTests/SupatermSettingsTests -only-testing:supatermTests/SupatermSettingsSchemaTests -only-testing:supatermTests/TerminalSidebarChromeViewTests -only-testing:supatermTests/GithubClientTests -only-testing:supatermTests/GithubPullRequestRefreshCoordinatorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- push hook validation passed, including web checks and the full mac test suite
