### PR TITLE
Add configurable new-tab insertion position

### DIFF
--- a/apps/mac/SupatermCLIShared/NewTabPosition.swift
+++ b/apps/mac/SupatermCLIShared/NewTabPosition.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public enum NewTabPosition: String, Codable, CaseIterable, Equatable, Hashable, Identifiable, Sendable {
+  case current
+  case end
+
+  public var id: Self {
+    self
+  }
+
+  public var title: String {
+    switch self {
+    case .current:
+      "After Current Tab"
+    case .end:
+      "At End"
+    }
+  }
+}

--- a/apps/mac/SupatermCLIShared/SupatermSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettings.swift
@@ -5,6 +5,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
   public var glowingPaneRingEnabled: Bool
+  public var newTabPosition: NewTabPosition
   public var restoreTerminalLayoutEnabled: Bool
   public var systemNotificationsEnabled: Bool
   public var updateChannel: UpdateChannel
@@ -14,6 +15,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     glowingPaneRingEnabled: Bool = true,
+    newTabPosition: NewTabPosition = .end,
     restoreTerminalLayoutEnabled: Bool = true,
     systemNotificationsEnabled: Bool = false,
     updateChannel: UpdateChannel
@@ -22,6 +24,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.glowingPaneRingEnabled = glowingPaneRingEnabled
+    self.newTabPosition = newTabPosition
     self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
     self.systemNotificationsEnabled = systemNotificationsEnabled
     self.updateChannel = updateChannel
@@ -32,6 +35,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     analyticsEnabled: true,
     crashReportsEnabled: true,
     glowingPaneRingEnabled: true,
+    newTabPosition: .end,
     restoreTerminalLayoutEnabled: true,
     systemNotificationsEnabled: false,
     updateChannel: .stable
@@ -49,6 +53,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     case analyticsEnabled
     case crashReportsEnabled
     case glowingPaneRingEnabled
+    case newTabPosition
     case restoreTerminalLayoutEnabled
     case systemNotificationsEnabled
     case updateChannel
@@ -63,6 +68,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
         return "Allow crash reports."
       case .glowingPaneRingEnabled:
         return "Show a glowing ring around panes with unread attention."
+      case .newTabPosition:
+        return "Choose whether new tabs open after the current tab or at the end."
       case .restoreTerminalLayoutEnabled:
         return "Restore spaces, tabs, and panes on launch."
       case .systemNotificationsEnabled:
@@ -76,6 +83,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
       switch self {
       case .appearanceMode:
         return AppearanceMode.allCases.map(\.rawValue)
+      case .newTabPosition:
+        return NewTabPosition.allCases.map(\.rawValue)
       case .updateChannel:
         return UpdateChannel.allCases.map(\.rawValue)
       default:
@@ -97,6 +106,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
       glowingPaneRingEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .glowingPaneRingEnabled)
           ?? defaults.glowingPaneRingEnabled,
+      newTabPosition:
+        try container.decodeIfPresent(NewTabPosition.self, forKey: .newTabPosition) ?? defaults.newTabPosition,
       restoreTerminalLayoutEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutEnabled)
           ?? defaults.restoreTerminalLayoutEnabled,
@@ -132,6 +143,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
       return .bool(crashReportsEnabled)
     case .glowingPaneRingEnabled:
       return .bool(glowingPaneRingEnabled)
+    case .newTabPosition:
+      return .string(newTabPosition.rawValue)
     case .restoreTerminalLayoutEnabled:
       return .bool(restoreTerminalLayoutEnabled)
     case .systemNotificationsEnabled:

--- a/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
@@ -64,6 +64,7 @@ struct SettingsFeature {
     )
     var crashReportsEnabled = SupatermSettings.default.crashReportsEnabled
     var glowingPaneRingEnabled = SupatermSettings.default.glowingPaneRingEnabled
+    var newTabPosition = SupatermSettings.default.newTabPosition
     var restoreTerminalLayoutEnabled = SupatermSettings.default.restoreTerminalLayoutEnabled
     var selectedTab = Tab.general
     var systemNotificationsEnabled = SupatermSettings.default.systemNotificationsEnabled
@@ -84,6 +85,7 @@ struct SettingsFeature {
     case checkForUpdatesButtonTapped
     case crashReportsEnabledChanged(Bool)
     case glowingPaneRingEnabledChanged(Bool)
+    case newTabPositionSelected(NewTabPosition)
     case restoreTerminalLayoutEnabledChanged(Bool)
     case settingsLoaded(SupatermSettings)
     case systemNotificationsAuthorizationChecked(DesktopNotificationClient.AuthorizationStatus)
@@ -188,6 +190,7 @@ struct SettingsFeature {
         state.analyticsEnabled = supatermSettings.analyticsEnabled
         state.crashReportsEnabled = supatermSettings.crashReportsEnabled
         state.glowingPaneRingEnabled = supatermSettings.glowingPaneRingEnabled
+        state.newTabPosition = supatermSettings.newTabPosition
         state.restoreTerminalLayoutEnabled = supatermSettings.restoreTerminalLayoutEnabled
         state.systemNotificationsEnabled = supatermSettings.systemNotificationsEnabled
         state.updateChannel = supatermSettings.updateChannel
@@ -404,6 +407,10 @@ struct SettingsFeature {
         state.glowingPaneRingEnabled = isEnabled
         return persist(state)
 
+      case .newTabPositionSelected(let newTabPosition):
+        state.newTabPosition = newTabPosition
+        return persist(state)
+
       case .restoreTerminalLayoutEnabledChanged(let isEnabled):
         state.restoreTerminalLayoutEnabled = isEnabled
         return persist(state)
@@ -492,6 +499,7 @@ struct SettingsFeature {
       analyticsEnabled: state.analyticsEnabled,
       crashReportsEnabled: state.crashReportsEnabled,
       glowingPaneRingEnabled: state.glowingPaneRingEnabled,
+      newTabPosition: state.newTabPosition,
       restoreTerminalLayoutEnabled: state.restoreTerminalLayoutEnabled,
       systemNotificationsEnabled: state.systemNotificationsEnabled,
       updateChannel: state.updateChannel

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -188,6 +188,15 @@ private struct SettingsGeneralView: View {
     )
   }
 
+  private var newTabPosition: Binding<NewTabPosition> {
+    Binding(
+      get: { store.newTabPosition },
+      set: { newValue in
+        _ = store.send(.newTabPositionSelected(newValue))
+      }
+    )
+  }
+
   var body: some View {
     Form {
       Section {
@@ -208,6 +217,17 @@ private struct SettingsGeneralView: View {
       }
 
       Section {
+        Picker(selection: newTabPosition) {
+          ForEach(NewTabPosition.allCases) { position in
+            Text(position.title).tag(position)
+          }
+        } label: {
+          SettingsRowLabel(
+            title: "New Tab Position",
+            subtitle: "Choose whether new tabs open after the current tab or at the end."
+          )
+        }
+
         SettingsToggleRow(
           title: "Restore Terminal Layout",
           subtitle: "Reopen tabs, splits, and working directories from your last session.",

--- a/apps/mac/supaterm/Features/Terminal/Models/TerminalTabManager.swift
+++ b/apps/mac/supaterm/Features/Terminal/Models/TerminalTabManager.swift
@@ -3,6 +3,11 @@ import Observation
 @MainActor
 @Observable
 final class TerminalTabManager {
+  enum Insertion: Equatable {
+    case end
+    case after(TerminalTabID)
+  }
+
   var tabs: [TerminalTabItem] = []
   var selectedTabId: TerminalTabID?
 
@@ -22,7 +27,8 @@ final class TerminalTabManager {
     title: String,
     icon: String?,
     isPinned: Bool = false,
-    isTitleLocked: Bool = false
+    isTitleLocked: Bool = false,
+    insertion: Insertion = .end
   ) -> TerminalTabID {
     let tab = TerminalTabItem(
       title: title,
@@ -33,7 +39,7 @@ final class TerminalTabManager {
     if isPinned {
       tabs = pinnedTabs + [tab] + regularTabs
     } else {
-      tabs = pinnedTabs + regularTabs + [tab]
+      tabs.insert(tab, at: insertionIndex(for: insertion))
     }
     selectedTabId = tab.id
     return tab.id
@@ -196,5 +202,20 @@ final class TerminalTabManager {
     }
 
     setVisibleTabs(pinnedTabs + regularTabs)
+  }
+
+  private func insertionIndex(for insertion: Insertion) -> Int {
+    switch insertion {
+    case .end:
+      return tabs.endIndex
+    case .after(let anchorID):
+      guard let anchorIndex = tabs.firstIndex(where: { $0.id == anchorID }) else {
+        return tabs.endIndex
+      }
+      guard !tabs[anchorIndex].isPinned else {
+        return pinnedTabs.count
+      }
+      return tabs.index(after: anchorIndex)
+    }
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -182,6 +182,9 @@ final class TerminalHostState {
   @ObservationIgnored
   private let managesTerminalSurfaces: Bool
   @ObservationIgnored
+  @Shared(.supatermSettings)
+  private var supatermSettings = .default
+  @ObservationIgnored
   private var eventContinuation: AsyncStream<TerminalClient.Event>.Continuation?
   @ObservationIgnored
   @Shared(.terminalSpaceCatalog)
@@ -721,13 +724,17 @@ final class TerminalHostState {
     inheritingFromSurfaceID: UUID? = nil,
     sessionChangesEnabled: Bool = true
   ) -> TerminalTabID? {
-    guard let selectedSpaceID = spaceManager.selectedSpaceID else { return nil }
+    guard let target = resolveLocalCreateTabTarget(inheritingFromSurfaceID: inheritingFromSurfaceID)
+    else {
+      return nil
+    }
     return createTab(
-      in: selectedSpaceID,
+      in: target.spaceID,
       focusing: focusing,
       command: command,
       initialInput: initialInput,
-      inheritingFromSurfaceID: inheritingFromSurfaceID ?? currentFocusedSurfaceID(),
+      inheritingFromSurfaceID: target.inheritedSurfaceID,
+      insertion: resolvedNewTabInsertion(anchorTabID: target.anchorTabID),
       sessionChangesEnabled: sessionChangesEnabled
     )
   }
@@ -740,6 +747,7 @@ final class TerminalHostState {
     initialInput: String? = nil,
     workingDirectory: URL? = nil,
     inheritingFromSurfaceID: UUID? = nil,
+    insertion: TerminalTabManager.Insertion = .end,
     sessionChangesEnabled: Bool = true,
     synchronizesFocus: Bool = true
   ) -> TerminalTabID? {
@@ -750,7 +758,8 @@ final class TerminalHostState {
       : GHOSTTY_SURFACE_CONTEXT_TAB
     let tabID = tabManager.createTab(
       title: "Terminal \(nextTabIndex(in: spaceID))",
-      icon: "terminal"
+      icon: "terminal",
+      insertion: insertion
     )
     let tree = splitTree(
       for: tabID,
@@ -1260,6 +1269,7 @@ final class TerminalHostState {
           initialInput: nil,
           workingDirectory: request.cwd.map { URL(fileURLWithPath: $0, isDirectory: true) },
           inheritingFromSurfaceID: resolvedTarget.inheritedSurfaceID,
+          insertion: resolvedNewTabInsertion(anchorTabID: resolvedTarget.anchorTabID),
           sessionChangesEnabled: false,
           synchronizesFocus: Self.shouldSyncFocusDuringTabCreation(
             targetSpaceID: resolvedTarget.space.id,
@@ -2602,8 +2612,15 @@ final class TerminalHostState {
   }
 
   private struct ResolvedCreateTabTarget {
+    let anchorTabID: TerminalTabID?
     let inheritedSurfaceID: UUID?
     let space: TerminalSpaceItem
+  }
+
+  private struct ResolvedLocalCreateTabTarget {
+    let anchorTabID: TerminalTabID?
+    let inheritedSurfaceID: UUID?
+    let spaceID: TerminalSpaceID
   }
 
   private struct ResolvedCreatePaneTarget {
@@ -2632,6 +2649,7 @@ final class TerminalHostState {
       }
 
       return ResolvedCreateTabTarget(
+        anchorTabID: tabID,
         inheritedSurfaceID: paneID,
         space: space
       )
@@ -2644,9 +2662,49 @@ final class TerminalHostState {
         throw TerminalCreateTabError.spaceNotFound(windowIndex: windowIndex, spaceIndex: spaceIndex)
       }
       return ResolvedCreateTabTarget(
+        anchorTabID: spaceManager.selectedTabID(in: space.id),
         inheritedSurfaceID: inheritedSurfaceID(in: space.id),
         space: space
       )
+    }
+  }
+
+  private func resolveLocalCreateTabTarget(
+    inheritingFromSurfaceID: UUID?
+  ) -> ResolvedLocalCreateTabTarget? {
+    if let inheritingFromSurfaceID,
+      let anchorTabID = tabID(containing: inheritingFromSurfaceID),
+      let space = spaceManager.space(for: anchorTabID)
+    {
+      return .init(
+        anchorTabID: anchorTabID,
+        inheritedSurfaceID: inheritingFromSurfaceID,
+        spaceID: space.id
+      )
+    }
+
+    guard let spaceID = spaceManager.selectedSpaceID else {
+      return nil
+    }
+
+    return .init(
+      anchorTabID: spaceManager.selectedTabID(in: spaceID),
+      inheritedSurfaceID: inheritingFromSurfaceID ?? currentFocusedSurfaceID(),
+      spaceID: spaceID
+    )
+  }
+
+  private func resolvedNewTabInsertion(
+    anchorTabID: TerminalTabID?
+  ) -> TerminalTabManager.Insertion {
+    switch supatermSettings.newTabPosition {
+    case .current:
+      guard let anchorTabID else {
+        return .end
+      }
+      return .after(anchorTabID)
+    case .end:
+      return .end
     }
   }
 

--- a/apps/mac/supatermTests/SettingsFeatureTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureTests.swift
@@ -35,6 +35,7 @@ struct SettingsFeatureTests {
           analyticsEnabled: false,
           crashReportsEnabled: true,
           glowingPaneRingEnabled: false,
+          newTabPosition: .current,
           restoreTerminalLayoutEnabled: false,
           systemNotificationsEnabled: true,
           updateChannel: .tip
@@ -56,6 +57,7 @@ struct SettingsFeatureTests {
         $0.analyticsEnabled = false
         $0.crashReportsEnabled = true
         $0.glowingPaneRingEnabled = false
+        $0.newTabPosition = .current
         $0.restoreTerminalLayoutEnabled = false
         $0.systemNotificationsEnabled = true
         $0.updateChannel = .tip
@@ -226,6 +228,24 @@ struct SettingsFeatureTests {
 
       @Shared(.supatermSettings) var supatermSettings = .default
       #expect(!supatermSettings.restoreTerminalLayoutEnabled)
+    }
+  }
+
+  @Test
+  func newTabPositionSettingPersistsPrefs() async throws {
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let store = TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+
+      await store.send(.newTabPositionSelected(.current)) {
+        $0.newTabPosition = .current
+      }
+
+      @Shared(.supatermSettings) var supatermSettings = .default
+      #expect(supatermSettings.newTabPosition == .current)
     }
   }
 

--- a/apps/mac/supatermTests/SupatermSettingsSchemaTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsSchemaTests.swift
@@ -11,6 +11,7 @@ struct SupatermSettingsSchemaTests {
     let object = try #require(value.objectValue)
     let properties = try #require(object["properties"]?.objectValue)
     let appearanceMode = try #require(properties["appearanceMode"]?.objectValue)
+    let newTabPosition = try #require(properties["newTabPosition"]?.objectValue)
     let updateChannel = try #require(properties["updateChannel"]?.objectValue)
     let expectedKeys = Set(SupatermSettings.CodingKeys.allCases.map(\.rawValue)).union(["$schema"])
 
@@ -19,6 +20,8 @@ struct SupatermSettingsSchemaTests {
     #expect(Set(properties.keys) == expectedKeys)
     #expect(appearanceMode["default"]?.stringValue == SupatermSettings.default.appearanceMode.rawValue)
     #expect(appearanceMode["enum"]?.arrayValue == AppearanceMode.allCases.map { .string($0.rawValue) })
+    #expect(newTabPosition["default"]?.stringValue == SupatermSettings.default.newTabPosition.rawValue)
+    #expect(newTabPosition["enum"]?.arrayValue == NewTabPosition.allCases.map { .string($0.rawValue) })
     #expect(updateChannel["default"]?.stringValue == SupatermSettings.default.updateChannel.rawValue)
     #expect(updateChannel["enum"]?.arrayValue == UpdateChannel.allCases.map { .string($0.rawValue) })
   }

--- a/apps/mac/supatermTests/SupatermSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsTests.swift
@@ -22,6 +22,7 @@ struct SupatermSettingsTests {
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
+    #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
     #expect(prefs.updateChannel == .stable)
@@ -45,6 +46,7 @@ struct SupatermSettingsTests {
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
+    #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
     #expect(prefs.updateChannel == UpdateChannel.stable)
@@ -64,6 +66,7 @@ struct SupatermSettingsTests {
         "appearanceMode",
         "crashReportsEnabled",
         "glowingPaneRingEnabled",
+        "newTabPosition",
         "restoreTerminalLayoutEnabled",
         "systemNotificationsEnabled",
         "updateChannel",
@@ -72,10 +75,33 @@ struct SupatermSettingsTests {
 
   @Test
   func prefsRoundTripWithSchemaURL() throws {
-    let data = try JSONEncoder().encode(SupatermSettings.default)
+    let data = try JSONEncoder().encode(
+      SupatermSettings(
+        appearanceMode: .dark,
+        analyticsEnabled: false,
+        crashReportsEnabled: false,
+        glowingPaneRingEnabled: false,
+        newTabPosition: .current,
+        restoreTerminalLayoutEnabled: false,
+        systemNotificationsEnabled: true,
+        updateChannel: .tip
+      )
+    )
     let prefs = try JSONDecoder().decode(SupatermSettings.self, from: data)
 
-    #expect(prefs == SupatermSettings.default)
+    #expect(
+      prefs
+        == SupatermSettings(
+          appearanceMode: .dark,
+          analyticsEnabled: false,
+          crashReportsEnabled: false,
+          glowingPaneRingEnabled: false,
+          newTabPosition: .current,
+          restoreTerminalLayoutEnabled: false,
+          systemNotificationsEnabled: true,
+          updateChannel: .tip
+        )
+    )
   }
 
   @Test
@@ -95,6 +121,7 @@ struct SupatermSettingsTests {
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
+    #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
     #expect(prefs.updateChannel == .stable)

--- a/apps/mac/supatermTests/TerminalTabManagerTests.swift
+++ b/apps/mac/supatermTests/TerminalTabManagerTests.swift
@@ -163,4 +163,54 @@ struct TerminalTabManagerTests {
     #expect(manager.regularTabs.map(\.id) == [regularB])
     #expect(manager.tabs.map(\.id) == [regularA, pinned, regularB])
   }
+
+  @Test
+  func createTabWithCurrentInsertionAddsAfterSelectedRegularTab() {
+    let manager = TerminalTabManager()
+
+    let first = manager.createTab(title: "Terminal 1", icon: "terminal")
+    let second = manager.createTab(title: "Terminal 2", icon: "terminal")
+
+    let third = manager.createTab(
+      title: "Terminal 3",
+      icon: "terminal",
+      insertion: .after(first)
+    )
+
+    #expect(manager.tabs.map(\.id) == [first, third, second])
+    #expect(manager.selectedTabId == third)
+  }
+
+  @Test
+  func createTabAfterPinnedAnchorInsertsAtFirstRegularPosition() {
+    let manager = TerminalTabManager()
+
+    let pinnedA = manager.createTab(title: "Pinned A", icon: "terminal", isPinned: true)
+    let pinnedB = manager.createTab(title: "Pinned B", icon: "terminal", isPinned: true)
+    let regular = manager.createTab(title: "Regular", icon: "terminal")
+
+    let inserted = manager.createTab(
+      title: "Inserted",
+      icon: "terminal",
+      insertion: .after(pinnedA)
+    )
+
+    #expect(manager.tabs.map(\.id) == [pinnedA, pinnedB, inserted, regular])
+  }
+
+  @Test
+  func createTabWithMissingAnchorFallsBackToEnd() {
+    let manager = TerminalTabManager()
+
+    let first = manager.createTab(title: "Terminal 1", icon: "terminal")
+    let second = manager.createTab(title: "Terminal 2", icon: "terminal")
+
+    let inserted = manager.createTab(
+      title: "Terminal 3",
+      icon: "terminal",
+      insertion: .after(TerminalTabID())
+    )
+
+    #expect(manager.tabs.map(\.id) == [first, second, inserted])
+  }
 }

--- a/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowRegistryTests.swift
@@ -258,6 +258,110 @@ struct TerminalWindowRegistryTests {
   }
 
   @Test
+  func createTabUsesSelectedTabAsInsertionAnchorForExplicitSpaceTarget() throws {
+    try withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      @Shared(.supatermSettings) var supatermSettings = .default
+      $supatermSettings.withLock {
+        $0.newTabPosition = .current
+      }
+
+      let registry = TerminalWindowRegistry()
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+      let firstTabID = try #require(host.selectedTabID)
+      host.handleCommand(.createTab(inheritingFromSurfaceID: nil))
+      let secondTabID = try #require(host.selectedTabID)
+      host.handleCommand(.selectTab(firstTabID))
+
+      let store = Store(initialState: AppFeature.State()) {
+        AppFeature()
+      }
+      let windowControllerID = UUID()
+
+      registry.register(
+        keyboardShortcutForAction: { _ in nil },
+        windowControllerID: windowControllerID,
+        store: store,
+        terminal: host,
+        requestConfirmedWindowClose: {}
+      )
+      registry.updateWindow(makeWindow(), for: windowControllerID)
+
+      let result = try registry.createTab(
+        .init(
+          command: nil,
+          cwd: nil,
+          focus: false,
+          target: .space(windowIndex: 1, spaceIndex: 1)
+        )
+      )
+
+      #expect(result.tabIndex == 2)
+      #expect(
+        host.spaceManager.tabs(in: host.spaces[0].id).map(\.id.rawValue)
+          == [firstTabID.rawValue, result.tabID, secondTabID.rawValue]
+      )
+      #expect(host.selectedTabID == firstTabID)
+    }
+  }
+
+  @Test
+  func createTabUsesContextPaneTabAsInsertionAnchor() throws {
+    try withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      @Shared(.supatermSettings) var supatermSettings = .default
+      $supatermSettings.withLock {
+        $0.newTabPosition = .current
+      }
+
+      let registry = TerminalWindowRegistry()
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+      let firstTabID = try #require(host.selectedTabID)
+      let firstPaneID = try #require(host.selectedSurfaceView?.id)
+      host.handleCommand(.createTab(inheritingFromSurfaceID: nil))
+      let secondTabID = try #require(host.selectedTabID)
+
+      let store = Store(initialState: AppFeature.State()) {
+        AppFeature()
+      }
+      let windowControllerID = UUID()
+
+      registry.register(
+        keyboardShortcutForAction: { _ in nil },
+        windowControllerID: windowControllerID,
+        store: store,
+        terminal: host,
+        requestConfirmedWindowClose: {}
+      )
+      registry.updateWindow(makeWindow(), for: windowControllerID)
+
+      let result = try registry.createTab(
+        .init(
+          command: nil,
+          cwd: nil,
+          focus: false,
+          target: .contextPane(firstPaneID)
+        )
+      )
+
+      #expect(result.tabIndex == 2)
+      #expect(
+        host.spaceManager.tabs(in: host.spaces[0].id).map(\.id.rawValue)
+          == [firstTabID.rawValue, result.tabID, secondTabID.rawValue]
+      )
+      #expect(host.selectedTabID == secondTabID)
+    }
+  }
+
+  @Test
   func requestCloseTabInKeyWindowDispatchesReducerCommand() async throws {
     try await withDependencies {
       $0.defaultFileStorage = .inMemory

--- a/apps/supaterm.com/public/data/supaterm-settings.schema.json
+++ b/apps/supaterm.com/public/data/supaterm-settings.schema.json
@@ -31,6 +31,12 @@
       "description": "Show a glowing ring around panes with unread attention.",
       "type": "boolean"
     },
+    "newTabPosition": {
+      "default": "end",
+      "description": "Choose whether new tabs open after the current tab or at the end.",
+      "enum": ["current", "end"],
+      "type": "string"
+    },
     "restoreTerminalLayoutEnabled": {
       "default": true,
       "description": "Restore spaces, tabs, and panes on launch.",


### PR DESCRIPTION
## Summary
- add persisted `newTabPosition` with `current` and `end`, and expose it in Settings > General
- resolve tab insertion anchors in `TerminalHostState` and keep final insertion policy centralized in `TerminalTabManager`
- update the generated schema mirror and add regression coverage for settings, insertion order, and returned `tabIndex`

## Testing
- `xcodebuild test -workspace apps/mac/supaterm.xcworkspace -scheme supaterm -destination "platform=macOS" -only-testing:supatermTests/SupatermSettingsTests -only-testing:supatermTests/SupatermSettingsSchemaTests -only-testing:supatermTests/SettingsFeatureTests -only-testing:supatermTests/TerminalTabManagerTests -only-testing:supatermTests/TerminalWindowRegistryTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- pre-push web checks and tests
- pre-push full macOS test suite (`621` tests)

## Notes
- the branch was rebased onto the rewritten `main` and force-pushed before opening this PR
- the local commit hook still reports unrelated pre-existing trailing-comma lint failures in `supatermTests/AppDelegateTests.swift`, `supatermTests/PiSettingsInstallerTests.swift`, and `supatermTests/TerminalWindowFeatureTests.swift`
