### PR TITLE
Make Codex status transcript-driven

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermCodexHookSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermCodexHookSettings.swift
@@ -29,8 +29,6 @@ public enum SupatermCodexHookSettings {
 
   private struct Settings: Encodable {
     let hooks: [String: [HookGroup]] = [
-      "PostToolUse": [.init(hooks: [.init(command: command, timeout: 5)])],
-      "PreToolUse": [.init(hooks: [.init(command: command, timeout: 5)])],
       "SessionStart": [.init(matcher: "startup|resume", hooks: [.init(command: command, timeout: 10)])],
       "Stop": [.init(hooks: [.init(command: command, timeout: 10)])],
       "UserPromptSubmit": [.init(hooks: [.init(command: command, timeout: 10)])],

--- a/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
+++ b/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
@@ -27,17 +27,23 @@ enum CodexTranscriptTurnStatus: Equatable {
 struct CodexTranscriptUpdate: Equatable {
   var status: CodexTranscriptTurnStatus?
   var detail: String?
+  var messages: [String]
+  var replacesMessages: Bool
 
   init(
     status: CodexTranscriptTurnStatus? = nil,
-    detail: String? = nil
+    detail: String? = nil,
+    messages: [String] = [],
+    replacesMessages: Bool = false
   ) {
     self.status = status
     self.detail = detail
+    self.messages = messages
+    self.replacesMessages = replacesMessages
   }
 
   var hasChanges: Bool {
-    status != nil || detail != nil
+    status != nil || detail != nil || !messages.isEmpty
   }
 
   mutating func absorb(_ update: Self) {
@@ -46,6 +52,12 @@ struct CodexTranscriptUpdate: Equatable {
     }
     if let detail = update.detail {
       self.detail = detail
+    }
+    if update.replacesMessages {
+      messages = update.messages
+      replacesMessages = true
+    } else if !update.messages.isEmpty {
+      messages.append(contentsOf: update.messages)
     }
   }
 }
@@ -141,13 +153,22 @@ enum CodexTranscriptMonitor {
     case "task_started", "turn_started":
       return .init(status: .started(string(in: eventPayload, key: "turn_id")))
     case "task_complete", "turn_complete":
-      return .init(status: .completed(string(in: eventPayload, key: "turn_id")))
+      let messages = normalizedMessageList(string(in: eventPayload, key: "last_agent_message"))
+      return .init(
+        status: .completed(string(in: eventPayload, key: "turn_id")),
+        messages: messages,
+        replacesMessages: !messages.isEmpty
+      )
     case "turn_aborted":
       return .init(status: .aborted(string(in: eventPayload, key: "turn_id")))
     case "agent_message":
       let phase = string(in: eventPayload, key: "phase") ?? string(in: payload, key: "phase")
-      guard phase != "final_answer" else { return nil }
-      return detailUpdate(string(in: eventPayload, key: "message") ?? string(in: payload, key: "message"))
+      if phase == "final_answer" {
+        return finalMessageUpdate(
+          string(in: eventPayload, key: "message") ?? string(in: payload, key: "message")
+        )
+      }
+      return liveMessageUpdate(string(in: eventPayload, key: "message") ?? string(in: payload, key: "message"))
     default:
       return nil
     }
@@ -165,26 +186,55 @@ enum CodexTranscriptMonitor {
 
   private static func messageUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
     guard string(in: payload, key: "role") == "assistant" else { return nil }
-    guard string(in: payload, key: "phase") != "final_answer" else { return nil }
     let content = array(in: payload, key: "content")
-    let text = normalizedDetail(
+    let text = normalizedMessage(
       content?
         .compactMap { dictionaryValue in
           string(in: dictionaryValue, key: "text")
         }
         .joined(separator: " ")
     )
-    return detailUpdate(text)
+    if string(in: payload, key: "phase") == "final_answer" {
+      return finalMessageUpdate(text)
+    }
+    return liveMessageUpdate(text)
   }
 
-  private static func detailUpdate(
-    _ detail: String?
+  private static func liveMessageUpdate(
+    _ message: String?
   ) -> CodexTranscriptUpdate? {
-    guard let detail = normalizedDetail(detail) else { return nil }
-    return .init(detail: detail)
+    guard
+      let message = normalizedMessage(message),
+      let detail = normalizedDetail(message)
+    else {
+      return nil
+    }
+    return .init(detail: detail, messages: [message])
+  }
+
+  private static func finalMessageUpdate(
+    _ message: String?
+  ) -> CodexTranscriptUpdate? {
+    let messages = normalizedMessageList(message)
+    guard !messages.isEmpty else { return nil }
+    return .init(messages: messages, replacesMessages: true)
+  }
+
+  private static func normalizedMessageList(
+    _ message: String?
+  ) -> [String] {
+    normalizedMessage(message).map { [$0] } ?? []
   }
 
   private static func normalizedDetail(_ text: String?) -> String? {
+    guard let normalized = normalizedMessage(text) else { return nil }
+    if normalized.count <= 160 {
+      return normalized
+    }
+    return String(normalized.prefix(157)) + "..."
+  }
+
+  private static func normalizedMessage(_ text: String?) -> String? {
     guard let text else { return nil }
     let normalized =
       text
@@ -192,10 +242,7 @@ enum CodexTranscriptMonitor {
       .filter { !$0.isEmpty }
       .joined(separator: " ")
     guard !normalized.isEmpty else { return nil }
-    if normalized.count <= 160 {
-      return normalized
-    }
-    return String(normalized.prefix(157)) + "..."
+    return normalized
   }
 
   private static func dictionary(

--- a/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
+++ b/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
@@ -24,29 +24,16 @@ enum CodexTranscriptTurnStatus: Equatable {
   }
 }
 
-enum CodexTranscriptDetailPriority: Int {
-  case tool
-  case reasoning
-  case message
-}
-
 struct CodexTranscriptUpdate: Equatable {
   var status: CodexTranscriptTurnStatus?
   var detail: String?
-  var detailPriority: CodexTranscriptDetailPriority?
 
   init(
     status: CodexTranscriptTurnStatus? = nil,
-    detail: String? = nil,
-    detailPriority: CodexTranscriptDetailPriority? = nil
+    detail: String? = nil
   ) {
     self.status = status
     self.detail = detail
-    self.detailPriority = detailPriority
-  }
-
-  static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.status == rhs.status && lhs.detail == rhs.detail
   }
 
   var hasChanges: Bool {
@@ -58,20 +45,13 @@ struct CodexTranscriptUpdate: Equatable {
       self.status = status
     }
     if let detail = update.detail {
-      let currentPriority = detailPriority ?? .tool
-      let incomingPriority = update.detailPriority ?? .tool
-      guard self.detail == nil || incomingPriority.rawValue >= currentPriority.rawValue else {
-        return
-      }
       self.detail = detail
-      self.detailPriority = incomingPriority
     }
   }
 }
 
 struct CodexTranscriptCursor {
   var offset: UInt64
-  var detailPriority: CodexTranscriptDetailPriority?
 }
 
 enum CodexTranscriptMonitor {
@@ -80,14 +60,12 @@ enum CodexTranscriptMonitor {
   ) -> (CodexTranscriptCursor, CodexTranscriptUpdate?)? {
     guard let data = read(path: path, from: 0) else { return nil }
     let (consumedBytes, latestUpdate) = parse(data)
-    var cursor = CodexTranscriptCursor(offset: UInt64(consumedBytes), detailPriority: nil)
-    guard let latestUpdate, let update = mergedUpdate(latestUpdate, into: &cursor) else {
+    let cursor = CodexTranscriptCursor(offset: UInt64(consumedBytes))
+    guard let latestUpdate else { return (cursor, nil) }
+    if latestUpdate.status?.isFinal == true {
       return (cursor, nil)
     }
-    if update.status?.isFinal == true {
-      return (cursor, nil)
-    }
-    return (cursor, update)
+    return (cursor, latestUpdate)
   }
 
   static func advance(
@@ -108,13 +86,7 @@ enum CodexTranscriptMonitor {
     let (consumedBytes, latestUpdate) = parse(data)
     var updatedCursor = cursor
     updatedCursor.offset += UInt64(consumedBytes)
-    let filteredUpdate: CodexTranscriptUpdate?
-    if let latestUpdate {
-      filteredUpdate = mergedUpdate(latestUpdate, into: &updatedCursor)
-    } else {
-      filteredUpdate = nil
-    }
-    return (updatedCursor, filteredUpdate)
+    return (updatedCursor, latestUpdate)
   }
 
   private static func read(path: String, from offset: UInt64) -> Data? {
@@ -142,32 +114,6 @@ enum CodexTranscriptMonitor {
       latestUpdate.absorb(update)
     }
     return (completeData.count, latestUpdate.hasChanges ? latestUpdate : nil)
-  }
-
-  private static func mergedUpdate(
-    _ update: CodexTranscriptUpdate,
-    into cursor: inout CodexTranscriptCursor
-  ) -> CodexTranscriptUpdate? {
-    var update = update
-
-    if case .started = update.status {
-      cursor.detailPriority = nil
-    }
-
-    if let detail = update.detail {
-      let incomingPriority = update.detailPriority ?? .tool
-      if let currentPriority = cursor.detailPriority, incomingPriority.rawValue < currentPriority.rawValue {
-        update.detail = nil
-      } else if !detail.isEmpty {
-        cursor.detailPriority = incomingPriority
-      }
-    }
-
-    if update.status?.isFinal == true {
-      cursor.detailPriority = nil
-    }
-
-    return update.hasChanges ? update : nil
   }
 
   private static func update(in line: Data) -> CodexTranscriptUpdate? {
@@ -198,18 +144,10 @@ enum CodexTranscriptMonitor {
       return .init(status: .completed(string(in: eventPayload, key: "turn_id")))
     case "turn_aborted":
       return .init(status: .aborted(string(in: eventPayload, key: "turn_id")))
-    case "agent_reasoning":
-      return thinkingDetailUpdate(
-        string(in: eventPayload, key: "text") ?? string(in: payload, key: "text"),
-        priority: .reasoning
-      )
     case "agent_message":
       let phase = string(in: eventPayload, key: "phase") ?? string(in: payload, key: "phase")
       guard phase != "final_answer" else { return nil }
-      return plainDetailUpdate(
-        string(in: eventPayload, key: "message") ?? string(in: payload, key: "message"),
-        priority: .message
-      )
+      return detailUpdate(string(in: eventPayload, key: "message") ?? string(in: payload, key: "message"))
     default:
       return nil
     }
@@ -220,18 +158,6 @@ enum CodexTranscriptMonitor {
     switch itemType {
     case "message":
       return messageUpdate(payload)
-    case "reasoning":
-      return reasoningUpdate(payload)
-    case "local_shell_call":
-      return localShellUpdate(payload)
-    case "function_call":
-      return functionCallUpdate(payload)
-    case "custom_tool_call":
-      return customToolCallUpdate(payload)
-    case "tool_search_call":
-      return toolSearchUpdate(payload)
-    case "web_search_call":
-      return webSearchUpdate(payload)
     default:
       return nil
     }
@@ -248,136 +174,14 @@ enum CodexTranscriptMonitor {
         }
         .joined(separator: " ")
     )
-    guard let text else { return nil }
-    return plainDetailUpdate(text, priority: .message)
+    return detailUpdate(text)
   }
 
-  private static func reasoningUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    let summary = array(in: payload, key: "summary")?.compactMap { item in
-      string(in: item, key: "text")
-    }
-    let content = array(in: payload, key: "content")?.compactMap { item in
-      string(in: item, key: "text")
-    }
-    return thinkingDetailUpdate(
-      summary?.first ?? content?.first,
-      priority: .reasoning
-    )
-  }
-
-  private static func localShellUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    guard
-      let action = dictionary(in: payload, key: "action"),
-      string(in: action, key: "type") == "exec"
-    else {
-      return plainDetailUpdate("Bash")
-    }
-    return labeledDetailUpdate(
-      prefix: "Bash",
-      text: commandText(from: arrayOfStrings(in: action, key: "command"))
-    ) ?? plainDetailUpdate("Bash")
-  }
-
-  private static func functionCallUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    guard let name = normalizedDetail(string(in: payload, key: "name")) else {
-      return plainDetailUpdate("Working...")
-    }
-    if name == "exec_command" {
-      return plainDetailUpdate(execCommandDetail(arguments: string(in: payload, key: "arguments")) ?? "Working...")
-    }
-    return plainDetailUpdate(executingDetail(name: name) ?? "Working...")
-  }
-
-  private static func customToolCallUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    guard let name = normalizedDetail(string(in: payload, key: "name")) else {
-      return plainDetailUpdate("Working...")
-    }
-    return plainDetailUpdate(executingDetail(name: name) ?? "Working...")
-  }
-
-  private static func toolSearchUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    let arguments = dictionary(in: payload, key: "arguments")
-    let query = string(in: arguments, key: "query")
-    if let query {
-      return labeledDetailUpdate(prefix: "Search", text: query)
-    }
-    if let execution = string(in: payload, key: "execution"), execution != "search" {
-      return labeledDetailUpdate(prefix: "Search", text: execution)
-    }
-    return plainDetailUpdate("Search")
-  }
-
-  private static func webSearchUpdate(_ payload: [String: Any]) -> CodexTranscriptUpdate? {
-    guard let action = dictionary(in: payload, key: "action") else {
-      return plainDetailUpdate("Web")
-    }
-    let detail: String?
-    switch string(in: action, key: "type") {
-    case "search":
-      detail = string(in: action, key: "query") ?? arrayOfStrings(in: action, key: "queries")?.first
-    case "open_page":
-      detail = string(in: action, key: "url")
-    case "find_in_page":
-      let pattern = string(in: action, key: "pattern")
-      let url = string(in: action, key: "url")
-      detail =
-        if let pattern, let url {
-          "'\(pattern)' in \(url)"
-        } else {
-          pattern ?? url
-        }
-    default:
-      detail = nil
-    }
-    return labeledDetailUpdate(prefix: "Web", text: detail) ?? plainDetailUpdate("Web")
-  }
-
-  private static func execCommandDetail(arguments: String?) -> String? {
-    guard let argumentsObject = object(fromJSONString: arguments) else { return nil }
-    return normalizedDetail(string(in: argumentsObject, key: "cmd"))
-  }
-
-  private static func executingDetail(name: String?) -> String? {
-    guard let name = normalizedDetail(name) else { return nil }
-    return "Executing \(name)"
-  }
-
-  private static func labeledDetailUpdate(
-    prefix: String,
-    text: String?,
-    priority: CodexTranscriptDetailPriority = .tool
-  ) -> CodexTranscriptUpdate? {
-    guard let detail = labeledDetail(prefix: prefix, text: text) else { return nil }
-    return .init(detail: detail, detailPriority: priority)
-  }
-
-  private static func plainDetailUpdate(
-    _ detail: String?,
-    priority: CodexTranscriptDetailPriority = .tool
+  private static func detailUpdate(
+    _ detail: String?
   ) -> CodexTranscriptUpdate? {
     guard let detail = normalizedDetail(detail) else { return nil }
-    return .init(detail: detail, detailPriority: priority)
-  }
-
-  private static func thinkingDetailUpdate(
-    _ text: String?,
-    priority: CodexTranscriptDetailPriority = .reasoning
-  ) -> CodexTranscriptUpdate? {
-    _ = text
-    return .init(detail: "Thinking...", detailPriority: priority)
-  }
-
-  private static func labeledDetail(
-    prefix: String,
-    text: String?
-  ) -> String? {
-    guard let text = normalizedDetail(text) else { return nil }
-    return "\(prefix) · \(text)"
-  }
-
-  private static func commandText(from command: [String]?) -> String? {
-    guard let command, !command.isEmpty else { return nil }
-    return normalizedDetail(command.joined(separator: " "))
+    return .init(detail: detail)
   }
 
   private static func normalizedDetail(_ text: String?) -> String? {
@@ -394,11 +198,6 @@ enum CodexTranscriptMonitor {
     return String(normalized.prefix(157)) + "..."
   }
 
-  private static func object(fromJSONString string: String?) -> [String: Any]? {
-    guard let string, let data = string.data(using: .utf8) else { return nil }
-    return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-  }
-
   private static func dictionary(
     in object: [String: Any]?,
     key: String
@@ -411,13 +210,6 @@ enum CodexTranscriptMonitor {
     key: String
   ) -> [[String: Any]]? {
     (object?[key] as? [Any])?.compactMap { $0 as? [String: Any] }
-  }
-
-  private static func arrayOfStrings(
-    in object: [String: Any]?,
-    key: String
-  ) -> [String]? {
-    (object?[key] as? [Any])?.compactMap { $0 as? String }
   }
 
   private static func string(

--- a/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
+++ b/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
@@ -5,6 +5,15 @@ enum CodexTranscriptTurnStatus: Equatable {
   case completed(String?)
   case aborted(String?)
 
+  var startsNewTurn: Bool {
+    switch self {
+    case .started:
+      true
+    case .completed, .aborted:
+      false
+    }
+  }
+
   var isFinal: Bool {
     switch self {
     case .started:
@@ -126,9 +135,11 @@ enum CodexTranscriptMonitor {
     let completeData = data.prefix(through: newlineIndex)
     var latestUpdate = CodexTranscriptUpdate()
     for line in completeData.split(separator: 0x0A) {
-      if let update = update(in: Data(line)) {
-        latestUpdate.absorb(update)
+      guard let update = update(in: Data(line)) else { continue }
+      if update.status?.startsNewTurn == true {
+        latestUpdate = CodexTranscriptUpdate()
       }
+      latestUpdate.absorb(update)
     }
     return (completeData.count, latestUpdate.hasChanges ? latestUpdate : nil)
   }

--- a/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
+++ b/apps/mac/supaterm/App/CodexTranscriptMonitor.swift
@@ -66,10 +66,19 @@ struct CodexTranscriptCursor {
 }
 
 enum CodexTranscriptMonitor {
-  static func makeCursor(at path: String) -> CodexTranscriptCursor? {
+  static func start(
+    at path: String
+  ) -> (CodexTranscriptCursor, CodexTranscriptUpdate?)? {
     guard let data = read(path: path, from: 0) else { return nil }
-    let (consumedBytes, _) = parse(data)
-    return .init(offset: UInt64(consumedBytes), detailPriority: nil)
+    let (consumedBytes, latestUpdate) = parse(data)
+    var cursor = CodexTranscriptCursor(offset: UInt64(consumedBytes), detailPriority: nil)
+    guard let latestUpdate, let update = mergedUpdate(latestUpdate, into: &cursor) else {
+      return (cursor, nil)
+    }
+    if update.status?.isFinal == true {
+      return (cursor, nil)
+    }
+    return (cursor, update)
   }
 
   static func advance(
@@ -84,8 +93,7 @@ enum CodexTranscriptMonitor {
       return nil
     }
     if UInt64(fileSize) < cursor.offset {
-      guard let resetCursor = makeCursor(at: path) else { return nil }
-      return (resetCursor, nil)
+      return start(at: path)
     }
     guard let data = read(path: path, from: cursor.offset) else { return nil }
     let (consumedBytes, latestUpdate) = parse(data)

--- a/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
+++ b/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
@@ -116,25 +116,22 @@ final class TerminalAgentSessionStore {
     sessionID: String,
     context: SupatermCLIContext?
   ) -> Bool {
-    let agent: SupatermAgentKind = .codex
-    let key = SessionKey(agent: agent, sessionID: sessionID)
+    let key = SessionKey(agent: .codex, sessionID: sessionID)
     guard
       let transcriptPath = sessions[key]?.transcriptPath,
-      let startup = CodexTranscriptMonitor.start(at: transcriptPath)
+      let (initialCursor, initialUpdate) = CodexTranscriptMonitor.start(at: transcriptPath)
     else {
       return false
     }
-    let (initialCursor, initialUpdate) = startup
     var cursor = initialCursor
     let interval = transcriptPollInterval
     let sleep = self.sleep
     transcriptMonitorTasks[key]?.cancel()
-    cancelRunningTimeout(agent: agent, sessionID: sessionID)
+    cancelRunningTimeout(agent: key.agent, sessionID: sessionID)
     if let initialUpdate {
       handleTranscriptUpdate(
         initialUpdate,
         key: key,
-        agent: agent,
         sessionID: sessionID,
         context: context
       )
@@ -155,7 +152,6 @@ final class TerminalAgentSessionStore {
         self?.handleTranscriptUpdate(
           update,
           key: key,
-          agent: agent,
           sessionID: sessionID,
           context: context
         )
@@ -209,18 +205,17 @@ final class TerminalAgentSessionStore {
   private func handleTranscriptUpdate(
     _ update: CodexTranscriptUpdate,
     key: SessionKey,
-    agent: SupatermAgentKind,
     sessionID: String,
     context: SupatermCLIContext?
   ) {
     if update.status?.isFinal == true {
       transcriptMonitorTasks.removeValue(forKey: key)
-      cancelRunningTimeout(agent: agent, sessionID: sessionID)
+      cancelRunningTimeout(agent: key.agent, sessionID: sessionID)
     }
     delegate?.terminalAgentSessionStore(
       self,
       didReceiveCodexTranscriptUpdate: update,
-      agent: agent,
+      agent: key.agent,
       sessionID: sessionID,
       context: context
     )

--- a/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
+++ b/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
@@ -111,22 +111,34 @@ final class TerminalAgentSessionStore {
     sessions = sessions.filter { $0.value.surfaceID != surfaceID }
   }
 
-  func armTranscriptMonitor(
-    agent: SupatermAgentKind,
+  @discardableResult
+  func beginCodexTracking(
     sessionID: String,
     context: SupatermCLIContext?
   ) -> Bool {
-    guard agent == .codex else { return false }
+    let agent: SupatermAgentKind = .codex
     let key = SessionKey(agent: agent, sessionID: sessionID)
     guard
       let transcriptPath = sessions[key]?.transcriptPath,
-      var cursor = CodexTranscriptMonitor.makeCursor(at: transcriptPath)
+      let startup = CodexTranscriptMonitor.start(at: transcriptPath)
     else {
       return false
     }
+    let (initialCursor, initialUpdate) = startup
+    var cursor = initialCursor
     let interval = transcriptPollInterval
     let sleep = self.sleep
     transcriptMonitorTasks[key]?.cancel()
+    cancelRunningTimeout(agent: agent, sessionID: sessionID)
+    if let initialUpdate {
+      handleTranscriptUpdate(
+        initialUpdate,
+        key: key,
+        agent: agent,
+        sessionID: sessionID,
+        context: context
+      )
+    }
     transcriptMonitorTasks[key] = Task { [weak self] in
       while !Task.isCancelled {
         try? await sleep(interval)

--- a/apps/mac/supaterm/App/TerminalWindowRegistry.swift
+++ b/apps/mac/supaterm/App/TerminalWindowRegistry.swift
@@ -1321,15 +1321,9 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
   private func handleRunningAgentHook(
     _ request: SupatermAgentHookRequest
   ) -> TerminalAgentHookResult {
-    let event = request.event
-    guard let sessionID = event.sessionID else {
+    guard let sessionID = prepareAgentTurn(request) else {
       return .init(desktopNotification: nil)
     }
-    clearRecentStructuredNotifications(
-      agent: request.agent,
-      context: request.context,
-      sessionID: sessionID
-    )
     _ = setAgentActivity(
       .init(
         kind: request.agent,
@@ -1345,21 +1339,22 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
   private func handleUserPromptSubmitAgentHook(
     _ request: SupatermAgentHookRequest
   ) -> TerminalAgentHookResult {
-    guard request.agent == .codex else {
-      return handleRunningAgentHook(request)
-    }
-    guard let sessionID = request.event.sessionID else {
+    guard let sessionID = prepareAgentTurn(request) else {
       return .init(desktopNotification: nil)
     }
-    clearRecentStructuredNotifications(
-      agent: request.agent,
-      context: request.context,
-      sessionID: sessionID
-    )
-    _ = agentSessionStore.beginCodexTracking(
-      sessionID: sessionID,
-      context: request.context
-    )
+    if request.agent == .codex {
+      _ = agentSessionStore.beginCodexTracking(
+        sessionID: sessionID,
+        context: request.context
+      )
+    } else {
+      _ = setAgentActivity(
+        .init(kind: request.agent, phase: .running),
+        agent: request.agent,
+        sessionID: sessionID,
+        context: request.context
+      )
+    }
     return .init(desktopNotification: nil)
   }
 
@@ -1497,6 +1492,19 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
 
     return .init(desktopNotification: nil)
   }
+
+  private func prepareAgentTurn(
+    _ request: SupatermAgentHookRequest
+  ) -> String? {
+    guard let sessionID = request.event.sessionID else { return nil }
+    clearRecentStructuredNotifications(
+      agent: request.agent,
+      context: request.context,
+      sessionID: sessionID
+    )
+    return sessionID
+  }
+
   @discardableResult
   private func setAgentActivity(
     _ activity: TerminalHostState.AgentActivity,
@@ -1504,22 +1512,21 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
     sessionID: String,
     context: SupatermCLIContext?
   ) -> Bool {
-    let updated = updateAgentActivity(
-      activity, agent: agent, sessionID: sessionID, context: context)
-    if updated {
-      if activity.phase == .running {
-        if agent == .codex {
-          agentSessionStore.cancelRunningTimeout(agent: agent, sessionID: sessionID)
-        } else {
-          agentSessionStore.cancelTranscriptMonitor(agent: agent, sessionID: sessionID)
-          agentSessionStore.armRunningTimeout(agent: agent, sessionID: sessionID, context: context)
-        }
-      } else {
-        agentSessionStore.cancelTranscriptMonitor(agent: agent, sessionID: sessionID)
-        agentSessionStore.cancelRunningTimeout(agent: agent, sessionID: sessionID)
-      }
+    guard updateAgentActivity(activity, agent: agent, sessionID: sessionID, context: context)
+    else {
+      return false
     }
-    return updated
+    switch activity.phase {
+    case .running where agent == .codex:
+      agentSessionStore.cancelRunningTimeout(agent: agent, sessionID: sessionID)
+    case .running:
+      agentSessionStore.cancelTranscriptMonitor(agent: agent, sessionID: sessionID)
+      agentSessionStore.armRunningTimeout(agent: agent, sessionID: sessionID, context: context)
+    default:
+      agentSessionStore.cancelTranscriptMonitor(agent: agent, sessionID: sessionID)
+      agentSessionStore.cancelRunningTimeout(agent: agent, sessionID: sessionID)
+    }
+    return true
   }
 
   private func clearRecentStructuredNotifications(

--- a/apps/mac/supaterm/App/TerminalWindowRegistry.swift
+++ b/apps/mac/supaterm/App/TerminalWindowRegistry.swift
@@ -1369,6 +1369,15 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
         sessionID: sessionID,
         context: request.context
       )
+      if request.agent == .codex {
+        _ = updateCodexHoverMessages(
+          event.lastAssistantMessage.map { [$0] } ?? [],
+          replacing: true,
+          agent: request.agent,
+          sessionID: sessionID,
+          context: request.context
+        )
+      }
     }
     guard
       let body = event.lastAssistantMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1395,6 +1404,13 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
       return .init(desktopNotification: nil)
     }
     _ = clearAgentActivity(agent: request.agent, sessionID: sessionID, context: request.context)
+    if request.agent == .codex {
+      _ = clearCodexHoverMessages(
+        agent: request.agent,
+        context: request.context,
+        sessionID: sessionID
+      )
+    }
     agentSessionStore.clearSession(agent: request.agent, sessionID: sessionID)
     return .init(desktopNotification: nil)
   }
@@ -1548,6 +1564,47 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
   }
 
   @discardableResult
+  private func clearCodexHoverMessages(
+    agent: SupatermAgentKind,
+    context: SupatermCLIContext?,
+    sessionID: String
+  ) -> Bool {
+    updateCodexHoverMessages(
+      [],
+      replacing: true,
+      agent: agent,
+      sessionID: sessionID,
+      context: context
+    )
+  }
+
+  @discardableResult
+  private func updateCodexHoverMessages(
+    _ messages: [String],
+    replacing: Bool,
+    agent: SupatermAgentKind,
+    sessionID: String,
+    context: SupatermCLIContext?
+  ) -> Bool {
+    let candidateSurfaceIDs = agentCandidateSurfaceIDs(
+      agent: agent,
+      sessionID: sessionID,
+      context: context
+    )
+    for surfaceID in candidateSurfaceIDs {
+      for entry in activeEntries()
+      where entry.terminal.recordCodexHoverMessages(
+        messages,
+        replacing: replacing,
+        for: surfaceID
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
+  @discardableResult
   private func clearAgentActivity(
     agent: SupatermAgentKind,
     sessionID: String,
@@ -1606,6 +1663,22 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
     sessionID: String,
     context: SupatermCLIContext?
   ) {
+    if update.status?.startsNewTurn == true {
+      _ = clearCodexHoverMessages(
+        agent: agent,
+        context: context,
+        sessionID: sessionID
+      )
+    }
+    if !update.messages.isEmpty {
+      _ = updateCodexHoverMessages(
+        update.messages,
+        replacing: update.replacesMessages,
+        agent: agent,
+        sessionID: sessionID,
+        context: context
+      )
+    }
     if update.status?.isFinal == true {
       _ = updateAgentActivity(
         .init(kind: agent, phase: .idle, detail: nil),

--- a/apps/mac/supaterm/App/TerminalWindowRegistry.swift
+++ b/apps/mac/supaterm/App/TerminalWindowRegistry.swift
@@ -1254,14 +1254,26 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
     case .sessionStart:
       if let sessionID = event.sessionID {
         agentSessionStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
+        if request.agent == .codex {
+          _ = agentSessionStore.beginCodexTracking(
+            sessionID: sessionID,
+            context: request.context
+          )
+        }
       }
       return .init(desktopNotification: nil)
 
     case .unsupported:
       return .init(desktopNotification: nil)
 
-    case .postToolUse, .preToolUse, .userPromptSubmit:
+    case .postToolUse, .preToolUse:
+      if request.agent == .codex {
+        return .init(desktopNotification: nil)
+      }
       return handleRunningAgentHook(request)
+
+    case .userPromptSubmit:
+      return handleUserPromptSubmitAgentHook(request)
 
     case .stop:
       return try handleStopAgentHook(request)
@@ -1321,14 +1333,30 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
     _ = setAgentActivity(
       .init(
         kind: request.agent,
-        phase: .running,
-        detail: hookRunningDetail(
-          agent: request.agent,
-          eventName: event.hookEventName,
-          toolName: event.toolName
-        )
+        phase: .running
       ),
       agent: request.agent,
+      sessionID: sessionID,
+      context: request.context
+    )
+    return .init(desktopNotification: nil)
+  }
+
+  private func handleUserPromptSubmitAgentHook(
+    _ request: SupatermAgentHookRequest
+  ) -> TerminalAgentHookResult {
+    guard request.agent == .codex else {
+      return handleRunningAgentHook(request)
+    }
+    guard let sessionID = request.event.sessionID else {
+      return .init(desktopNotification: nil)
+    }
+    clearRecentStructuredNotifications(
+      agent: request.agent,
+      context: request.context,
+      sessionID: sessionID
+    )
+    _ = agentSessionStore.beginCodexTracking(
       sessionID: sessionID,
       context: request.context
     )
@@ -1469,22 +1497,6 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
 
     return .init(desktopNotification: nil)
   }
-  private func hookRunningDetail(
-    agent: SupatermAgentKind,
-    eventName: SupatermAgentHookEventName,
-    toolName: String?
-  ) -> String? {
-    guard agent == .codex else { return nil }
-    switch eventName {
-    case .preToolUse, .postToolUse:
-      return toolName?.trimmingCharacters(in: .whitespacesAndNewlines)
-    case .userPromptSubmit:
-      return "Thinking"
-    default:
-      return nil
-    }
-  }
-
   @discardableResult
   private func setAgentActivity(
     _ activity: TerminalHostState.AgentActivity,
@@ -1496,9 +1508,7 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
       activity, agent: agent, sessionID: sessionID, context: context)
     if updated {
       if activity.phase == .running {
-        if agentSessionStore.armTranscriptMonitor(
-          agent: agent, sessionID: sessionID, context: context)
-        {
+        if agent == .codex {
           agentSessionStore.cancelRunningTimeout(agent: agent, sessionID: sessionID)
         } else {
           agentSessionStore.cancelTranscriptMonitor(agent: agent, sessionID: sessionID)
@@ -1598,9 +1608,8 @@ final class TerminalWindowRegistry: TerminalAgentSessionStoreDelegate {
       )
       return
     }
-    guard let detail = update.detail else { return }
     _ = updateAgentActivity(
-      .init(kind: agent, phase: .running, detail: detail),
+      .init(kind: agent, phase: .running, detail: update.detail),
       agent: agent,
       sessionID: sessionID,
       context: context

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -6,6 +6,14 @@ import Sharing
 import SupatermCLIShared
 import SwiftUI
 
+private func normalizedTerminalAgentDetail(_ detail: String?) -> String? {
+  guard let detail = detail?.trimmingCharacters(in: .whitespacesAndNewlines), !detail.isEmpty
+  else {
+    return nil
+  }
+  return detail
+}
+
 @MainActor
 @Observable
 final class TerminalHostState {
@@ -131,7 +139,7 @@ final class TerminalHostState {
     ) {
       self.kind = kind
       self.phase = phase
-      self.detail = Self.normalizedDetail(detail)
+      self.detail = normalizedTerminalAgentDetail(detail)
     }
 
     static func claude(
@@ -167,14 +175,6 @@ final class TerminalHostState {
         return false
       }
     }
-
-    private static func normalizedDetail(_ detail: String?) -> String? {
-      guard let detail = detail?.trimmingCharacters(in: .whitespacesAndNewlines), !detail.isEmpty
-      else {
-        return nil
-      }
-      return detail
-    }
   }
 
   @ObservationIgnored
@@ -209,6 +209,7 @@ final class TerminalHostState {
   private var paneNotifications: [UUID: [PaneNotification]] = [:]
   private var agentActivityByTab: [TerminalTabID: AgentActivity] = [:]
   private var agentActivitySurfaceIDByTab: [TerminalTabID: UUID] = [:]
+  private var codexHoverMessagesByTab: [TerminalTabID: [String]] = [:]
   private var previousSelectedTabIDBySpace: [TerminalSpaceID: TerminalTabID] = [:]
   private var previousSelectedSpaceID: TerminalSpaceID?
   private var lastEmittedFocusSurfaceID: UUID?
@@ -685,6 +686,11 @@ final class TerminalHostState {
     agentActivityByTab[tabID]
   }
 
+  func codexHoverMarkdown(for tabID: TerminalTabID) -> String? {
+    guard let messages = codexHoverMessagesByTab[tabID], !messages.isEmpty else { return nil }
+    return messages.reversed().joined(separator: "\n\n---\n\n")
+  }
+
   func showsAgentActivityDetail(for tabID: TerminalTabID) -> Bool {
     guard let activitySurfaceID = agentActivitySurfaceIDByTab[tabID] else { return false }
     return focusedSurfaceIDByTab[tabID] == activitySurfaceID
@@ -703,6 +709,32 @@ final class TerminalHostState {
     guard let tabID = tabID(containing: surfaceID) else { return false }
     agentActivityByTab.removeValue(forKey: tabID)
     agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+    return true
+  }
+
+  @discardableResult
+  func clearCodexHoverMessages(for surfaceID: UUID) -> Bool {
+    guard let tabID = tabID(containing: surfaceID) else { return false }
+    codexHoverMessagesByTab.removeValue(forKey: tabID)
+    return true
+  }
+
+  @discardableResult
+  func recordCodexHoverMessages(
+    _ messages: [String],
+    replacing: Bool,
+    for surfaceID: UUID
+  ) -> Bool {
+    guard let tabID = tabID(containing: surfaceID) else { return false }
+    var nextMessages = replacing ? [] : (codexHoverMessagesByTab[tabID] ?? [])
+    for message in messages.compactMap(normalizedTerminalAgentDetail) where nextMessages.last != message {
+      nextMessages.append(message)
+    }
+    if nextMessages.isEmpty {
+      codexHoverMessagesByTab.removeValue(forKey: tabID)
+    } else {
+      codexHoverMessagesByTab[tabID] = nextMessages
+    }
     return true
   }
   private func ensureInitialTab(
@@ -2401,6 +2433,7 @@ final class TerminalHostState {
       previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
       agentActivityByTab.removeValue(forKey: tabID)
       agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+      codexHoverMessagesByTab.removeValue(forKey: tabID)
       spaceManager.space(for: tabID)
         .flatMap { spaceManager.tabManager(for: $0.id) }?
         .closeTab(tabID)
@@ -2418,6 +2451,7 @@ final class TerminalHostState {
     if agentActivitySurfaceIDByTab[tabID] == surfaceID {
       agentActivityByTab.removeValue(forKey: tabID)
       agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+      codexHoverMessagesByTab.removeValue(forKey: tabID)
     }
     updateRunningState(for: tabID)
     updateTabTitle(for: tabID)
@@ -2974,6 +3008,7 @@ final class TerminalHostState {
     }
     agentActivityByTab.removeValue(forKey: tabID)
     agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+    codexHoverMessagesByTab.removeValue(forKey: tabID)
     focusedSurfaceIDByTab.removeValue(forKey: tabID)
     previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
     previousSelectedTabIDBySpace = previousSelectedTabIDBySpace.filter { $0.value != tabID }

--- a/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
@@ -523,17 +523,15 @@ struct TerminalSidebarTabSummaryView: View {
   }
 
   static func popoverMarkdown(
-    agentActivity: TerminalHostState.AgentActivity?,
+    codexHoverMarkdown: String?,
     showsAgentActivityDetail: Bool,
     notificationMarkdown: String?
   ) -> String? {
-    if let agentActivity,
-      showsAgentActivityDetail,
-      agentActivity.kind == .codex,
-      agentActivity.phase == .running,
-      let detail = agentActivity.detail
+    if showsAgentActivityDetail,
+      let codexHoverMarkdown,
+      !codexHoverMarkdown.isEmpty
     {
-      return detail
+      return codexHoverMarkdown
     }
     return notificationMarkdown
   }
@@ -1047,7 +1045,7 @@ struct TerminalSidebarTabRow: View {
 
   private var popoverMarkdown: String? {
     TerminalSidebarTabSummaryView.popoverMarkdown(
-      agentActivity: terminal.agentActivity(for: tab.id),
+      codexHoverMarkdown: terminal.codexHoverMarkdown(for: tab.id),
       showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
       notificationMarkdown: notificationPresentation?.markdown
     )

--- a/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
@@ -18,7 +18,7 @@ struct CodexSettingsInstallerTests {
 
     let object = try codexSettingsObject(homeDirectoryURL: homeDirectoryURL)
     let hooks = try #require(object["hooks"] as? [String: Any])
-    #expect(Set(hooks.keys) == ["PostToolUse", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit"])
+    #expect(Set(hooks.keys) == ["SessionStart", "Stop", "UserPromptSubmit"])
   }
 
   @Test
@@ -62,8 +62,60 @@ struct CodexSettingsInstallerTests {
       .flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
       .compactMap { $0["command"] as? String }
 
-    #expect(commands.contains("echo keep"))
-    #expect(commands.contains(SupatermCodexHookSettings.command))
+    #expect(commands == ["echo keep"])
+  }
+
+  @Test
+  func installRemovesManagedPreAndPostToolUseHooks() throws {
+    let homeDirectoryURL = try temporaryCodexHomeDirectory()
+    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
+
+    let command = SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    try writeCodexSettings(
+      """
+      {
+        "hooks": {
+          "PostToolUse": [
+            {
+              "hooks": [
+                {
+                  "command": "\(command)",
+                  "timeout": 5,
+                  "type": "command"
+                }
+              ]
+            }
+          ],
+          "PreToolUse": [
+            {
+              "hooks": [
+                {
+                  "command": "\(command)",
+                  "timeout": 5,
+                  "type": "command"
+                }
+              ]
+            }
+          ]
+        }
+      }
+      """,
+      homeDirectoryURL: homeDirectoryURL
+    )
+
+    let installer = CodexSettingsInstaller(
+      homeDirectoryURL: homeDirectoryURL,
+      runEnableHooksCommand: { .init(status: 0, standardError: "") }
+    )
+
+    try installer.installSupatermHooks()
+
+    let object = try codexSettingsObject(homeDirectoryURL: homeDirectoryURL)
+    let hooks = try #require(object["hooks"] as? [String: Any])
+
+    #expect(hooks["PostToolUse"] == nil)
+    #expect(hooks["PreToolUse"] == nil)
+    #expect(Set(hooks.keys) == ["SessionStart", "Stop", "UserPromptSubmit"])
   }
 
   @Test

--- a/apps/mac/supatermTests/CodexTranscriptFixtures.swift
+++ b/apps/mac/supatermTests/CodexTranscriptFixtures.swift
@@ -3,7 +3,9 @@ import Foundation
 enum CodexTranscriptFixtures {
   enum Line {
     case taskStarted(turnID: String)
+    case turnStarted(turnID: String)
     case taskComplete(turnID: String, lastAgentMessage: String? = nil)
+    case turnComplete(turnID: String)
     case turnAborted(turnID: String)
     case localShellCall(command: [String])
     case functionCall(name: String, arguments: [String: Any]? = nil)
@@ -27,12 +29,28 @@ enum CodexTranscriptFixtures {
           ]
         )
 
+      case .turnStarted(let turnID):
+        object = event(
+          type: "turn_started",
+          payload: [
+            "turn_id": turnID,
+          ]
+        )
+
       case .taskComplete(let turnID, let lastAgentMessage):
         var payload: [String: Any] = ["turn_id": turnID]
         if let lastAgentMessage {
           payload["last_agent_message"] = lastAgentMessage
         }
         object = event(type: "task_complete", payload: payload)
+
+      case .turnComplete(let turnID):
+        object = event(
+          type: "turn_complete",
+          payload: [
+            "turn_id": turnID,
+          ]
+        )
 
       case .turnAborted(let turnID):
         object = event(

--- a/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
+++ b/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
@@ -38,6 +38,37 @@ struct CodexTranscriptMonitorTests {
   }
 
   @Test
+  func startDoesNotReusePreviousTurnDetailWhenNewTurnOnlyStarted() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    try CodexTranscriptFixtures.append(.assistantMessage("Finished the previous turn"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.taskComplete(turnID: "turn-0"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
+
+    let result = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+
+    #expect(result.1?.status == .started("turn-1"))
+    #expect(result.1?.detail == nil)
+  }
+
+  @Test
+  func startDoesNotReusePreviousTurnMessagePriorityForNewTurnReasoning() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    try CodexTranscriptFixtures.append(.assistantMessage("Finished the previous turn"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.taskComplete(turnID: "turn-0"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.reasoning("Planning the next step"), to: transcriptURL)
+
+    let result = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+
+    #expect(result.1?.status == .started("turn-1"))
+    #expect(result.1?.detail == "Thinking...")
+  }
+
+  @Test
   func advancePrefersAssistantMessageOverToolCallWithinSingleRead() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }

--- a/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
+++ b/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
@@ -193,4 +193,75 @@ struct CodexTranscriptMonitorTests {
     #expect(result.1?.status == .completed("turn-1"))
     #expect(result.1?.status?.isFinal == true)
   }
+
+  @Test
+  func advanceKeepsFullAssistantMessageForHoverHistory() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    let longMessage = Array(repeating: "message", count: 30).joined(separator: " ")
+    let truncatedMessage = String(longMessage.prefix(157)) + "..."
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
+
+    try CodexTranscriptFixtures.append(.assistantMessage(longMessage), to: transcriptURL)
+
+    let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
+
+    #expect(result.1?.detail == truncatedMessage)
+    #expect(result.1?.messages == [longMessage])
+    #expect(result.1?.replacesMessages == false)
+  }
+
+  @Test
+  func advanceFinalAssistantMessageReplacesHoverMessagesWithoutRunningDetail() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    let (initialCursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
+
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Inspecting the transcript path"),
+      to: transcriptURL
+    )
+
+    let firstResult = try #require(CodexTranscriptMonitor.advance(initialCursor, at: transcriptURL.path))
+
+    #expect(firstResult.1?.detail == "Inspecting the transcript path")
+    #expect(firstResult.1?.messages == ["Inspecting the transcript path"])
+    #expect(firstResult.1?.replacesMessages == false)
+
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Done.", phase: "final_answer"),
+      to: transcriptURL
+    )
+
+    let secondResult = try #require(CodexTranscriptMonitor.advance(firstResult.0, at: transcriptURL.path))
+
+    #expect(secondResult.1?.detail == nil)
+    #expect(secondResult.1?.messages == ["Done."])
+    #expect(secondResult.1?.replacesMessages == true)
+  }
+
+  @Test
+  func advanceTaskCompleteCarriesLastAgentMessageForHoverReplacement() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    let longMessage = Array(repeating: "message", count: 30).joined(separator: " ")
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
+    try CodexTranscriptFixtures.append(
+      .taskComplete(turnID: "turn-1", lastAgentMessage: longMessage),
+      to: transcriptURL
+    )
+
+    let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
+
+    #expect(result.1?.status == .completed("turn-1"))
+    #expect(result.1?.detail == nil)
+    #expect(result.1?.messages == [longMessage])
+    #expect(result.1?.replacesMessages == true)
+  }
 }

--- a/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
+++ b/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
@@ -5,33 +5,36 @@ import Testing
 
 struct CodexTranscriptMonitorTests {
   @Test
-  func advanceReadsLatestStatusAndDetail() throws {
+  func startReadsActiveTranscriptSnapshot() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
     try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
     try CodexTranscriptFixtures.append(.reasoning("Inspecting the workspace"), to: transcriptURL)
 
-    let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
+    let result = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
 
-    #expect(result.0.offset > cursor.offset)
+    #expect(result.0.offset > 0)
     #expect(result.1?.status == .started("turn-1"))
     #expect(result.1?.detail == "Thinking...")
   }
 
   @Test
-  func advanceDetectsFinalTurnStatus() throws {
+  func startSuppressesCompletedTranscriptSnapshotButKeepsPolling() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
     try CodexTranscriptFixtures.append(.taskComplete(turnID: "turn-1"), to: transcriptURL)
 
-    let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
+    let initial = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
 
-    #expect(result.1?.status == .completed("turn-1"))
-    #expect(result.1?.status?.isFinal == true)
+    #expect(initial.1 == nil)
+
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-2"), to: transcriptURL)
+
+    let result = try #require(CodexTranscriptMonitor.advance(initial.0, at: transcriptURL.path))
+
+    #expect(result.1?.status == .started("turn-2"))
   }
 
   @Test
@@ -39,7 +42,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(.assistantMessage("Inspecting the transcript path"), to: transcriptURL)
     try CodexTranscriptFixtures.append(
       .functionCall(
@@ -61,7 +65,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let initialCursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (initialCursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(.assistantMessage("Inspecting the transcript path"), to: transcriptURL)
 
     let firstResult = try #require(CodexTranscriptMonitor.advance(initialCursor, at: transcriptURL.path))
@@ -80,7 +85,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(
       .functionCall(
         name: "exec_command",
@@ -101,7 +107,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(.functionCall(name: "update_plan"), to: transcriptURL)
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
@@ -114,7 +121,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(.functionCall(name: "exec_command"), to: transcriptURL)
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
@@ -127,7 +135,8 @@ struct CodexTranscriptMonitorTests {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
-    let cursor = try #require(CodexTranscriptMonitor.makeCursor(at: transcriptURL.path))
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
     try CodexTranscriptFixtures.append(
       #"{"timestamp":"2026-04-05T07:00:00.000Z","type":"response_item","payload":{"type":"reasoning","# +
         #""summary":[],"content":null}}"#,
@@ -137,5 +146,20 @@ struct CodexTranscriptMonitorTests {
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
 
     #expect(result.1?.detail == "Thinking...")
+  }
+
+  @Test
+  func advanceDetectsFinalTurnStatus() throws {
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    let (cursor, initialUpdate) = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
+    #expect(initialUpdate == nil)
+    try CodexTranscriptFixtures.append(.taskComplete(turnID: "turn-1"), to: transcriptURL)
+
+    let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
+
+    #expect(result.1?.status == .completed("turn-1"))
+    #expect(result.1?.status?.isFinal == true)
   }
 }

--- a/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
+++ b/apps/mac/supatermTests/CodexTranscriptMonitorTests.swift
@@ -10,13 +10,13 @@ struct CodexTranscriptMonitorTests {
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
     try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
-    try CodexTranscriptFixtures.append(.reasoning("Inspecting the workspace"), to: transcriptURL)
+    try CodexTranscriptFixtures.append(.assistantMessage("Inspecting the workspace"), to: transcriptURL)
 
     let result = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
 
     #expect(result.0.offset > 0)
     #expect(result.1?.status == .started("turn-1"))
-    #expect(result.1?.detail == "Thinking...")
+    #expect(result.1?.detail == "Inspecting the workspace")
   }
 
   @Test
@@ -53,7 +53,7 @@ struct CodexTranscriptMonitorTests {
   }
 
   @Test
-  func startDoesNotReusePreviousTurnMessagePriorityForNewTurnReasoning() throws {
+  func startDoesNotReusePreviousTurnDetailForNewTurnReasoning() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -65,7 +65,7 @@ struct CodexTranscriptMonitorTests {
     let result = try #require(CodexTranscriptMonitor.start(at: transcriptURL.path))
 
     #expect(result.1?.status == .started("turn-1"))
-    #expect(result.1?.detail == "Thinking...")
+    #expect(result.1?.detail == nil)
   }
 
   @Test
@@ -92,7 +92,7 @@ struct CodexTranscriptMonitorTests {
   }
 
   @Test
-  func advanceDoesNotDemoteAssistantMessageToReasoningAcrossReads() throws {
+  func advanceIgnoresReasoningAfterAssistantMessageAcrossReads() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -112,7 +112,7 @@ struct CodexTranscriptMonitorTests {
   }
 
   @Test
-  func advanceUsesExecCommandCmdForToolDetail() throws {
+  func advanceIgnoresExecCommandToolDetail() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -130,11 +130,11 @@ struct CodexTranscriptMonitorTests {
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
 
-    #expect(result.1?.detail == "sed -n '1,40p' docs/coding-agents-integration.md")
+    #expect(result.1 == nil)
   }
 
   @Test
-  func advanceFormatsGenericToolCallsAsExecuting() throws {
+  func advanceIgnoresGenericToolCalls() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -144,11 +144,11 @@ struct CodexTranscriptMonitorTests {
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
 
-    #expect(result.1?.detail == "Executing update_plan")
+    #expect(result.1 == nil)
   }
 
   @Test
-  func advanceFallsBackToWorkingWhenExecCommandHasNoCmd() throws {
+  func advanceIgnoresExecCommandWithoutCommandText() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -158,11 +158,11 @@ struct CodexTranscriptMonitorTests {
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
 
-    #expect(result.1?.detail == "Working...")
+    #expect(result.1 == nil)
   }
 
   @Test
-  func advanceShowsThinkingForEmptyReasoningPayload() throws {
+  func advanceIgnoresReasoningPayloadWithoutMessageText() throws {
     let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -176,7 +176,7 @@ struct CodexTranscriptMonitorTests {
 
     let result = try #require(CodexTranscriptMonitor.advance(cursor, at: transcriptURL.path))
 
-    #expect(result.1?.detail == "Thinking...")
+    #expect(result.1 == nil)
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
@@ -20,14 +20,10 @@ struct SupatermCodexHookSettingsTests {
       ) as? [String: Any]
     let hooks = try #require(object?["hooks"] as? [String: [[String: Any]]])
 
-    #expect(Set(hooks.keys) == ["PostToolUse", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit"])
-    #expect(try commandHook(in: hooks, event: "PostToolUse")["timeout"] as? Int == 5)
-    #expect(try commandHook(in: hooks, event: "PreToolUse")["timeout"] as? Int == 5)
+    #expect(Set(hooks.keys) == ["SessionStart", "Stop", "UserPromptSubmit"])
     #expect(try commandHook(in: hooks, event: "SessionStart")["timeout"] as? Int == 10)
     #expect(try commandHook(in: hooks, event: "Stop")["timeout"] as? Int == 10)
     #expect(try commandHook(in: hooks, event: "UserPromptSubmit")["timeout"] as? Int == 10)
-    #expect(try group(in: hooks, event: "PostToolUse")["matcher"] as? String == nil)
-    #expect(try group(in: hooks, event: "PreToolUse")["matcher"] as? String == nil)
     #expect(try group(in: hooks, event: "SessionStart")["matcher"] as? String == "startup|resume")
   }
 }

--- a/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
@@ -81,6 +81,71 @@ struct TerminalAgentSessionStoreTests {
     #expect(delegate.expirations.isEmpty)
   }
 
+  @Test
+  func beginCodexTrackingPublishesActiveTranscriptSnapshot() throws {
+    let delegate = SessionStoreDelegateSpy()
+    let store = TerminalAgentSessionStore(
+      agentRunningTimeout: .seconds(5),
+      transcriptPollInterval: .seconds(1),
+      sleep: { _ in }
+    )
+    store.delegate = delegate
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
+    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
+    store.recordSession(
+      agent: .codex,
+      sessionID: "session-1",
+      context: context,
+      transcriptPath: transcriptURL.path
+    )
+
+    #expect(store.beginCodexTracking(sessionID: "session-1", context: context))
+    #expect(delegate.transcriptUpdates.count == 1)
+    #expect(delegate.transcriptUpdates.first?.0 == .started("turn-1"))
+    #expect(delegate.transcriptUpdates.first?.1 == nil)
+  }
+
+  @Test
+  func beginCodexTrackingIgnoresStaleFinalSnapshotAndPublishesLaterTurn() async throws {
+    let clock = TestClock()
+    let delegate = SessionStoreDelegateSpy()
+    let store = TerminalAgentSessionStore(
+      agentRunningTimeout: .seconds(5),
+      transcriptPollInterval: .seconds(1),
+      sleep: { duration in
+        try await clock.sleep(for: duration)
+      }
+    )
+    store.delegate = delegate
+    let transcriptURL = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    try CodexTranscriptFixtures.append(.taskComplete(turnID: "turn-0"), to: transcriptURL)
+    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
+    store.recordSession(
+      agent: .codex,
+      sessionID: "session-1",
+      context: context,
+      transcriptPath: transcriptURL.path
+    )
+
+    #expect(store.beginCodexTracking(sessionID: "session-1", context: context))
+    #expect(delegate.transcriptUpdates.isEmpty)
+
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptURL)
+
+    await flushEffects()
+    await clock.advance(by: .seconds(1))
+    await flushEffects()
+
+    #expect(delegate.transcriptUpdates.count == 1)
+    #expect(delegate.transcriptUpdates.first?.0 == .started("turn-1"))
+    #expect(delegate.transcriptUpdates.first?.1 == nil)
+  }
+
   private func flushEffects() async {
     for _ in 0..<5 {
       await Task.yield()
@@ -91,6 +156,7 @@ struct TerminalAgentSessionStoreTests {
 @MainActor
 private final class SessionStoreDelegateSpy: TerminalAgentSessionStoreDelegate {
   var expirations: [(SupatermAgentKind, String)] = []
+  var transcriptUpdates: [(CodexTranscriptTurnStatus?, String?)] = []
 
   func terminalAgentSessionStore(
     _ store: TerminalAgentSessionStore,
@@ -98,7 +164,9 @@ private final class SessionStoreDelegateSpy: TerminalAgentSessionStoreDelegate {
     agent: SupatermAgentKind,
     sessionID: String,
     context: SupatermCLIContext?
-  ) {}
+  ) {
+    transcriptUpdates.append((update.status, update.detail))
+  }
 
   func terminalAgentSessionStore(
     _ store: TerminalAgentSessionStore,

--- a/apps/mac/supatermTests/TerminalHostStateNotificationTests.swift
+++ b/apps/mac/supatermTests/TerminalHostStateNotificationTests.swift
@@ -366,6 +366,48 @@ struct TerminalHostStateNotificationTests {
   }
 
   @Test
+  func codexHoverMarkdownShowsLatestMessageFirstWithDivider() throws {
+    initializeGhosttyForTests()
+
+    let host = TerminalHostState()
+    host.windowActivity = .init(isKeyWindow: true, isVisible: true)
+    host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+
+    let tabID = try #require(host.selectedTabID)
+    let surface = try #require(host.selectedSurfaceView)
+
+    #expect(host.recordCodexHoverMessages(["First message"], replacing: false, for: surface.id))
+    #expect(host.recordCodexHoverMessages(["Second message"], replacing: false, for: surface.id))
+
+    #expect(
+      host.codexHoverMarkdown(for: tabID) == """
+        Second message
+
+        ---
+
+        First message
+        """
+    )
+  }
+
+  @Test
+  func replacingCodexHoverMarkdownDropsEarlierMessages() throws {
+    initializeGhosttyForTests()
+
+    let host = TerminalHostState()
+    host.windowActivity = .init(isKeyWindow: true, isVisible: true)
+    host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+
+    let tabID = try #require(host.selectedTabID)
+    let surface = try #require(host.selectedSurfaceView)
+
+    #expect(host.recordCodexHoverMessages(["First message", "Second message"], replacing: false, for: surface.id))
+    #expect(host.recordCodexHoverMessages(["Final answer"], replacing: true, for: surface.id))
+
+    #expect(host.codexHoverMarkdown(for: tabID) == "Final answer")
+  }
+
+  @Test
   func agentActivityDetailHidesWhenFocusMovesToDifferentPaneInSameTab() throws {
     initializeGhosttyForTests()
 

--- a/apps/mac/supatermTests/TerminalSidebarChromeViewTests.swift
+++ b/apps/mac/supatermTests/TerminalSidebarChromeViewTests.swift
@@ -191,17 +191,29 @@ struct TerminalSidebarChromeViewTests {
   }
 
   @Test
-  func runningCodexDetailTakesPopoverPrecedenceOverNotificationMarkdown() {
+  func runningCodexHoverMarkdownTakesPopoverPrecedenceOverNotificationMarkdown() {
     #expect(
       TerminalSidebarTabSummaryView.popoverMarkdown(
-        agentActivity: .codex(.running, detail: "Inspecting transcript activity"),
+        codexHoverMarkdown: """
+          Need approval?
+
+          ---
+
+          Inspecting transcript activity
+          """,
         showsAgentActivityDetail: true,
         notificationMarkdown: """
           Need approval
 
           Full notification body
           """
-      ) == "Inspecting transcript activity"
+      ) == """
+        Need approval?
+
+        ---
+
+        Inspecting transcript activity
+        """
     )
   }
 
@@ -209,7 +221,7 @@ struct TerminalSidebarChromeViewTests {
   func notificationMarkdownReturnsWhenCodexDetailIsHiddenForPopover() {
     #expect(
       TerminalSidebarTabSummaryView.popoverMarkdown(
-        agentActivity: .codex(.running, detail: "Inspecting transcript activity"),
+        codexHoverMarkdown: "Inspecting transcript activity",
         showsAgentActivityDetail: false,
         notificationMarkdown: """
           Need approval
@@ -228,7 +240,7 @@ struct TerminalSidebarChromeViewTests {
   func popoverMarkdownIsNilWithoutVisibleActivityDetailOrNotification() {
     #expect(
       TerminalSidebarTabSummaryView.popoverMarkdown(
-        agentActivity: .codex(.running),
+        codexHoverMarkdown: nil,
         showsAgentActivityDetail: false,
         notificationMarkdown: nil
       ) == nil

--- a/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
@@ -953,45 +953,7 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
-  func codexPreToolUseAndStopUpdateCodexActivity() throws {
-    let harness = try makeClaudeHookHarness()
-
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
-    )
-
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Bash"))
-
-    let result = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.stop)
-    )
-
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
-    #expect(result.desktopNotification == nil)
-    #expect(harness.host.unreadNotificationCount(for: harness.tabID) == 1)
-    #expect(harness.host.unreadNotifiedSurfaceIDs(in: harness.tabID) == Set([harness.context.surfaceID]))
-    #expect(harness.host.latestNotificationText(for: harness.tabID) == "Done.")
-  }
-
-  @Test
-  func codexPostToolUseMarksTabRunning() throws {
-    let harness = try makeClaudeHookHarness()
-
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.postToolUse, context: harness.context)
-    )
-
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Bash"))
-  }
-
-  @Test
-  func codexTranscriptResponseItemsReplaceHookFallbackDetail() async throws {
+  func codexSessionStartTracksTranscriptLifecycleWithoutHookFallback() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
       agentRunningTimeout: .milliseconds(10),
@@ -1006,15 +968,12 @@ struct TerminalWindowRegistryTests {
         context: harness.context
       )
     )
-    _ = try harness.registry.handleAgentHook(
-      codexHook(
-        CodexHookFixtures.preToolUse,
-        transcriptPath: transcriptPath,
-        context: harness.context
-      )
-    )
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Bash"))
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
 
     try CodexTranscriptFixtures.append(
       .localShellCall(command: ["git", "status", "--short"]),
@@ -1062,6 +1021,71 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
+  func codexSessionStartShowsAlreadyRunningTranscriptSnapshot() throws {
+    let harness = try makeClaudeHookHarness()
+    let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptPath.deletingLastPathComponent()) }
+
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    try CodexTranscriptFixtures.append(.assistantMessage("Resuming active rollout"), to: transcriptPath)
+
+    _ = try harness.registry.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+
+    #expect(
+      harness.host.agentActivity(for: harness.tabID)
+        == .codex(.running, detail: "Resuming active rollout")
+    )
+  }
+
+  @Test
+  func codexPreToolUseDoesNotMarkTabRunning() throws {
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
+    )
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
+    )
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
+  }
+
+  @Test
+  func codexPostToolUseDoesNotMarkTabRunning() throws {
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
+    )
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.postToolUse, context: harness.context)
+    )
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
+  }
+
+  @Test
+  func codexUserPromptSubmitDoesNotMarkTabRunning() throws {
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
+    )
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.userPromptSubmit, context: harness.context)
+    )
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
+  }
+
+  @Test
   func codexTranscriptBatchPrefersAssistantMessageOverExecCommand() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
@@ -1077,13 +1101,8 @@ struct TerminalWindowRegistryTests {
         context: harness.context
       )
     )
-    _ = try harness.registry.handleAgentHook(
-      codexHook(
-        CodexHookFixtures.preToolUse,
-        transcriptPath: transcriptPath,
-        context: harness.context
-      )
-    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
 
     try CodexTranscriptFixtures.append(
       .assistantMessage("Inspecting the transcript path"),
@@ -1122,15 +1141,8 @@ struct TerminalWindowRegistryTests {
         context: harness.context
       )
     )
-    _ = try harness.registry.handleAgentHook(
-      codexHook(
-        CodexHookFixtures.userPromptSubmit,
-        transcriptPath: transcriptPath,
-        context: harness.context
-      )
-    )
-
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Thinking"))
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
 
     try CodexTranscriptFixtures.append(
       .assistantMessage("Inspecting the transcript path"),
@@ -1171,13 +1183,8 @@ struct TerminalWindowRegistryTests {
         context: harness.context
       )
     )
-    _ = try harness.registry.handleAgentHook(
-      codexHook(
-        CodexHookFixtures.preToolUse,
-        transcriptPath: transcriptPath,
-        context: harness.context
-      )
-    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
 
     try CodexTranscriptFixtures.append(
       .functionCall(
@@ -1212,15 +1219,10 @@ struct TerminalWindowRegistryTests {
         context: harness.context
       )
     )
-    _ = try harness.registry.handleAgentHook(
-      codexHook(
-        CodexHookFixtures.userPromptSubmit,
-        transcriptPath: transcriptPath,
-        context: harness.context
-      )
-    )
+    try CodexTranscriptFixtures.append(.turnStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Thinking"))
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
 
     try CodexTranscriptFixtures.append(
       .agentReasoning("Inspecting transcript activity"),
@@ -1254,14 +1256,39 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
+  func codexTurnCompleteMarksTabIdle() async throws {
+    let clock = TestClock()
+    let harness = try makeClaudeHookHarness(
+      agentRunningTimeout: .milliseconds(10),
+      clock: clock
+    )
+    let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptPath.deletingLastPathComponent()) }
+
+    _ = try harness.registry.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+    try CodexTranscriptFixtures.append(.turnStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
+
+    try CodexTranscriptFixtures.append(.turnComplete(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
+  }
+
+  @Test
   func codexStopDeliversDesktopNotificationWhenWindowIsInactive() throws {
     let harness = try makeClaudeHookHarness(windowActivity: .inactive)
 
     _ = try harness.registry.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
     )
     let result = try harness.registry.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.stop)
@@ -1289,9 +1316,6 @@ struct TerminalWindowRegistryTests {
       CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
     )
     _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.stop)
     )
 
@@ -1310,9 +1334,6 @@ struct TerminalWindowRegistryTests {
       CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
     )
     _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.stop)
     )
     _ = try harness.registry.handleAgentHook(
@@ -1328,7 +1349,7 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
-  func codexTranscriptKeepsRunningUntilTranscriptCompletes() async throws {
+  func codexTranscriptIgnoresStaleFinalSnapshotUntilNextTurnCompletes() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
       agentRunningTimeout: .milliseconds(10),
@@ -1351,11 +1372,11 @@ struct TerminalWindowRegistryTests {
       codexHook(CodexHookFixtures.userPromptSubmit, transcriptPath: transcriptPath)
     )
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Thinking"))
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
 
     await flushEffects()
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Thinking"))
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
 
     try CodexTranscriptFixtures.append(
       .taskStarted(turnID: "turn-1"),
@@ -1363,7 +1384,7 @@ struct TerminalWindowRegistryTests {
     )
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Thinking"))
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
 
     try CodexTranscriptFixtures.append(
       .taskComplete(turnID: "turn-1"),
@@ -1380,9 +1401,6 @@ struct TerminalWindowRegistryTests {
 
     _ = try harness.registry.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.sessionStart, context: harness.context)
-    )
-    _ = try harness.registry.handleAgentHook(
-      CodexHookFixtures.request(CodexHookFixtures.preToolUse, context: harness.context)
     )
     let result = try harness.registry.handleAgentHook(
       .init(

--- a/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
@@ -993,6 +993,10 @@ struct TerminalWindowRegistryTests {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Updating the registry and sidebar")
     )
+    #expect(
+      harness.host.codexHoverMarkdown(for: harness.tabID)
+        == "Updating the registry and sidebar"
+    )
 
     try CodexTranscriptFixtures.append(
       .assistantMessage(
@@ -1005,7 +1009,11 @@ struct TerminalWindowRegistryTests {
 
     #expect(
       harness.host.agentActivity(for: harness.tabID)
-        == .codex(.running, detail: "Updating the registry and sidebar")
+        == .codex(.running)
+    )
+    #expect(
+      harness.host.codexHoverMarkdown(for: harness.tabID)
+        == "Final answer should stay out of the running subtitle"
     )
 
     try CodexTranscriptFixtures.append(
@@ -1165,6 +1173,80 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
+  func codexTranscriptAccumulatesHoverMessagesLatestFirst() async throws {
+    let clock = TestClock()
+    let harness = try makeClaudeHookHarness(
+      agentRunningTimeout: .milliseconds(10),
+      clock: clock
+    )
+    let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
+
+    _ = try harness.registry.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
+
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Inspecting the transcript path"),
+      to: transcriptPath
+    )
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Updating the registry and sidebar"),
+      to: transcriptPath
+    )
+    await advanceClock(clock)
+
+    #expect(
+      harness.host.codexHoverMarkdown(for: harness.tabID) == """
+        Updating the registry and sidebar
+
+        ---
+
+        Inspecting the transcript path
+        """
+    )
+  }
+
+  @Test
+  func codexTranscriptKeepsFullHoverMessageWhenRunningDetailIsTruncated() async throws {
+    let clock = TestClock()
+    let harness = try makeClaudeHookHarness(
+      agentRunningTimeout: .milliseconds(10),
+      clock: clock
+    )
+    let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
+    let longMessage = Array(repeating: "message", count: 30).joined(separator: " ")
+    let truncatedMessage = String(longMessage.prefix(157)) + "..."
+
+    _ = try harness.registry.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    await advanceClock(clock)
+
+    try CodexTranscriptFixtures.append(
+      .assistantMessage(longMessage),
+      to: transcriptPath
+    )
+    await advanceClock(clock)
+
+    #expect(
+      harness.host.agentActivity(for: harness.tabID)
+        == .codex(.running, detail: truncatedMessage)
+    )
+    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == longMessage)
+  }
+
+  @Test
   func codexTranscriptIgnoresExecCommandRunningDetail() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
@@ -1297,6 +1379,36 @@ struct TerminalWindowRegistryTests {
     #expect(harness.host.unreadNotificationCount(for: harness.tabID) == 1)
     #expect(harness.host.unreadNotifiedSurfaceIDs(in: harness.tabID) == Set([harness.context.surfaceID]))
     #expect(harness.host.latestNotificationText(for: harness.tabID) == "Done.")
+    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == "Done.")
+  }
+
+  @Test
+  func codexStopReplacesHoverHistoryWithLastAssistantMessage() async throws {
+    let clock = TestClock()
+    let harness = try makeClaudeHookHarness(
+      agentRunningTimeout: .milliseconds(10),
+      clock: clock,
+      windowActivity: .inactive
+    )
+    let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
+
+    _ = try harness.registry.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
+    try CodexTranscriptFixtures.append(.assistantMessage("Inspecting the transcript path"), to: transcriptPath)
+    try CodexTranscriptFixtures.append(.assistantMessage("Updating the registry and sidebar"), to: transcriptPath)
+    await advanceClock(clock)
+
+    _ = try harness.registry.handleAgentHook(
+      CodexHookFixtures.request(CodexHookFixtures.stop, context: harness.context)
+    )
+
+    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == "Done.")
   }
 
   @Test
@@ -1410,6 +1522,7 @@ struct TerminalWindowRegistryTests {
     #expect(harness.host.unreadNotificationCount(for: harness.tabID) == 0)
     #expect(harness.host.unreadNotifiedSurfaceIDs(in: harness.tabID).isEmpty)
     #expect(harness.host.latestNotificationText(for: harness.tabID) == nil)
+    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == nil)
   }
 
   private func makeWindow() -> NSWindow {

--- a/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
@@ -981,10 +981,7 @@ struct TerminalWindowRegistryTests {
     )
     await advanceClock(clock)
 
-    #expect(
-      harness.host.agentActivity(for: harness.tabID)
-        == .codex(.running, detail: "Bash · git status --short")
-    )
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
 
     try CodexTranscriptFixtures.append(
       .assistantMessage("Updating the registry and sidebar"),
@@ -1086,7 +1083,7 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
-  func codexTranscriptBatchPrefersAssistantMessageOverExecCommand() async throws {
+  func codexTranscriptIgnoresToolCallsAfterAssistantMessage() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
       agentRunningTimeout: .milliseconds(10),
@@ -1126,7 +1123,7 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
-  func codexTranscriptDoesNotDemoteAssistantMessageToThinkingAcrossPolls() async throws {
+  func codexTranscriptIgnoresReasoningAfterAssistantMessageAcrossPolls() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
       agentRunningTimeout: .milliseconds(10),
@@ -1168,7 +1165,7 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
-  func codexTranscriptUsesExecCommandCmdForRunningDetail() async throws {
+  func codexTranscriptIgnoresExecCommandRunningDetail() async throws {
     let clock = TestClock()
     let harness = try makeClaudeHookHarness(
       agentRunningTimeout: .milliseconds(10),
@@ -1197,10 +1194,7 @@ struct TerminalWindowRegistryTests {
     )
     await advanceClock(clock)
 
-    #expect(
-      harness.host.agentActivity(for: harness.tabID)
-        == .codex(.running, detail: "git status --short")
-    )
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
   }
 
   @Test
@@ -1230,10 +1224,7 @@ struct TerminalWindowRegistryTests {
     )
     await advanceClock(clock)
 
-    #expect(
-      harness.host.agentActivity(for: harness.tabID)
-        == .codex(.running, detail: "Thinking...")
-    )
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
 
     try CodexTranscriptFixtures.append(
       .agentMessage("Need approval?", phase: "commentary"),

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -119,8 +119,8 @@ The app binds Codex sessions to pane surfaces and turns Codex hook events into t
 - `task_complete`, `turn_complete`, and `turn_aborted` mark the tab as `idle`.
 - Resume and startup read the current transcript snapshot before polling, so an already-active Codex turn appears as `running` immediately.
 - While a Codex turn is running, Supaterm tails the Codex rollout file from `transcript_path`.
-- `event_msg` lines drive lifecycle and fallback text.
-- `response_item` lines drive live activity detail such as `Bash · git status --short`, `Reasoning · ...`, or `Message · ...`.
+- `event_msg` lines drive lifecycle, and non-final `agent_message` events can update live activity detail.
+- `response_item` lines only update live activity detail for non-final assistant messages.
 - While Codex is `running`, the sidebar tab row uses its secondary line for live activity detail only when the Codex pane is the focused pane in that tab. Background Codex panes keep the tab-level running badge, but the secondary line falls back to the unread notification preview instead of exposing live internal progress.
 
 The same shared activity model powers both agents, and desktop notification titles now derive from the explicit agent kind instead of assuming one agent.

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -103,9 +103,7 @@ Codex now uses the same app-side bridge and tab-state model.
 ### Hook Injection
 - Supaterm's canonical Codex hook fragment is also available from `sp internal agent-settings codex`.
 - The installed global hooks tell Codex to invoke `sp agent receive-agent-hook --agent codex` for:
-  - `PostToolUse`
   - `SessionStart` with matcher `startup|resume`
-  - `PreToolUse`
   - `UserPromptSubmit`
   - `Stop`
 
@@ -113,12 +111,13 @@ Codex now uses the same app-side bridge and tab-state model.
 
 The app binds Codex sessions to pane surfaces and turns Codex hook events into tab activity.
 
-- `SessionStart` binds the session to the current pane surface.
-- `PostToolUse` marks the tab as `running`.
-- `PreToolUse` marks the tab as `running`.
-- `UserPromptSubmit` marks the tab as `running`.
+- `SessionStart` binds the session to the current pane surface and starts transcript observation for the recorded `transcript_path`.
+- `UserPromptSubmit` re-arms transcript observation for the next turn and clears structured completion suppression without marking the tab as `running` on its own.
 - `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided.
-- Supaterm keeps Codex `running` until `Stop`, `SessionEnd`, terminal exit, or the Codex transcript records a completed or aborted turn.
+- Codex `running` and `idle` now come from transcript lifecycle events instead of `PreToolUse` or `PostToolUse`.
+- `task_started` and `turn_started` mark the tab as `running`.
+- `task_complete`, `turn_complete`, and `turn_aborted` mark the tab as `idle`.
+- Resume and startup read the current transcript snapshot before polling, so an already-active Codex turn appears as `running` immediately.
 - While a Codex turn is running, Supaterm tails the Codex rollout file from `transcript_path`.
 - `event_msg` lines drive lifecycle and fallback text.
 - `response_item` lines drive live activity detail such as `Bash · git status --short`, `Reasoning · ...`, or `Message · ...`.


### PR DESCRIPTION
## Summary

- Problem: Codex tab activity still entered `.running` from managed tool hooks instead of the transcript lifecycle.
- Why it matters: startup and resume could miss already-active turns, and status could drift from the real Codex turn state.
- What changed: Codex running and idle state now come from transcript lifecycle events, startup reads the transcript snapshot before tailing, managed Codex hooks were reduced to `SessionStart`, `UserPromptSubmit`, and `Stop`, and the follow-up simplify pass removed duplicated turn-prep and activity-handling branches.
- What did NOT change (scope boundary): completion notifications still use `Stop`, running subtitle priority still comes from transcript content, and other agent integrations were not changed.

## Rationale

The transcript is the only source that actually describes turn start, turn progress, and turn completion. Driving status from hook side effects left a blind spot on resume and kept Codex activity coupled to events that are not authoritative. This change moves status to the same source of truth that already drives running detail, while keeping hook handling limited to session setup and structured completion.

## User-visible / Behavior Changes

- Codex tabs enter `.running` when transcript lifecycle events report a started turn, including startup and resume from an already-active transcript.
- Codex tabs return to `.idle` on transcript completion and abort events, with `Stop` still acting as the structured completion fallback.
- `UserPromptSubmit` no longer marks Codex running by itself.
- Stale Codex tool hook events no longer drive tab status.

## Diagram (if applicable)

```text
Before:
[Codex hook fires] -> [tab set running]
[startup/resume after started event] -> [monitor starts at EOF] -> [tab can stay idle]

After:
[SessionStart or UserPromptSubmit] -> [monitor arms from transcript snapshot]
[task_started / turn_started] -> [tab running]
[reasoning / tool / assistant message] -> [running detail updates]
[task_complete / turn_complete / turn_aborted] -> [tab idle]
```

## Human Verification

- Verified scenarios: focused regression tests for hook settings, installer rewrite behavior, transcript startup snapshots, running-detail priority, ignored stale hook events, and transcript-driven running and idle transitions in the registry and session store.
- Edge cases checked: startup and resume with an already-active transcript, stale final snapshots before the next turn, `UserPromptSubmit` without forcing running, transcript abort/completion paths, and the simplification pass preserving the same registry/session-store behavior.
- What you did **not** verify: manual app interaction in a launched macOS build.
- How can a human manually verify this: install the Codex hooks, start a turn and confirm the tab only becomes running after transcript start events, resume into an already-running Codex session and confirm the tab is already running from the transcript snapshot, then complete or abort the turn and confirm the tab returns to idle while `Stop` still delivers completion notifications.
