### PR TITLE
feat: move panes to new tabs without restarting

### DIFF
--- a/apps/mac/supaterm/Features/Socket/SupatermDebugSnapshotResolver.swift
+++ b/apps/mac/supaterm/Features/Socket/SupatermDebugSnapshotResolver.swift
@@ -17,12 +17,14 @@ enum SupatermDebugSnapshotResolver {
 
     for window in windows {
       for space in window.spaces {
-        for tab in space.tabs where tab.id == context.tabID {
-          let pane = tab.panes.first { $0.id == context.surfaceID }
+        for tab in space.tabs {
+          guard let pane = tab.panes.first(where: { $0.id == context.surfaceID }) else { continue }
           var problems: [String] = []
-          if pane == nil {
-            problems.append(
-              "Context pane \(context.surfaceID.uuidString) was not found in tab \(context.tabID.uuidString).")
+          if tab.id != context.tabID {
+            let problem =
+              "Context tab \(context.tabID.uuidString) is stale. "
+              + "Pane \(context.surfaceID.uuidString) now belongs to tab \(tab.id.uuidString)."
+            problems.append(problem)
           }
           return .init(
             currentTarget: .init(
@@ -33,8 +35,8 @@ enum SupatermDebugSnapshotResolver {
               tabIndex: tab.index,
               tabID: tab.id,
               tabTitle: tab.title,
-              paneIndex: pane?.index,
-              paneID: pane?.id
+              paneIndex: pane.index,
+              paneID: pane.id
             ),
             problems: problems
           )
@@ -44,7 +46,7 @@ enum SupatermDebugSnapshotResolver {
 
     return .init(
       currentTarget: nil,
-      problems: ["Context tab \(context.tabID.uuidString) was not found."]
+      problems: ["Context pane \(context.surfaceID.uuidString) was not found."]
     )
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceBridge.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceBridge.swift
@@ -73,6 +73,7 @@ final class GhosttySurfaceBridge {
   var onSplitAction: ((GhosttySplitAction) -> Bool)?
   var onCloseRequest: ((Bool) -> Void)?
   var onNewTab: (() -> Bool)?
+  var onMoveSurfaceToNewTab: (() -> Bool)?
   var onCloseTab: ((ghostty_action_close_tab_mode_e) -> Bool)?
   var onGotoTab: ((ghostty_action_goto_tab_e) -> Bool)?
   var onMoveTab: ((ghostty_action_move_tab_s) -> Bool)?

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -1257,6 +1257,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
       ))
     menu.addItem(
       contextMenuItem(
+        title: "Move to New Tab",
+        action: #selector(GhosttySurfaceView.moveToNewTab(_:)),
+        symbol: "macwindow.on.rectangle"
+      ))
+    menu.addItem(
+      contextMenuItem(
         title: "Close Pane",
         action: #selector(GhosttySurfaceView.closePane(_:)),
         symbol: "xmark"
@@ -1304,6 +1310,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   @IBAction func splitUp(_ sender: Any?) {
     _ = bridge.onSplitAction?(.newSplit(direction: .up))
+  }
+
+  @IBAction func moveToNewTab(_ sender: Any?) {
+    _ = bridge.onMoveSurfaceToNewTab?()
   }
 
   @IBAction func closePane(_ sender: Any?) {
@@ -2006,10 +2016,11 @@ final class GhosttySurfaceScrollView: NSView {
   }
 
   override func mouseMoved(with event: NSEvent) {
-    guard Self.shouldFlashLegacyScrollers(
-      scrollerStyle: NSScroller.preferredScrollerStyle,
-      reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-    )
+    guard
+      Self.shouldFlashLegacyScrollers(
+        scrollerStyle: NSScroller.preferredScrollerStyle,
+        reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+      )
     else { return }
     scrollView.flashScrollers()
   }

--- a/apps/mac/supaterm/Features/Terminal/Models/TerminalTabManager.swift
+++ b/apps/mac/supaterm/Features/Terminal/Models/TerminalTabManager.swift
@@ -22,7 +22,8 @@ final class TerminalTabManager {
     title: String,
     icon: String?,
     isPinned: Bool = false,
-    isTitleLocked: Bool = false
+    isTitleLocked: Bool = false,
+    selecting: Bool = true
   ) -> TerminalTabID {
     let tab = TerminalTabItem(
       title: title,
@@ -35,7 +36,9 @@ final class TerminalTabManager {
     } else {
       tabs = pinnedTabs + regularTabs + [tab]
     }
-    selectedTabId = tab.id
+    if selecting {
+      selectedTabId = tab.id
+    }
     return tab.id
   }
 

--- a/apps/mac/supaterm/Features/Terminal/TerminalClient.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalClient.swift
@@ -226,6 +226,7 @@ struct TerminalClient: Sendable {
     case createTab(inheritingFromSurfaceID: UUID?)
     case deleteSpace(TerminalSpaceID)
     case ensureInitialTab(focusing: Bool, startupInput: String?)
+    case moveSurfaceToNewTab(UUID)
     case navigateSearch(GhosttySearchDirection)
     case moveSidebarTab(
       tabID: TerminalTabID, pinnedOrder: [TerminalTabID], regularOrder: [TerminalTabID])
@@ -256,6 +257,7 @@ struct TerminalClient: Sendable {
     case commandPaletteToggleRequested
     case closeRequested(TerminalCloseRequest)
     case gotoTabRequested(TerminalGotoTabTarget)
+    case moveSurfaceToNewTabRequested(UUID)
     case newTabRequested(inheritingFromSurfaceID: UUID?)
     case notificationReceived(TerminalNotificationEvent)
   }

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -798,8 +798,7 @@ final class TerminalHostState {
     moveAgentActivity(surfaceID: surfaceID, from: sourceTabID, to: destinationTabID)
 
     if updatedSourceTree.isEmpty {
-      removeTabMetadata(for: sourceTabID)
-      spaceManager.tabManager(for: sourceSpace.id)?.closeTab(sourceTabID)
+      removeTab(sourceTabID, from: sourceSpace.id)
     } else {
       trees[sourceTabID] = updatedSourceTree
       updateSourceTabFocusAfterRemovingSurface(
@@ -2432,10 +2431,8 @@ final class TerminalHostState {
     recentStructuredNotificationsBySurfaceID.removeValue(forKey: surfaceID)
 
     if newTree.isEmpty {
-      removeTabMetadata(for: tabID)
-      spaceManager.space(for: tabID)
-        .flatMap { spaceManager.tabManager(for: $0.id) }?
-        .closeTab(tabID)
+      guard let spaceID = spaceManager.space(for: tabID)?.id else { return }
+      removeTab(tabID, from: spaceID)
       if tabs.isEmpty {
         _ = createTab(focusing: false, sessionChangesEnabled: false)
       } else if let selectedTabID = selectedTabID {
@@ -2501,47 +2498,27 @@ final class TerminalHostState {
 
   private func configureBridgeTitleCallbacks(for view: GhosttySurfaceView) {
     view.bridge.onTitleChange = { [weak self, weak view] _ in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return
+      self?.withViewTab(view) { this, _, tabID in
+        this.updateTabTitle(for: tabID)
+        this.sessionDidChange()
       }
-      self.updateTabTitle(for: tabID)
-      self.sessionDidChange()
     }
     view.bridge.onPathChange = { [weak self, weak view] in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return
+      self?.withViewTab(view) { this, _, tabID in
+        this.updateTabTitle(for: tabID)
+        this.sessionDidChange()
       }
-      self.updateTabTitle(for: tabID)
-      self.sessionDidChange()
     }
     view.bridge.onTabTitleChange = { [weak self, weak view] title in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return false
-      }
-      self.setLockedTabTitle(title, for: tabID)
-      return true
+      self?.withViewTab(view) { this, _, tabID in
+        this.setLockedTabTitle(title, for: tabID)
+        return true
+      } ?? false
     }
     view.bridge.onPromptTabTitle = { [weak self, weak view] in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return
+      self?.withViewTab(view) { this, view, tabID in
+        this.promptTabTitle(for: tabID, using: view)
       }
-      self.promptTabTitle(for: tabID, using: view)
     }
     view.bridge.onCopyTitleToClipboard = { [weak self, weak view] in
       guard let self, let view else { return false }
@@ -2565,15 +2542,10 @@ final class TerminalHostState {
       return true
     }
     view.bridge.onCloseTab = { [weak self, weak view] _ in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return false
-      }
-      self.requestCloseTab(tabID)
-      return true
+      self?.withViewTab(view) { this, _, tabID in
+        this.requestCloseTab(tabID)
+        return true
+      } ?? false
     }
   }
 
@@ -2590,14 +2562,9 @@ final class TerminalHostState {
       return true
     }
     view.bridge.onProgressReport = { [weak self, weak view] _ in
-      guard
-        let self,
-        let view,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return
+      self?.withViewTab(view) { this, _, tabID in
+        this.updateRunningState(for: tabID)
       }
-      self.updateRunningState(for: tabID)
     }
     view.bridge.onCommandFinished = { [weak self, weak view] in
       guard let self, let view else { return }
@@ -2624,20 +2591,15 @@ final class TerminalHostState {
       self.handleDirectInteraction(on: view.id)
     }
     view.onFocusChange = { [weak self, weak view] focused in
-      guard
-        let self,
-        let view,
-        focused,
-        let tabID = self.tabID(containing: view.id)
-      else {
-        return
+      guard focused else { return }
+      self?.withViewTab(view) { this, view, tabID in
+        this.applyFocusedSurface(view.id, in: tabID)
+        this.updateTabTitle(for: tabID)
+        this.updateRunningState(for: tabID)
+        this.clearNotificationAttention(for: view.id)
+        this.emitFocusChangedIfNeeded(view.id)
+        this.sessionDidChange()
       }
-      self.applyFocusedSurface(view.id, in: tabID)
-      self.updateTabTitle(for: tabID)
-      self.updateRunningState(for: tabID)
-      self.clearNotificationAttention(for: view.id)
-      self.emitFocusChangedIfNeeded(view.id)
-      self.sessionDidChange()
     }
   }
 
@@ -2683,6 +2645,40 @@ final class TerminalHostState {
       icon: "terminal",
       selecting: selecting
     )
+  }
+
+  private func withViewTab(
+    _ view: GhosttySurfaceView?,
+    _ body: (TerminalHostState, GhosttySurfaceView, TerminalTabID) -> Void
+  ) {
+    guard
+      let view,
+      let tabID = tabID(containing: view.id)
+    else {
+      return
+    }
+    body(self, view, tabID)
+  }
+
+  private func withViewTab<T>(
+    _ view: GhosttySurfaceView?,
+    _ body: (TerminalHostState, GhosttySurfaceView, TerminalTabID) -> T
+  ) -> T? {
+    guard
+      let view,
+      let tabID = tabID(containing: view.id)
+    else {
+      return nil
+    }
+    return body(self, view, tabID)
+  }
+
+  private func removeTab(
+    _ tabID: TerminalTabID,
+    from spaceID: TerminalSpaceID
+  ) {
+    removeTabMetadata(for: tabID)
+    spaceManager.tabManager(for: spaceID)?.closeTab(tabID)
   }
 
   private func inheritedSurfaceID(in spaceID: TerminalSpaceID) -> UUID? {

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -397,6 +397,7 @@ final class TerminalHostState {
       .createSpace:
       handleCreationCommand(command)
     case .navigateSearch,
+      .moveSurfaceToNewTab,
       .nextTab,
       .performGhosttyBindingActionOnFocusedSurface,
       .performBindingActionOnFocusedSurface,
@@ -462,6 +463,8 @@ final class TerminalHostState {
     switch command {
     case .navigateSearch(let direction):
       _ = navigateSearchOnFocusedSurface(direction)
+    case .moveSurfaceToNewTab(let surfaceID):
+      moveSurfaceToNewTab(surfaceID)
     case .nextTab:
       nextTab()
     case .performGhosttyBindingActionOnFocusedSurface(let action):
@@ -748,10 +751,7 @@ final class TerminalHostState {
       tabManager.tabs.isEmpty
       ? GHOSTTY_SURFACE_CONTEXT_WINDOW
       : GHOSTTY_SURFACE_CONTEXT_TAB
-    let tabID = tabManager.createTab(
-      title: "Terminal \(nextTabIndex(in: spaceID))",
-      icon: "terminal"
-    )
+    guard let tabID = createTabRecord(in: spaceID) else { return nil }
     let tree = splitTree(
       for: tabID,
       inheritingFromSurfaceID: inheritingFromSurfaceID,
@@ -772,6 +772,52 @@ final class TerminalHostState {
       sessionDidChange()
     }
     return tabID
+  }
+
+  private func moveSurfaceToNewTab(_ surfaceID: UUID) {
+    guard
+      let sourceTabID = tabID(containing: surfaceID),
+      let sourceSpace = spaceManager.space(for: sourceTabID),
+      let sourceTree = trees[sourceTabID],
+      let sourceNode = sourceTree.find(id: surfaceID),
+      let surface = surfaces[surfaceID],
+      let destinationTabID = createTabRecord(in: sourceSpace.id, selecting: false)
+    else {
+      return
+    }
+
+    let nextSourceSurface =
+      focusedSurfaceIDByTab[sourceTabID] == surfaceID
+      ? sourceTree.focusTargetAfterClosing(sourceNode)
+      : nil
+    let updatedSourceTree = sourceTree.removing(sourceNode)
+
+    trees[destinationTabID] = SplitTree(view: surface)
+    focusedSurfaceIDByTab[destinationTabID] = surfaceID
+    previousFocusedSurfaceIDByTab.removeValue(forKey: destinationTabID)
+    moveAgentActivity(surfaceID: surfaceID, from: sourceTabID, to: destinationTabID)
+
+    if updatedSourceTree.isEmpty {
+      removeTabMetadata(for: sourceTabID)
+      spaceManager.tabManager(for: sourceSpace.id)?.closeTab(sourceTabID)
+    } else {
+      trees[sourceTabID] = updatedSourceTree
+      updateSourceTabFocusAfterRemovingSurface(
+        surfaceID,
+        nextSurface: nextSourceSurface ?? updatedSourceTree.root?.leftmostLeaf(),
+        from: sourceTabID
+      )
+      updateRunningState(for: sourceTabID)
+      updateTabTitle(for: sourceTabID)
+    }
+
+    updateRunningState(for: destinationTabID)
+    updateTabTitle(for: destinationTabID)
+    _ = applySelectedSpace(sourceSpace.id)
+    applySelectedTab(destinationTabID, in: sourceSpace.id)
+    focusSurface(surface, in: destinationTabID)
+    syncFocus(windowActivity)
+    sessionDidChange()
   }
 
   @discardableResult
@@ -2386,11 +2432,7 @@ final class TerminalHostState {
     recentStructuredNotificationsBySurfaceID.removeValue(forKey: surfaceID)
 
     if newTree.isEmpty {
-      trees.removeValue(forKey: tabID)
-      focusedSurfaceIDByTab.removeValue(forKey: tabID)
-      previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
-      agentActivityByTab.removeValue(forKey: tabID)
-      agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+      removeTabMetadata(for: tabID)
       spaceManager.space(for: tabID)
         .flatMap { spaceManager.tabManager(for: $0.id) }?
         .closeTab(tabID)
@@ -2445,39 +2487,69 @@ final class TerminalHostState {
       context: context,
       managesWindowAppearance: false
     )
-    configureBridgeCallbacks(for: view, tabID: tabID)
-    configureSurfaceCallbacks(for: view, tabID: tabID)
+    configureBridgeCallbacks(for: view)
+    configureSurfaceCallbacks(for: view)
     surfaces[view.id] = view
     return view
   }
 
-  private func configureBridgeCallbacks(
-    for view: GhosttySurfaceView,
-    tabID: TerminalTabID
-  ) {
-    view.bridge.onTitleChange = { [weak self] _ in
-      guard let self else { return }
+  private func configureBridgeCallbacks(for view: GhosttySurfaceView) {
+    configureBridgeTitleCallbacks(for: view)
+    configureBridgePaneCallbacks(for: view)
+    configureBridgeLifecycleCallbacks(for: view)
+  }
+
+  private func configureBridgeTitleCallbacks(for view: GhosttySurfaceView) {
+    view.bridge.onTitleChange = { [weak self, weak view] _ in
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return
+      }
       self.updateTabTitle(for: tabID)
       self.sessionDidChange()
     }
-    view.bridge.onPathChange = { [weak self] in
-      guard let self else { return }
+    view.bridge.onPathChange = { [weak self, weak view] in
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return
+      }
       self.updateTabTitle(for: tabID)
       self.sessionDidChange()
     }
-    view.bridge.onTabTitleChange = { [weak self] title in
-      guard let self else { return false }
+    view.bridge.onTabTitleChange = { [weak self, weak view] title in
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return false
+      }
       self.setLockedTabTitle(title, for: tabID)
       return true
     }
     view.bridge.onPromptTabTitle = { [weak self, weak view] in
-      guard let self, let view else { return }
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return
+      }
       self.promptTabTitle(for: tabID, using: view)
     }
     view.bridge.onCopyTitleToClipboard = { [weak self, weak view] in
       guard let self, let view else { return false }
       return self.copyTitleToClipboard(for: view.id)
     }
+  }
+
+  private func configureBridgePaneCallbacks(for view: GhosttySurfaceView) {
     view.bridge.onSplitAction = { [weak self, weak view] action in
       guard let self, let view else { return false }
       return self.performSplitAction(action, for: view.id)
@@ -2487,11 +2559,25 @@ final class TerminalHostState {
       self.emit(.newTabRequested(inheritingFromSurfaceID: view?.id))
       return true
     }
-    view.bridge.onCloseTab = { [weak self] _ in
-      guard let self else { return false }
+    view.bridge.onMoveSurfaceToNewTab = { [weak self, weak view] in
+      guard let self, let view else { return false }
+      self.emit(.moveSurfaceToNewTabRequested(view.id))
+      return true
+    }
+    view.bridge.onCloseTab = { [weak self, weak view] _ in
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return false
+      }
       self.requestCloseTab(tabID)
       return true
     }
+  }
+
+  private func configureBridgeLifecycleCallbacks(for view: GhosttySurfaceView) {
     view.bridge.onGotoTab = { [weak self] target in
       guard let self else { return false }
       guard let mappedTarget = self.mapGotoTabTarget(target) else { return false }
@@ -2503,8 +2589,14 @@ final class TerminalHostState {
       self.emit(.commandPaletteToggleRequested)
       return true
     }
-    view.bridge.onProgressReport = { [weak self] _ in
-      guard let self else { return }
+    view.bridge.onProgressReport = { [weak self, weak view] _ in
+      guard
+        let self,
+        let view,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return
+      }
       self.updateRunningState(for: tabID)
     }
     view.bridge.onCommandFinished = { [weak self, weak view] in
@@ -2526,16 +2618,20 @@ final class TerminalHostState {
     }
   }
 
-  private func configureSurfaceCallbacks(
-    for view: GhosttySurfaceView,
-    tabID: TerminalTabID
-  ) {
+  private func configureSurfaceCallbacks(for view: GhosttySurfaceView) {
     view.onDirectInteraction = { [weak self, weak view] in
       guard let self, let view else { return }
       self.handleDirectInteraction(on: view.id)
     }
     view.onFocusChange = { [weak self, weak view] focused in
-      guard let self, let view, focused else { return }
+      guard
+        let self,
+        let view,
+        focused,
+        let tabID = self.tabID(containing: view.id)
+      else {
+        return
+      }
       self.applyFocusedSurface(view.id, in: tabID)
       self.updateTabTitle(for: tabID)
       self.updateRunningState(for: tabID)
@@ -2575,6 +2671,18 @@ final class TerminalHostState {
   private func currentFocusedSurfaceID() -> UUID? {
     guard let selectedTabID = spaceManager.selectedTabID else { return nil }
     return focusedSurfaceIDByTab[selectedTabID]
+  }
+
+  private func createTabRecord(
+    in spaceID: TerminalSpaceID,
+    selecting: Bool = true
+  ) -> TerminalTabID? {
+    guard let tabManager = spaceManager.tabManager(for: spaceID) else { return nil }
+    return tabManager.createTab(
+      title: "Terminal \(nextTabIndex(in: spaceID))",
+      icon: "terminal",
+      selecting: selecting
+    )
   }
 
   private func inheritedSurfaceID(in spaceID: TerminalSpaceID) -> UUID? {
@@ -2914,11 +3022,7 @@ final class TerminalHostState {
       surface.closeSurface()
       surfaces.removeValue(forKey: surface.id)
     }
-    agentActivityByTab.removeValue(forKey: tabID)
-    agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
-    focusedSurfaceIDByTab.removeValue(forKey: tabID)
-    previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
-    previousSelectedTabIDBySpace = previousSelectedTabIDBySpace.filter { $0.value != tabID }
+    clearTabState(for: tabID)
   }
 
   private func notifications(for tabID: TerminalTabID) -> [UUID: [PaneNotification]] {
@@ -3045,6 +3149,53 @@ final class TerminalHostState {
       }
     }
     return .index(raw)
+  }
+
+  private func moveAgentActivity(
+    surfaceID: UUID,
+    from sourceTabID: TerminalTabID,
+    to destinationTabID: TerminalTabID
+  ) {
+    guard agentActivitySurfaceIDByTab[sourceTabID] == surfaceID else { return }
+    let activity = agentActivityByTab[sourceTabID]
+    agentActivityByTab.removeValue(forKey: sourceTabID)
+    agentActivitySurfaceIDByTab.removeValue(forKey: sourceTabID)
+    if let activity {
+      agentActivityByTab[destinationTabID] = activity
+      agentActivitySurfaceIDByTab[destinationTabID] = surfaceID
+    }
+  }
+
+  private func updateSourceTabFocusAfterRemovingSurface(
+    _ surfaceID: UUID,
+    nextSurface: GhosttySurfaceView?,
+    from tabID: TerminalTabID
+  ) {
+    if focusedSurfaceIDByTab[tabID] == surfaceID {
+      if let nextSurface {
+        focusedSurfaceIDByTab[tabID] = nextSurface.id
+      } else {
+        focusedSurfaceIDByTab.removeValue(forKey: tabID)
+      }
+      previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
+      return
+    }
+    if previousFocusedSurfaceIDByTab[tabID] == surfaceID {
+      previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
+    }
+  }
+
+  private func removeTabMetadata(for tabID: TerminalTabID) {
+    trees.removeValue(forKey: tabID)
+    clearTabState(for: tabID)
+  }
+
+  private func clearTabState(for tabID: TerminalTabID) {
+    agentActivityByTab.removeValue(forKey: tabID)
+    agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
+    focusedSurfaceIDByTab.removeValue(forKey: tabID)
+    previousFocusedSurfaceIDByTab.removeValue(forKey: tabID)
+    previousSelectedTabIDBySpace = previousSelectedTabIDBySpace.filter { $0.value != tabID }
   }
 
   private func nextTabIndex(in spaceID: TerminalSpaceID) -> Int {

--- a/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
@@ -142,6 +142,7 @@ struct TerminalWindowFeature {
     case floatingSidebarVisibilityChanged(Bool)
     case navigateSearchMenuItemSelected(GhosttySearchDirection)
     case newTabButtonTapped(inheritingFromSurfaceID: UUID?)
+    case moveSurfaceToNewTabRequested(UUID)
     case nextSpaceRequested
     case nextTabMenuItemSelected
     case pinnedTabOrderChanged([TerminalTabID])
@@ -210,6 +211,9 @@ struct TerminalWindowFeature {
           case .previous:
             return .send(.previousTabMenuItemSelected)
           }
+
+        case .moveSurfaceToNewTabRequested(let surfaceID):
+          return .send(.moveSurfaceToNewTabRequested(surfaceID))
 
         case .newTabRequested(let inheritingFromSurfaceID):
           return .send(.newTabButtonTapped(inheritingFromSurfaceID: inheritingFromSurfaceID))
@@ -312,6 +316,10 @@ struct TerminalWindowFeature {
       case .newTabButtonTapped(let inheritingFromSurfaceID):
         analyticsClient.capture("terminal_tab_created")
         return sendCommand(.createTab(inheritingFromSurfaceID: inheritingFromSurfaceID))
+
+      case .moveSurfaceToNewTabRequested(let surfaceID):
+        analyticsClient.capture("terminal_tab_created")
+        return sendCommand(.moveSurfaceToNewTab(surfaceID))
 
       case .nextSpaceRequested:
         return sendCommand(.nextSpace)

--- a/apps/mac/supatermTests/GhosttySurfaceViewContextMenuTests.swift
+++ b/apps/mac/supatermTests/GhosttySurfaceViewContextMenuTests.swift
@@ -36,6 +36,7 @@ struct GhosttySurfaceViewContextMenuTests {
       "Split Left",
       "Split Down",
       "Split Up",
+      "Move to New Tab",
       "Close Pane",
       "Reset Terminal",
       "Change Tab Title...",
@@ -46,5 +47,14 @@ struct GhosttySurfaceViewContextMenuTests {
       #expect(item.image != nil)
       #expect(item.image?.accessibilityDescription == item.title)
     }
+  }
+
+  @Test
+  func contextMenuIncludesMoveToNewTabBeforeClosePane() {
+    let menu = GhosttySurfaceView.contextMenu(hasSelection: false)
+    let titles = menu.items.map(\.title)
+
+    #expect(titles.firstIndex(of: "Move to New Tab") == 6)
+    #expect(titles.firstIndex(of: "Close Pane") == 7)
   }
 }

--- a/apps/mac/supatermTests/SPTargetResolverTests.swift
+++ b/apps/mac/supatermTests/SPTargetResolverTests.swift
@@ -135,6 +135,7 @@ struct SPTargetResolverTests {
 
     #expect(target == .pane(windowIndex: 2, spaceIndex: 1, tabIndex: 2, paneIndex: 1))
   }
+
 }
 
 private func treeSnapshot() -> SupatermTreeSnapshot {

--- a/apps/mac/supatermTests/SupatermDebugSnapshotResolverTests.swift
+++ b/apps/mac/supatermTests/SupatermDebugSnapshotResolverTests.swift
@@ -81,7 +81,7 @@ struct SupatermDebugSnapshotResolverTests {
   }
 
   @Test
-  func resolveReturnsTabContextAndProblemWhenPaneIsMissing() {
+  func resolveReturnsProblemWhenPaneIsMissing() {
     let spaceID = UUID(uuidString: "6C6B0B59-B32D-4F5B-B8FD-F6D6D26924B2")!
     let tabID = UUID(uuidString: "9B9391CD-A14D-4FC8-AFA3-03A8E5DBA04A")!
     let context = SupatermCLIContext(
@@ -122,23 +122,74 @@ struct SupatermDebugSnapshotResolverTests {
       context: context
     )
 
-    #expect(
-      resolution.currentTarget
-        == .init(
-          windowIndex: 1,
-          spaceIndex: 1,
-          spaceID: spaceID,
-          spaceName: "A",
-          tabIndex: 1,
-          tabID: tabID,
-          tabTitle: "shell",
-          paneIndex: nil,
-          paneID: nil
-        )
+    _ = spaceID
+    _ = tabID
+    #expect(resolution.currentTarget == nil)
+    #expect(resolution.problems == ["Context pane \(context.surfaceID.uuidString) was not found."])
+  }
+
+  @Test
+  func resolveUsesLivePaneLocationWhenContextTabIsStale() {
+    let oldTabID = UUID(uuidString: "9B9391CD-A14D-4FC8-AFA3-03A8E5DBA04A")!
+    let newTabID = UUID(uuidString: "B841A963-E06A-4B72-8C53-F496BB944164")!
+    let paneID = UUID(uuidString: "51BCF751-312F-43A3-B2D4-138E76618AE2")!
+    let context = SupatermCLIContext(surfaceID: paneID, tabID: oldTabID)
+    let pane = SupatermAppDebugSnapshot.Pane(
+      index: 1,
+      id: paneID,
+      isFocused: true,
+      displayTitle: "shell",
+      pwd: "/tmp",
+      isReadOnly: false,
+      hasSecureInput: false,
+      bellCount: 0,
+      isRunning: true,
+      progressState: "indeterminate",
+      progressValue: nil,
+      needsCloseConfirmation: false,
+      lastCommandExitCode: nil,
+      lastCommandDurationMs: nil,
+      lastChildExitCode: nil,
+      lastChildExitTimeMs: nil
     )
-    #expect(
-      resolution.problems
-        == ["Context pane \(context.surfaceID.uuidString) was not found in tab \(tabID.uuidString)."]
+    let tab = SupatermAppDebugSnapshot.Tab(
+      index: 2,
+      id: newTabID,
+      title: "shell",
+      isSelected: true,
+      isPinned: false,
+      isDirty: true,
+      isTitleLocked: false,
+      hasRunningActivity: true,
+      hasBell: false,
+      hasReadOnly: false,
+      hasSecureInput: false,
+      panes: [pane]
     )
+    let space = SupatermAppDebugSnapshot.Space(
+      index: 1,
+      id: UUID(uuidString: "6B537788-BE46-4D8F-9BA9-D2A60A70B468")!,
+      name: "A",
+      isSelected: true,
+      tabs: [tab]
+    )
+    let window = SupatermAppDebugSnapshot.Window(
+      index: 1,
+      isKey: true,
+      isVisible: true,
+      spaces: [space]
+    )
+
+    let resolution = SupatermDebugSnapshotResolver.resolve(
+      windows: [window],
+      context: context
+    )
+    let problem =
+      "Context tab \(oldTabID.uuidString) is stale. "
+      + "Pane \(paneID.uuidString) now belongs to tab \(newTabID.uuidString)."
+
+    #expect(resolution.currentTarget?.tabID == newTabID)
+    #expect(resolution.currentTarget?.paneID == paneID)
+    #expect(resolution.problems == [problem])
   }
 }

--- a/apps/mac/supatermTests/TerminalHostStateSurfaceMoveTests.swift
+++ b/apps/mac/supatermTests/TerminalHostStateSurfaceMoveTests.swift
@@ -1,0 +1,93 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+@testable import supaterm
+
+@MainActor
+struct TerminalHostStateSurfaceMoveTests {
+  @Test
+  func movingPaneFromSplitCreatesNewTabWithSameSurfaceAndMovesTabState() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+
+      let sourceTabID = try #require(host.selectedTabID)
+      let sourceSurface = try #require(host.selectedSurfaceView)
+      let secondPane = try host.createPane(
+        .init(
+          command: nil,
+          direction: .right,
+          focus: false,
+          equalize: false,
+          target: .contextPane(sourceSurface.id)
+        )
+      )
+      _ = try host.notify(
+        .init(
+          body: "Need approval",
+          subtitle: "",
+          target: .contextPane(sourceSurface.id),
+          title: nil
+        )
+      )
+      #expect(host.setAgentActivity(.codex(.running, detail: "Thinking"), for: sourceSurface.id))
+
+      host.handleCommand(.moveSurfaceToNewTab(sourceSurface.id))
+
+      let destinationTabID = try #require(host.selectedTabID)
+
+      #expect(destinationTabID != sourceTabID)
+      #expect(host.splitTree(for: sourceTabID).leaves().map(\.id) == [secondPane.paneID])
+      #expect(host.splitTree(for: destinationTabID).leaves().map(\.id) == [sourceSurface.id])
+      #expect(host.selectedSurfaceView === sourceSurface)
+      #expect(host.unreadNotificationCount(for: sourceTabID) == 0)
+      #expect(host.unreadNotificationCount(for: destinationTabID) == 1)
+      #expect(host.unreadNotifiedSurfaceIDs(in: destinationTabID) == Set([sourceSurface.id]))
+      #expect(host.agentActivity(for: sourceTabID) == nil)
+      #expect(host.agentActivity(for: destinationTabID) == .codex(.running, detail: "Thinking"))
+
+      sourceSurface.bridge.state.title = "tail -f"
+      sourceSurface.bridge.onTitleChange?("tail -f")
+
+      #expect(host.spaceManager.tab(for: destinationTabID)?.title == "tail -f")
+      #expect(host.spaceManager.tab(for: sourceTabID)?.title != "tail -f")
+    }
+  }
+
+  @Test
+  func movingOnlyPaneRemovesSourceTabWithoutClosingSurface() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+
+      let sourceTabID = try #require(host.selectedTabID)
+      let sourceSurface = try #require(host.selectedSurfaceView)
+      let surfaceHandle = try #require(sourceSurface.surface)
+
+      host.handleCommand(.moveSurfaceToNewTab(sourceSurface.id))
+
+      let destinationTabID = try #require(host.selectedTabID)
+      let focusResult = try host.focusPane(.contextPane(sourceSurface.id))
+
+      #expect(destinationTabID != sourceTabID)
+      #expect(host.tabs.count == 1)
+      #expect(host.spaceManager.tab(for: sourceTabID) == nil)
+      #expect(host.splitTree(for: destinationTabID).leaves().map(\.id) == [sourceSurface.id])
+      #expect(host.selectedSurfaceView === sourceSurface)
+      #expect(sourceSurface.surface == surfaceHandle)
+      #expect(sourceSurface.surface != nil)
+      #expect(focusResult.target.tabID == destinationTabID.rawValue)
+      #expect(focusResult.target.paneID == sourceSurface.id)
+    }
+  }
+}

--- a/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
@@ -82,6 +82,23 @@ struct TerminalWindowFeatureTests {
   }
 
   @Test
+  func clientMoveSurfaceEventRoutesIntoMoveCommand() async {
+    let recorder = TerminalCommandRecorder()
+    let surfaceID = UUID()
+
+    let store = TestStore(initialState: TerminalWindowFeature.State()) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { recorder.record($0) }
+    }
+
+    await store.send(.clientEvent(.moveSurfaceToNewTabRequested(surfaceID)))
+    await store.receive(\.moveSurfaceToNewTabRequested)
+
+    #expect(recorder.commands == [.moveSurfaceToNewTab(surfaceID)])
+  }
+
+  @Test
   func closeTabRequestedAsksHostToResolveClose() async {
     let recorder = TerminalCommandRecorder()
     let tabID = TerminalTabID()
@@ -852,6 +869,22 @@ struct TerminalWindowFeatureTests {
     )
 
     #expect(recorder.commands == [expected])
+  }
+
+  @Test
+  func moveSurfaceToNewTabRequestedSendsMoveCommand() async {
+    let recorder = TerminalCommandRecorder()
+    let surfaceID = UUID()
+
+    let store = TestStore(initialState: TerminalWindowFeature.State()) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { recorder.record($0) }
+    }
+
+    await store.send(.moveSurfaceToNewTabRequested(surfaceID))
+
+    #expect(recorder.commands == [.moveSurfaceToNewTab(surfaceID)])
   }
 
   @Test

--- a/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
@@ -636,6 +636,32 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
+  func claudeEventsFollowMovedSurfaceWhenContextTabIsStale() throws {
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.registry.handleAgentHook(
+      ClaudeHookFixtures.request(ClaudeHookFixtures.sessionStart, context: harness.context)
+    )
+    _ = try harness.registry.handleAgentHook(
+      ClaudeHookFixtures.request(ClaudeHookFixtures.preToolUse, context: harness.context)
+    )
+
+    harness.host.handleCommand(.moveSurfaceToNewTab(harness.context.surfaceID))
+
+    let destinationTabID = try #require(harness.host.selectedTabID)
+    _ = try harness.registry.handleAgentHook(
+      ClaudeHookFixtures.request(ClaudeHookFixtures.notification, context: harness.context)
+    )
+
+    #expect(destinationTabID != harness.tabID)
+    #expect(harness.host.agentActivity(for: harness.tabID) == nil)
+    #expect(harness.host.agentActivity(for: destinationTabID) == .claude(.needsInput))
+    #expect(harness.host.unreadNotificationCount(for: destinationTabID) == 1)
+    #expect(harness.host.unreadNotifiedSurfaceIDs(in: destinationTabID) == Set([harness.context.surfaceID]))
+    #expect(harness.host.latestNotificationText(for: destinationTabID) == "Claude needs your attention")
+  }
+
+  @Test
   func commandFinishedClearsAgentActivityAndStoredSessionRouting() throws {
     let harness = try makeClaudeHookHarness()
 


### PR DESCRIPTION
## Summary

- Problem: panes could not be moved into a fresh tab without recreating the terminal surface.
- Why it matters: moving an active pane should preserve the live terminal session, focus, unread state, and agent activity.
- What changed: the terminal host now rehomes an existing surface into a new tab, the Ghostty bridge exposes the action from the pane context menu, and the related snapshot/window tests cover the move flow.
- What did NOT change (scope boundary): this does not add new socket or CLI behavior, and it does not change how ordinary new-tab or split creation works.

## Rationale

The feature is only correct if the existing surface survives the move. Recreating the pane would drop process state and make the command misleading. The implementation therefore moves the current surface and retargets tab metadata around it instead of spawning a replacement.

## User-visible / Behavior Changes

- Pane context menus can move the selected pane into a new tab without restarting that terminal session.
- Focus moves to the new tab with the same surface still active.
- Unread notifications, tab title updates, and agent activity follow the moved surface.

## Diagram (if applicable)

```text
Before:
[move pane to new tab] -> [new tab created with a fresh surface] -> [original live pane cannot be preserved]

After:
[move pane to new tab] -> [existing surface is reattached into a new tab] -> [session, focus, and tab state stay intact]
```

## Human Verification

- Verified scenarios: ran `make mac-lint`; ran targeted macOS tests for `TerminalHostStateSurfaceMoveTests`, `TerminalWindowFeatureTests`, `TerminalWindowRegistryTests`, `GhosttySurfaceViewContextMenuTests`, `SupatermDebugSnapshotResolverTests`, and `SPTargetResolverTests`; the pushed branch also passed the pre-push hook with `make web-check`, `make web-test`, and `make mac-test`.
- Edge cases checked: moving a pane out of a split leaves the source tab with the remaining pane; moving the only pane removes the source tab without closing the live surface; unread notification and agent activity state move with the surface.
- What you did **not** verify: manual interactive QA in the macOS app after the latest `main` changes, because the branch is currently paused in a conflict during rebase.
- How can a human manually verify this: open a split tab, start a long-running command in one pane, use the pane context menu to move that pane into a new tab, then confirm the command continues in the new tab and the source tab keeps only the remaining pane.
