### PR TITLE
SUP-39 Add SSH hook notification fallback

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermClaudeHookSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermClaudeHookSettings.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 public enum SupatermClaudeHookSettings {
-  public static let command = SupatermManagedHookCommand.receiveHookCommand(for: .claude)
+  public static func command(for eventName: SupatermAgentHookEventName) -> String {
+    SupatermManagedHookCommand.receiveHookCommand(for: .claude, eventName: eventName)
+  }
 
   public static func jsonString() throws -> String {
     let encoder = JSONEncoder()
@@ -29,12 +31,12 @@ public enum SupatermClaudeHookSettings {
 
   private struct Settings: Encodable {
     let hooks: [String: [HookGroup]] = [
-      "Notification": [.init(matcher: "", hooks: [.init(command: command, timeout: 10)])],
-      "PreToolUse": [.init(matcher: "", hooks: [.init(command: command, timeout: 5, isAsync: true)])],
-      "SessionEnd": [.init(matcher: "", hooks: [.init(command: command, timeout: 1)])],
-      "SessionStart": [.init(matcher: "", hooks: [.init(command: command, timeout: 10)])],
-      "Stop": [.init(hooks: [.init(command: command, timeout: 10)])],
-      "UserPromptSubmit": [.init(hooks: [.init(command: command, timeout: 10)])],
+      "Notification": [.init(matcher: "", hooks: [.init(command: SupatermClaudeHookSettings.command(for: .notification), timeout: 10)])],
+      "PreToolUse": [.init(matcher: "", hooks: [.init(command: SupatermClaudeHookSettings.command(for: .preToolUse), timeout: 5, isAsync: true)])],
+      "SessionEnd": [.init(matcher: "", hooks: [.init(command: SupatermClaudeHookSettings.command(for: .sessionEnd), timeout: 1)])],
+      "SessionStart": [.init(matcher: "", hooks: [.init(command: SupatermClaudeHookSettings.command(for: .sessionStart), timeout: 10)])],
+      "Stop": [.init(hooks: [.init(command: SupatermClaudeHookSettings.command(for: .stop), timeout: 10)])],
+      "UserPromptSubmit": [.init(hooks: [.init(command: SupatermClaudeHookSettings.command(for: .userPromptSubmit), timeout: 10)])],
     ]
   }
 

--- a/apps/mac/SupatermCLIShared/SupatermCodexHookSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermCodexHookSettings.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 public enum SupatermCodexHookSettings {
-  public static let command = SupatermManagedHookCommand.receiveHookCommand(for: .codex)
+  public static func command(for eventName: SupatermAgentHookEventName) -> String {
+    SupatermManagedHookCommand.receiveHookCommand(for: .codex, eventName: eventName)
+  }
 
   public static func jsonString() throws -> String {
     let encoder = JSONEncoder()
@@ -29,11 +31,11 @@ public enum SupatermCodexHookSettings {
 
   private struct Settings: Encodable {
     let hooks: [String: [HookGroup]] = [
-      "PostToolUse": [.init(hooks: [.init(command: command, timeout: 5)])],
-      "PreToolUse": [.init(hooks: [.init(command: command, timeout: 5)])],
-      "SessionStart": [.init(matcher: "startup|resume", hooks: [.init(command: command, timeout: 10)])],
-      "Stop": [.init(hooks: [.init(command: command, timeout: 10)])],
-      "UserPromptSubmit": [.init(hooks: [.init(command: command, timeout: 10)])],
+      "PostToolUse": [.init(hooks: [.init(command: SupatermCodexHookSettings.command(for: .postToolUse), timeout: 5)])],
+      "PreToolUse": [.init(hooks: [.init(command: SupatermCodexHookSettings.command(for: .preToolUse), timeout: 5)])],
+      "SessionStart": [.init(matcher: "startup|resume", hooks: [.init(command: SupatermCodexHookSettings.command(for: .sessionStart), timeout: 10)])],
+      "Stop": [.init(hooks: [.init(command: SupatermCodexHookSettings.command(for: .stop), timeout: 10)])],
+      "UserPromptSubmit": [.init(hooks: [.init(command: SupatermCodexHookSettings.command(for: .userPromptSubmit), timeout: 10)])],
     ]
   }
 

--- a/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
+++ b/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
@@ -2,18 +2,18 @@ import Foundation
 
 public enum SupatermManagedHookCommand {
   public static func receiveHookCommand(for agent: SupatermAgentKind) -> String {
-    #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue) || true"#
+    #"[ -n "${SUPATERM_CLI_PATH:-}" ] && \#(receiveAgentHookCommand(for: agent)) || true"#
   }
 
   public static func receiveHookCommand(
     for agent: SupatermAgentKind,
     eventName: SupatermAgentHookEventName
   ) -> String {
-    guard let fallbackCommand = terminalNotificationCommand(for: agent, eventName: eventName) else {
+    guard let fallbackBody = fallbackNotificationBody(for: eventName) else {
       return receiveHookCommand(for: agent)
     }
     return #"""
-if [ -n "${SUPATERM_CLI_PATH:-}" ]; then "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue); else \#(fallbackCommand); fi || true
+if [ -n "${SUPATERM_CLI_PATH:-}" ]; then \#(receiveAgentHookCommand(for: agent)); else \#(terminalNotificationCommand(title: agent.notificationTitle, body: fallbackBody)); fi || true
 """#
   }
 
@@ -39,25 +39,20 @@ if [ -n "${SUPATERM_CLI_PATH:-}" ]; then "$SUPATERM_CLI_PATH" agent receive-agen
     return trimmed
   }
 
-  private static func terminalNotificationCommand(
-    for agent: SupatermAgentKind,
-    eventName: SupatermAgentHookEventName
-  ) -> String? {
-    guard let fallback = fallbackNotification(for: agent, eventName: eventName) else {
-      return nil
-    }
-    return #"printf '\033]777;notify;%s;%s\a' \#(shellSingleQuoted(fallback.title)) \#(shellSingleQuoted(fallback.body))"#
+  private static func receiveAgentHookCommand(for agent: SupatermAgentKind) -> String {
+    #""$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue)"#
   }
 
-  private static func fallbackNotification(
-    for agent: SupatermAgentKind,
-    eventName: SupatermAgentHookEventName
-  ) -> (title: String, body: String)? {
+  private static func terminalNotificationCommand(title: String, body: String) -> String {
+    #"printf '\033]777;notify;%s;%s\a' \#(shellSingleQuoted(title)) \#(shellSingleQuoted(body))"#
+  }
+
+  private static func fallbackNotificationBody(for eventName: SupatermAgentHookEventName) -> String? {
     switch eventName {
     case .notification:
-      return (agent.notificationTitle, "Needs input")
+      return "Needs input"
     case .stop:
-      return (agent.notificationTitle, "Turn complete")
+      return "Turn complete"
     case .postToolUse, .preToolUse, .sessionEnd, .sessionStart, .unsupported(_), .userPromptSubmit:
       return nil
     }

--- a/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
+++ b/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
@@ -5,6 +5,18 @@ public enum SupatermManagedHookCommand {
     #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue) || true"#
   }
 
+  public static func receiveHookCommand(
+    for agent: SupatermAgentKind,
+    eventName: SupatermAgentHookEventName
+  ) -> String {
+    guard let fallbackCommand = terminalNotificationCommand(for: agent, eventName: eventName) else {
+      return receiveHookCommand(for: agent)
+    }
+    return #"""
+if [ -n "${SUPATERM_CLI_PATH:-}" ]; then "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue); else \#(fallbackCommand); fi || true
+"""#
+  }
+
   public static func installArguments(for agent: SupatermAgentKind) -> [String] {
     ["agent", "install-hook", agent.rawValue]
   }
@@ -25,5 +37,33 @@ public enum SupatermManagedHookCommand {
       return nil
     }
     return trimmed
+  }
+
+  private static func terminalNotificationCommand(
+    for agent: SupatermAgentKind,
+    eventName: SupatermAgentHookEventName
+  ) -> String? {
+    guard let fallback = fallbackNotification(for: agent, eventName: eventName) else {
+      return nil
+    }
+    return #"printf '\033]777;notify;%s;%s\a' \#(shellSingleQuoted(fallback.title)) \#(shellSingleQuoted(fallback.body))"#
+  }
+
+  private static func fallbackNotification(
+    for agent: SupatermAgentKind,
+    eventName: SupatermAgentHookEventName
+  ) -> (title: String, body: String)? {
+    switch eventName {
+    case .notification:
+      return (agent.notificationTitle, "Needs input")
+    case .stop:
+      return (agent.notificationTitle, "Turn complete")
+    case .postToolUse, .preToolUse, .sessionEnd, .sessionStart, .unsupported(_), .userPromptSubmit:
+      return nil
+    }
+  }
+
+  private static func shellSingleQuoted(_ value: String) -> String {
+    "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
   }
 }

--- a/apps/mac/sp/SPHelp.swift
+++ b/apps/mac/sp/SPHelp.swift
@@ -214,7 +214,7 @@ enum SPHelp {
       sp agent install-hook claude
       sp agent remove-hook claude
       printf '{"hook_event_name":"Notification","message":"Claude needs your attention"}' | sp agent receive-agent-hook --agent claude
-      \(SupatermClaudeHookSettings.command)
+      \(SupatermClaudeHookSettings.command(for: .notification))
     """
 
   static let installAgentHookDiscussion = """

--- a/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
@@ -57,7 +57,7 @@ struct ClaudeSettingsInstallerTests {
       .compactMap { $0["command"] as? String }
 
     #expect(commands.contains("echo keep"))
-    #expect(commands.contains(SupatermClaudeHookSettings.command))
+    #expect(commands.contains(SupatermClaudeHookSettings.command(for: .notification)))
   }
 
   @Test
@@ -75,7 +75,7 @@ struct ClaudeSettingsInstallerTests {
               "hooks": [
                 {
                   "async": false,
-                  "command": "\(SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\""))",
+                  "command": \(try jsonStringLiteral(SupatermClaudeHookSettings.command(for: .preToolUse))),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -95,7 +95,7 @@ struct ClaudeSettingsInstallerTests {
     let hooks = try #require(groups.last?["hooks"] as? [[String: Any]])
     let supatermHook = try #require(hooks.last)
 
-    #expect(supatermHook["command"] as? String == SupatermClaudeHookSettings.command)
+    #expect(supatermHook["command"] as? String == SupatermClaudeHookSettings.command(for: .preToolUse))
     #expect(supatermHook["timeout"] as? Int == 5)
     #expect(supatermHook["async"] as? Bool == true)
   }
@@ -105,7 +105,7 @@ struct ClaudeSettingsInstallerTests {
     let homeDirectoryURL = try temporaryHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
 
-    let escapedCommand = SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermClaudeHookSettings.command(for: .notification))
     try writeSettings(
       """
       {
@@ -115,7 +115,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 10,
                   "type": "command"
                 }
@@ -125,7 +125,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 20,
                   "type": "command"
                 }
@@ -144,7 +144,7 @@ struct ClaudeSettingsInstallerTests {
     let commands = try notificationGroupsValue(in: object)
       .flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
       .compactMap { $0["command"] as? String }
-      .filter { $0 == SupatermClaudeHookSettings.command }
+      .filter { $0 == SupatermClaudeHookSettings.command(for: .notification) }
 
     #expect(commands.count == 1)
   }
@@ -153,7 +153,7 @@ struct ClaudeSettingsInstallerTests {
   func installReplacesExistingSupatermCommand() throws {
     let homeDirectoryURL = try temporaryHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let command = SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermClaudeHookSettings.command(for: .sessionStart))
 
     try writeSettings(
       """
@@ -164,7 +164,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(command)",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -187,7 +187,7 @@ struct ClaudeSettingsInstallerTests {
     #expect(
       commands.filter(AgentHookCommandOwnership.isSupatermManagedCommand).count == 1
     )
-    #expect(commands.contains(SupatermClaudeHookSettings.command))
+    #expect(commands.contains(SupatermClaudeHookSettings.command(for: .sessionStart)))
   }
 
   @Test

--- a/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
@@ -63,7 +63,7 @@ struct CodexSettingsInstallerTests {
       .compactMap { $0["command"] as? String }
 
     #expect(commands.contains("echo keep"))
-    #expect(commands.contains(SupatermCodexHookSettings.command))
+    #expect(commands.contains(SupatermCodexHookSettings.command(for: .preToolUse)))
   }
 
   @Test
@@ -80,7 +80,7 @@ struct CodexSettingsInstallerTests {
               "matcher": ".*",
               "hooks": [
                 {
-                  "command": "\(SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\""))",
+                  "command": \(try jsonStringLiteral(SupatermCodexHookSettings.command(for: .sessionStart))),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -107,7 +107,7 @@ struct CodexSettingsInstallerTests {
     let supatermHook = try #require(hooks.last)
 
     #expect(group["matcher"] as? String == "startup|resume")
-    #expect(supatermHook["command"] as? String == SupatermCodexHookSettings.command)
+    #expect(supatermHook["command"] as? String == SupatermCodexHookSettings.command(for: .sessionStart))
     #expect(supatermHook["timeout"] as? Int == 10)
   }
 
@@ -116,7 +116,7 @@ struct CodexSettingsInstallerTests {
     let homeDirectoryURL = try temporaryCodexHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
 
-    let escapedCommand = SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermCodexHookSettings.command(for: .stop))
     try writeCodexSettings(
       """
       {
@@ -125,7 +125,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 10,
                   "type": "command"
                 }
@@ -134,7 +134,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 20,
                   "type": "command"
                 }
@@ -158,7 +158,7 @@ struct CodexSettingsInstallerTests {
     let commands = try codexEventGroupsValue("Stop", in: object)
       .flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
       .compactMap { $0["command"] as? String }
-      .filter { $0 == SupatermCodexHookSettings.command }
+      .filter { $0 == SupatermCodexHookSettings.command(for: .stop) }
 
     #expect(commands.count == 1)
   }
@@ -167,7 +167,7 @@ struct CodexSettingsInstallerTests {
   func installReplacesExistingSupatermCommand() throws {
     let homeDirectoryURL = try temporaryCodexHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let command = SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermCodexHookSettings.command(for: .stop))
 
     try writeCodexSettings(
       """
@@ -177,7 +177,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(command)",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -205,7 +205,7 @@ struct CodexSettingsInstallerTests {
     #expect(
       commands.filter(AgentHookCommandOwnership.isSupatermManagedCommand).count == 1
     )
-    #expect(commands.contains(SupatermCodexHookSettings.command))
+    #expect(commands.contains(SupatermCodexHookSettings.command(for: .stop)))
   }
 
   @Test

--- a/apps/mac/supatermTests/JSONStringTestSupport.swift
+++ b/apps/mac/supatermTests/JSONStringTestSupport.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+
+func jsonStringLiteral(_ value: String) throws -> String {
+  let data = try JSONEncoder().encode(value)
+  return try #require(String(data: data, encoding: .utf8))
+}
+
+func expectedManagedNotificationCommand(agent: String, title: String, body: String) -> String {
+  #"if [ -n "${SUPATERM_CLI_PATH:-}" ]; then "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent "#
+    + agent
+    + #"; else printf '\033]777;notify;%s;%s\a' "#
+    + "'\(title)'"
+    + " "
+    + "'\(body)'"
+    + "; fi || true"
+}

--- a/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
@@ -5,10 +5,25 @@ import Testing
 
 struct SupatermClaudeHookSettingsTests {
   @Test
-  func commandStaysStable() {
+  func commandStaysStableForNotificationAndStopFallbacks() {
+    let notificationCommand = SupatermClaudeHookSettings.command(for: .notification)
+    let expectedNotification = expectedManagedNotificationCommand(
+      agent: "claude",
+      title: "Claude Code",
+      body: "Needs input"
+    )
+    let stopCommand = SupatermClaudeHookSettings.command(for: .stop)
+    let expectedStop = expectedManagedNotificationCommand(
+      agent: "claude",
+      title: "Claude Code",
+      body: "Turn complete"
+    )
+
     #expect(
-      SupatermClaudeHookSettings.command
-        == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent claude || true"#
+      notificationCommand == expectedNotification
+    )
+    #expect(
+      stopCommand == expectedStop
     )
   }
 
@@ -30,7 +45,17 @@ struct SupatermClaudeHookSettingsTests {
     #expect(try commandHook(in: hooks, event: "Stop")["timeout"] as? Int == 10)
     #expect(try commandHook(in: hooks, event: "UserPromptSubmit")["timeout"] as? Int == 10)
     #expect(
-      try commandHook(in: hooks, event: "Notification")["command"] as? String == SupatermClaudeHookSettings.command)
+      try commandHook(in: hooks, event: "Notification")["command"] as? String
+        == SupatermClaudeHookSettings.command(for: .notification)
+    )
+    #expect(
+      try commandHook(in: hooks, event: "PreToolUse")["command"] as? String
+        == SupatermClaudeHookSettings.command(for: .preToolUse)
+    )
+    #expect(
+      try commandHook(in: hooks, event: "Stop")["command"] as? String
+        == SupatermClaudeHookSettings.command(for: .stop)
+    )
   }
 }
 

--- a/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
@@ -5,10 +5,16 @@ import Testing
 
 struct SupatermCodexHookSettingsTests {
   @Test
-  func commandStaysStable() {
+  func commandStaysStableForStopFallback() {
+    let command = SupatermCodexHookSettings.command(for: .stop)
+    let expected = expectedManagedNotificationCommand(
+      agent: "codex",
+      title: "Codex",
+      body: "Turn complete"
+    )
+
     #expect(
-      SupatermCodexHookSettings.command
-        == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent codex || true"#
+      command == expected
     )
   }
 
@@ -29,6 +35,10 @@ struct SupatermCodexHookSettingsTests {
     #expect(try group(in: hooks, event: "PostToolUse")["matcher"] as? String == nil)
     #expect(try group(in: hooks, event: "PreToolUse")["matcher"] as? String == nil)
     #expect(try group(in: hooks, event: "SessionStart")["matcher"] as? String == "startup|resume")
+    #expect(
+      try commandHook(in: hooks, event: "Stop")["command"] as? String
+        == SupatermCodexHookSettings.command(for: .stop)
+    )
   }
 }
 

--- a/apps/mac/supatermTests/SupatermManagedHookCommandTests.swift
+++ b/apps/mac/supatermTests/SupatermManagedHookCommandTests.swift
@@ -5,18 +5,46 @@ import Testing
 
 struct SupatermManagedHookCommandTests {
   @Test
-  func receiveHookCommandMatchesClaudeSettingsCommand() {
-    #expect(
-      SupatermManagedHookCommand.receiveHookCommand(for: .claude)
-        == SupatermClaudeHookSettings.command
-    )
-  }
-
-  @Test
   func receiveHookCommandBuildsPiCommand() {
     #expect(
       SupatermManagedHookCommand.receiveHookCommand(for: .pi)
         == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent pi || true"#
+    )
+  }
+
+  @Test
+  func notificationEventCommandPrefersStructuredBridgeAndFallsBackToOscNotification() {
+    let command = SupatermManagedHookCommand.receiveHookCommand(for: .claude, eventName: .notification)
+    let expected = expectedManagedNotificationCommand(
+      agent: "claude",
+      title: "Claude Code",
+      body: "Needs input"
+    )
+
+    #expect(
+      command == expected
+    )
+  }
+
+  @Test
+  func stopEventCommandFallsBackToOscCompletionNotification() {
+    let command = SupatermManagedHookCommand.receiveHookCommand(for: .codex, eventName: .stop)
+    let expected = expectedManagedNotificationCommand(
+      agent: "codex",
+      title: "Codex",
+      body: "Turn complete"
+    )
+
+    #expect(
+      command == expected
+    )
+  }
+
+  @Test
+  func nonNotificationEventKeepsStructuredOnlyCommand() {
+    #expect(
+      SupatermManagedHookCommand.receiveHookCommand(for: .claude, eventName: .preToolUse)
+        == SupatermManagedHookCommand.receiveHookCommand(for: .claude)
     )
   }
 
@@ -35,7 +63,7 @@ struct SupatermManagedHookCommandTests {
 
     #expect(
       AgentHookCommandOwnership.isSupatermManagedCommand(
-        SupatermManagedHookCommand.receiveHookCommand(for: .claude)
+        SupatermManagedHookCommand.receiveHookCommand(for: .claude, eventName: .notification)
       )
     )
     #expect(AgentHookCommandOwnership.isSupatermManagedCommand(managedCommand))

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -50,6 +50,7 @@ Claude is the current first-class coding agent integration.
 - On open, Settings reads `~/.claude/settings.json` to reflect whether Supaterm-managed hooks are currently present.
 - The CLI command preserves unrelated settings, removes any existing Supaterm-managed hooks anywhere in the file, and then installs the canonical Supaterm Claude hooks into the user settings file.
 - The installed hook command uses `SUPATERM_CLI_PATH` so the hook bridge targets the bundled `sp` binary injected into Supaterm panes.
+- When `SUPATERM_CLI_PATH` is missing, the managed hook command falls back to emitting an OSC 777 terminal notification for `Notification` and `Stop` so SSH sessions can still raise local Supaterm notifications.
 
 ### Hook Injection
 
@@ -108,6 +109,7 @@ Codex now uses the same app-side bridge and tab-state model.
   - `PreToolUse`
   - `UserPromptSubmit`
   - `Stop`
+- When `SUPATERM_CLI_PATH` is missing, the managed hook command falls back to emitting an OSC 777 terminal notification for `Stop` so SSH sessions can still raise local Supaterm notifications.
 
 ### App Behavior
 


### PR DESCRIPTION
## Summary

- Problem: managed agent hooks only surfaced notifications when `SUPATERM_CLI_PATH` existed, so generic SSH hops dropped agent stop and needs-input notifications.
- Why it matters: remote agent sessions over SSH looked silent even when the terminal could carry notifications natively.
- What changed: managed Claude and Codex hook commands now fall back to OSC 777 notifications for `notification` and `stop` events, while local sessions still use the structured Supaterm hook path.
- What did NOT change (scope boundary): this does not add a remote relay, remote socket bridge, or any broader cross-host notification architecture.

## Rationale

Supaterm already knows how to turn terminal-native desktop notification signals into local unread state and desktop delivery. The narrowest fix for SSH was to emit that native signal when the structured local bridge is unavailable, instead of inventing a second transport or remote control layer.

## User-visible / Behavior Changes

- SSH sessions that do not have `SUPATERM_CLI_PATH` now surface managed agent needs-input and turn-complete notifications through the terminal-native notification path.
- Local managed sessions keep the existing structured hook behavior.
- Non-notification hook events remain structured-only.

## Diagram (if applicable)

```text
Before:
[agent hook over SSH] -> [no SUPATERM_CLI_PATH] -> [no notification]

After:
[agent hook over SSH] -> [no SUPATERM_CLI_PATH] -> [OSC 777 notify] -> [terminal-native notification]
```

## Human Verification

- Verified scenarios: focused tests for managed hook command generation, hook settings JSON, and installer canonicalization; lint; repo pre-push web checks; full mac test suite during push.
- Edge cases checked: `notification` and `stop` use the SSH fallback, other events stay structured-only, and the generated shell command remains stable for settings installation.
- What you did **not** verify: a live end-to-end SSH session producing a desktop notification in the app UI.
- How can a human manually verify this: install managed hooks, start an agent inside an SSH session where `SUPATERM_CLI_PATH` is unset on the remote side, trigger a needs-input or stop event, and confirm the terminal surfaces the notification locally.
