### PR TITLE
Support custom commands and workspace launches in the command palette

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermCustomCommandsFile.swift
+++ b/apps/mac/SupatermCLIShared/SupatermCustomCommandsFile.swift
@@ -1,0 +1,304 @@
+import Foundation
+
+public struct SupatermCustomCommandsFile: Equatable, Sendable, Codable {
+  public var schema: String?
+  public var commands: [SupatermCustomCommand]
+
+  public init(
+    schema: String? = SupatermCustomCommandsSchema.url,
+    commands: [SupatermCustomCommand]
+  ) {
+    self.schema = schema
+    self.commands = commands
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case schema = "$schema"
+    case commands
+  }
+}
+
+public struct SupatermCustomCommand: Equatable, Sendable, Codable, Identifiable {
+  public let id: String
+  public let kind: Kind
+  public let name: String
+  public let description: String?
+  public let keywords: [String]
+  public let command: String?
+  public let restartBehavior: SupatermWorkspaceRestartBehavior?
+  public let workspace: SupatermWorkspaceDefinition?
+
+  public enum Kind: String, Equatable, Sendable, Codable {
+    case command
+    case workspace
+  }
+
+  public init(
+    id: String,
+    kind: Kind,
+    name: String,
+    description: String? = nil,
+    keywords: [String] = [],
+    command: String? = nil,
+    restartBehavior: SupatermWorkspaceRestartBehavior? = nil,
+    workspace: SupatermWorkspaceDefinition? = nil
+  ) {
+    self.id = id
+    self.kind = kind
+    self.name = name
+    self.description = description
+    self.keywords = keywords
+    self.command = command
+    self.restartBehavior = restartBehavior
+    self.workspace = workspace
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case kind
+    case name
+    case description
+    case keywords
+    case command
+    case restartBehavior
+    case workspace
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let id = try container.decode(String.self, forKey: .id)
+    let kind = try container.decode(Kind.self, forKey: .kind)
+    let name = try container.decode(String.self, forKey: .name)
+    let description = try container.decodeIfPresent(String.self, forKey: .description)
+    let keywords = try container.decodeIfPresent([String].self, forKey: .keywords) ?? []
+    let command = try container.decodeIfPresent(String.self, forKey: .command)
+    let restartBehavior = try container.decodeIfPresent(
+      SupatermWorkspaceRestartBehavior.self,
+      forKey: .restartBehavior
+    )
+    let workspace = try container.decodeIfPresent(SupatermWorkspaceDefinition.self, forKey: .workspace)
+
+    switch kind {
+    case .command:
+      guard command != nil else {
+        throw DecodingError.dataCorruptedError(
+          forKey: .command,
+          in: container,
+          debugDescription: "Command entries require a command string."
+        )
+      }
+    case .workspace:
+      guard workspace != nil else {
+        throw DecodingError.dataCorruptedError(
+          forKey: .workspace,
+          in: container,
+          debugDescription: "Workspace entries require a workspace definition."
+        )
+      }
+    }
+
+    self.init(
+      id: id,
+      kind: kind,
+      name: name,
+      description: description,
+      keywords: keywords,
+      command: command,
+      restartBehavior: restartBehavior,
+      workspace: workspace
+    )
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(kind, forKey: .kind)
+    try container.encode(name, forKey: .name)
+    try container.encodeIfPresent(description, forKey: .description)
+    if !keywords.isEmpty {
+      try container.encode(keywords, forKey: .keywords)
+    }
+    switch kind {
+    case .command:
+      try container.encode(command, forKey: .command)
+    case .workspace:
+      try container.encode(restartBehavior ?? .focusExisting, forKey: .restartBehavior)
+      try container.encode(workspace, forKey: .workspace)
+    }
+  }
+}
+
+public enum SupatermWorkspaceRestartBehavior: String, Equatable, Sendable, Codable, CaseIterable {
+  case focusExisting = "focus_existing"
+  case recreate
+  case confirmRecreate = "confirm_recreate"
+}
+
+public struct SupatermWorkspaceDefinition: Equatable, Sendable, Codable {
+  public let spaceName: String
+  public let tabs: [SupatermWorkspaceTabDefinition]
+
+  public init(
+    spaceName: String,
+    tabs: [SupatermWorkspaceTabDefinition]
+  ) {
+    self.spaceName = spaceName
+    self.tabs = tabs
+  }
+}
+
+public struct SupatermWorkspaceTabDefinition: Equatable, Sendable, Codable {
+  public let title: String
+  public let cwd: String?
+  public let selected: Bool
+  public let rootPane: SupatermWorkspacePaneDefinition
+
+  public init(
+    title: String,
+    cwd: String? = nil,
+    selected: Bool = false,
+    rootPane: SupatermWorkspacePaneDefinition
+  ) {
+    self.title = title
+    self.cwd = cwd
+    self.selected = selected
+    self.rootPane = rootPane
+  }
+}
+
+public enum SupatermWorkspaceSplitDirection: String, Equatable, Sendable, Codable, CaseIterable {
+  case left
+  case right
+  case up
+  case down
+}
+
+public struct SupatermWorkspaceEnvironment: Equatable, Sendable, Codable {
+  public let values: [String: String]
+
+  public init(_ values: [String: String] = [:]) {
+    self.values = values
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.init(try container.decode([String: String].self))
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(values)
+  }
+}
+
+public struct SupatermWorkspaceLeafPaneDefinition: Equatable, Sendable, Codable {
+  public let title: String?
+  public let cwd: String?
+  public let command: String?
+  public let focus: Bool
+  public let env: SupatermWorkspaceEnvironment
+
+  public init(
+    title: String? = nil,
+    cwd: String? = nil,
+    command: String? = nil,
+    focus: Bool = false,
+    env: SupatermWorkspaceEnvironment = .init()
+  ) {
+    self.title = title
+    self.cwd = cwd
+    self.command = command
+    self.focus = focus
+    self.env = env
+  }
+}
+
+public struct SupatermWorkspaceSplitPaneDefinition: Equatable, Sendable, Codable {
+  public let direction: SupatermWorkspaceSplitDirection
+  public let ratio: Double
+  public let first: SupatermWorkspacePaneDefinition
+  public let second: SupatermWorkspacePaneDefinition
+
+  public init(
+    direction: SupatermWorkspaceSplitDirection,
+    ratio: Double,
+    first: SupatermWorkspacePaneDefinition,
+    second: SupatermWorkspacePaneDefinition
+  ) {
+    self.direction = direction
+    self.ratio = ratio
+    self.first = first
+    self.second = second
+  }
+}
+
+public indirect enum SupatermWorkspacePaneDefinition: Equatable, Sendable, Codable {
+  case leaf(SupatermWorkspaceLeafPaneDefinition)
+  case split(SupatermWorkspaceSplitPaneDefinition)
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case title
+    case cwd
+    case command
+    case focus
+    case env
+    case direction
+    case ratio
+    case first
+    case second
+  }
+
+  private enum Kind: String, Codable {
+    case leaf
+    case split
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    switch try container.decode(Kind.self, forKey: .type) {
+    case .leaf:
+      self = .leaf(
+        .init(
+          title: try container.decodeIfPresent(String.self, forKey: .title),
+          cwd: try container.decodeIfPresent(String.self, forKey: .cwd),
+          command: try container.decodeIfPresent(String.self, forKey: .command),
+          focus: try container.decodeIfPresent(Bool.self, forKey: .focus) ?? false,
+          env: try container.decodeIfPresent(SupatermWorkspaceEnvironment.self, forKey: .env) ?? .init()
+        )
+      )
+    case .split:
+      self = .split(
+        .init(
+          direction: try container.decode(SupatermWorkspaceSplitDirection.self, forKey: .direction),
+          ratio: try container.decodeIfPresent(Double.self, forKey: .ratio) ?? 0.5,
+          first: try container.decode(SupatermWorkspacePaneDefinition.self, forKey: .first),
+          second: try container.decode(SupatermWorkspacePaneDefinition.self, forKey: .second)
+        )
+      )
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .leaf(let leaf):
+      try container.encode(Kind.leaf, forKey: .type)
+      try container.encodeIfPresent(leaf.title, forKey: .title)
+      try container.encodeIfPresent(leaf.cwd, forKey: .cwd)
+      try container.encodeIfPresent(leaf.command, forKey: .command)
+      if leaf.focus {
+        try container.encode(leaf.focus, forKey: .focus)
+      }
+      if !leaf.env.values.isEmpty {
+        try container.encode(leaf.env, forKey: .env)
+      }
+    case .split(let split):
+      try container.encode(Kind.split, forKey: .type)
+      try container.encode(split.direction, forKey: .direction)
+      try container.encode(split.ratio, forKey: .ratio)
+      try container.encode(split.first, forKey: .first)
+      try container.encode(split.second, forKey: .second)
+    }
+  }
+}

--- a/apps/mac/SupatermCLIShared/SupatermCustomCommandsSchema.swift
+++ b/apps/mac/SupatermCLIShared/SupatermCustomCommandsSchema.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+public enum SupatermCustomCommandsSchema {
+  static let schemaKey = "$schema"
+  public static let url = "https://supaterm.com/data/supaterm-custom-commands.schema.json"
+
+  public static func jsonString() throws -> String {
+    try schemaObject().stableJSONString()
+  }
+
+  private static func schemaObject() -> JSONValue {
+    .object([
+      "$schema": .string("https://json-schema.org/draft/2020-12/schema"),
+      "$id": .string(url),
+      "title": .string("supaterm.json"),
+      "description": .string("User-defined command palette commands and workspaces for Supaterm."),
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object(properties()),
+      "$defs": .object(definitions()),
+      "required": .array([.string("commands")]),
+    ])
+  }
+
+  private static func properties() -> [String: JSONValue] {
+    [
+      schemaKey: schemaProperty(
+        defaultValue: .string(url),
+        description: "Optional schema URL for editor completion and validation.",
+        format: "uri"
+      ),
+      "commands": .object([
+        "type": .string("array"),
+        "description": .string("The command-palette commands available in this scope."),
+        "items": .object([
+          "$ref": .string("#/$defs/command"),
+        ]),
+      ]),
+    ]
+  }
+
+  private static func definitions() -> [String: JSONValue] {
+    [
+      "command": commandDefinition(),
+      "simpleCommand": simpleCommandDefinition(),
+      "workspaceCommand": workspaceCommandDefinition(),
+      "workspace": workspaceDefinition(),
+      "tab": tabDefinition(),
+      "pane": paneDefinition(),
+      "leafPane": leafPaneDefinition(),
+      "splitPane": splitPaneDefinition(),
+    ]
+  }
+
+  private static func commandDefinition() -> JSONValue {
+    .object([
+      "oneOf": .array([
+        .object(["$ref": .string("#/$defs/simpleCommand")]),
+        .object(["$ref": .string("#/$defs/workspaceCommand")]),
+      ]),
+    ])
+  }
+
+  private static func simpleCommandDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object(baseCommandProperties(kind: "command", extras: [
+        "command": .object([
+          "type": .string("string"),
+          "description": .string("Shell text to send to the focused pane."),
+        ]),
+      ])),
+      "required": .array([.string("id"), .string("kind"), .string("name"), .string("command")]),
+    ])
+  }
+
+  private static func workspaceCommandDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object(baseCommandProperties(kind: "workspace", extras: [
+        "restartBehavior": .object([
+          "type": .string("string"),
+          "description": .string("What to do when a space with the same name already exists."),
+          "default": .string(SupatermWorkspaceRestartBehavior.focusExisting.rawValue),
+          "enum": .array(SupatermWorkspaceRestartBehavior.allCases.map { .string($0.rawValue) }),
+        ]),
+        "workspace": .object([
+          "$ref": .string("#/$defs/workspace"),
+        ]),
+      ])),
+      "required": .array([.string("id"), .string("kind"), .string("name"), .string("workspace")]),
+    ])
+  }
+
+  private static func workspaceDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object([
+        "spaceName": .object([
+          "type": .string("string"),
+          "description": .string("The target space name for this workspace."),
+        ]),
+        "tabs": .object([
+          "type": .string("array"),
+          "items": .object(["$ref": .string("#/$defs/tab")]),
+        ]),
+      ]),
+      "required": .array([.string("spaceName"), .string("tabs")]),
+    ])
+  }
+
+  private static func tabDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object([
+        "title": .object([
+          "type": .string("string"),
+          "description": .string("The locked title for the tab."),
+        ]),
+        "cwd": .object([
+          "type": .string("string"),
+          "description": .string("Optional working directory for panes in this tab."),
+        ]),
+        "selected": .object([
+          "type": .string("boolean"),
+          "default": .bool(false),
+          "description": .string("Whether this tab should be selected after launch."),
+        ]),
+        "rootPane": .object([
+          "$ref": .string("#/$defs/pane"),
+        ]),
+      ]),
+      "required": .array([.string("title"), .string("rootPane")]),
+    ])
+  }
+
+  private static func paneDefinition() -> JSONValue {
+    .object([
+      "oneOf": .array([
+        .object(["$ref": .string("#/$defs/leafPane")]),
+        .object(["$ref": .string("#/$defs/splitPane")]),
+      ]),
+    ])
+  }
+
+  private static func leafPaneDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object([
+        "type": .object([
+          "type": .string("string"),
+          "const": .string("leaf"),
+        ]),
+        "title": .object([
+          "type": .string("string"),
+        ]),
+        "cwd": .object([
+          "type": .string("string"),
+        ]),
+        "command": .object([
+          "type": .string("string"),
+        ]),
+        "focus": .object([
+          "type": .string("boolean"),
+          "default": .bool(false),
+        ]),
+        "env": .object([
+          "type": .string("object"),
+          "additionalProperties": .object([
+            "type": .string("string"),
+          ]),
+          "default": .object([:]),
+        ]),
+      ]),
+      "required": .array([.string("type")]),
+    ])
+  }
+
+  private static func splitPaneDefinition() -> JSONValue {
+    .object([
+      "type": .string("object"),
+      "additionalProperties": .bool(false),
+      "properties": .object([
+        "type": .object([
+          "type": .string("string"),
+          "const": .string("split"),
+        ]),
+        "direction": .object([
+          "type": .string("string"),
+          "enum": .array(SupatermWorkspaceSplitDirection.allCases.map { .string($0.rawValue) }),
+        ]),
+        "ratio": .object([
+          "type": .string("number"),
+          "default": .double(0.5),
+        ]),
+        "first": .object([
+          "$ref": .string("#/$defs/pane"),
+        ]),
+        "second": .object([
+          "$ref": .string("#/$defs/pane"),
+        ]),
+      ]),
+      "required": .array([.string("type"), .string("direction"), .string("first"), .string("second")]),
+    ])
+  }
+
+  private static func baseCommandProperties(
+    kind: String,
+    extras: [String: JSONValue]
+  ) -> [String: JSONValue] {
+    var properties: [String: JSONValue] = [
+      "id": .object([
+        "type": .string("string"),
+        "description": .string("Stable command identifier used for local-over-global overrides."),
+      ]),
+      "kind": .object([
+        "type": .string("string"),
+        "const": .string(kind),
+      ]),
+      "name": .object([
+        "type": .string("string"),
+        "description": .string("Visible title in the command palette."),
+      ]),
+      "description": .object([
+        "type": .string("string"),
+        "description": .string("Optional subtitle in the command palette."),
+      ]),
+      "keywords": .object([
+        "type": .string("array"),
+        "items": .object(["type": .string("string")]),
+        "default": .array([]),
+        "description": .string("Extra search terms for fuzzy matching."),
+      ]),
+    ]
+    for (key, value) in extras {
+      properties[key] = value
+    }
+    return properties
+  }
+
+  private static func schemaProperty(
+    defaultValue: JSONValue,
+    description: String,
+    format: String? = nil
+  ) -> JSONValue {
+    var object: [String: JSONValue] = [
+      "type": .string(jsonSchemaType(for: defaultValue)),
+      "default": defaultValue,
+      "description": .string(description),
+    ]
+    if let format {
+      object["format"] = .string(format)
+    }
+    return .object(object)
+  }
+
+  private static func jsonSchemaType(for value: JSONValue) -> String {
+    switch value {
+    case .null:
+      return "null"
+    case .bool:
+      return "boolean"
+    case .int:
+      return "integer"
+    case .double:
+      return "number"
+    case .string:
+      return "string"
+    case .array:
+      return "array"
+    case .object:
+      return "object"
+    }
+  }
+}

--- a/apps/mac/sp/SPHelp.swift
+++ b/apps/mac/sp/SPHelp.swift
@@ -208,12 +208,15 @@ enum SPHelp {
   static let receiveAgentHookDiscussion = """
     Reads one agent hook event JSON object from stdin and forwards it to Supaterm.
 
-    Manage coding-agent integrations from Supaterm Settings > Coding Agents. Use `sp agent install-hook` and `sp agent remove-hook` for Claude or Codex.
+    Manage coding-agent integrations from Supaterm Settings > Coding Agents.
+    Use `sp agent install-hook` and `sp agent remove-hook`
+    for Claude or Codex.
 
     Example:
       sp agent install-hook claude
       sp agent remove-hook claude
-      printf '{"hook_event_name":"Notification","message":"Claude needs your attention"}' | sp agent receive-agent-hook --agent claude
+      printf '{"hook_event_name":"Notification","message":"Claude needs your attention"}' |
+        sp agent receive-agent-hook --agent claude
       \(SupatermClaudeHookSettings.command)
     """
 
@@ -270,6 +273,11 @@ enum SPHelp {
   static let generateSettingsSchemaDiscussion = """
     Example:
       sp internal generate-settings-schema
+    """
+
+  static let generateCustomCommandsSchemaDiscussion = """
+    Example:
+      sp internal generate-custom-commands-schema
     """
 
   static let developmentDiscussion = """
@@ -416,6 +424,7 @@ enum SPHelp {
     Example:
       sp internal ping
       sp internal generate-settings-schema
+      sp internal generate-custom-commands-schema
       sp internal agent-settings claude
       sp internal dev claude session-start
     """

--- a/apps/mac/sp/SPInternalCommands.swift
+++ b/apps/mac/sp/SPInternalCommands.swift
@@ -12,6 +12,7 @@ extension SP {
       subcommands: [
         Ping.self,
         GenerateSettingsSchema.self,
+        GenerateCustomCommandsSchema.self,
         AgentSettings.self,
         Development.self,
         ClaudeTeams.self,
@@ -58,6 +59,18 @@ extension SP {
 
     mutating func run() throws {
       print(try SupatermSettingsSchema.jsonString())
+    }
+  }
+
+  struct GenerateCustomCommandsSchema: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "generate-custom-commands-schema",
+      abstract: "Print the Supaterm custom commands JSON schema.",
+      discussion: SPHelp.generateCustomCommandsSchemaDiscussion
+    )
+
+    mutating func run() throws {
+      print(try SupatermCustomCommandsSchema.jsonString())
     }
   }
 

--- a/apps/mac/supaterm/Features/Terminal/CustomCommands/TerminalCustomCommandCatalog.swift
+++ b/apps/mac/supaterm/Features/Terminal/CustomCommands/TerminalCustomCommandCatalog.swift
@@ -269,8 +269,7 @@ enum TerminalCustomCommandCatalog {
       pane: tab.rootPane,
       inheritedWorkingDirectory: tab.cwd,
       sourceURL: sourceURL,
-      commandID: commandID,
-      problems: &problems
+      commandID: commandID
     )
     let focusedLeafIndexes = focusedLeafIndexes(in: resolvedPane)
     if focusedLeafIndexes.count > 1 {
@@ -297,8 +296,7 @@ enum TerminalCustomCommandCatalog {
     pane: SupatermWorkspacePaneDefinition,
     inheritedWorkingDirectory: String?,
     sourceURL: URL,
-    commandID: String,
-    problems: inout [String]
+    commandID: String
   ) throws -> FocusMarkedPane {
     switch pane {
     case .leaf(let leaf):
@@ -327,15 +325,13 @@ enum TerminalCustomCommandCatalog {
           pane: split.first,
           inheritedWorkingDirectory: inheritedWorkingDirectory,
           sourceURL: sourceURL,
-          commandID: commandID,
-          problems: &problems
+          commandID: commandID
         ),
         second: try resolve(
           pane: split.second,
           inheritedWorkingDirectory: inheritedWorkingDirectory,
           sourceURL: sourceURL,
-          commandID: commandID,
-          problems: &problems
+          commandID: commandID
         )
       )
     }
@@ -386,13 +382,13 @@ enum TerminalCustomCommandCatalog {
     _ environment: SupatermWorkspaceEnvironment,
     commandID: String
   ) throws -> [SupatermCLIEnvironmentVariable] {
-    try environment.values.keys.sorted().map { key in
+    try environment.values.sorted { $0.key < $1.key }.map { key, value in
       if isReservedEnvironmentKey(key) {
         throw CatalogError.invalid("reserved environment key \(key) in command \(commandID)")
       }
       return .init(
         key: key,
-        value: environment.values[key] ?? ""
+        value: value
       )
     }
   }

--- a/apps/mac/supaterm/Features/Terminal/CustomCommands/TerminalCustomCommandCatalog.swift
+++ b/apps/mac/supaterm/Features/Terminal/CustomCommands/TerminalCustomCommandCatalog.swift
@@ -1,0 +1,486 @@
+import Foundation
+import SupatermCLIShared
+
+struct TerminalCustomCommandProblem: Equatable, Identifiable, Sendable {
+  let id: String
+  let message: String
+
+  init(message: String) {
+    self.id = message
+    self.message = message
+  }
+}
+
+struct TerminalCustomTextCommandSnapshot: Equatable, Sendable {
+  let command: String
+}
+
+struct TerminalCustomWorkspaceLeafSnapshot: Equatable, Sendable {
+  let title: String?
+  let workingDirectoryPath: String?
+  let command: String?
+  let environmentVariables: [SupatermCLIEnvironmentVariable]
+}
+
+struct TerminalCustomWorkspaceSplitSnapshot: Equatable, Sendable {
+  let direction: SupatermWorkspaceSplitDirection
+  let ratio: Double
+  let first: TerminalCustomWorkspacePaneSnapshot
+  let second: TerminalCustomWorkspacePaneSnapshot
+}
+
+indirect enum TerminalCustomWorkspacePaneSnapshot: Equatable, Sendable {
+  case leaf(TerminalCustomWorkspaceLeafSnapshot)
+  case split(TerminalCustomWorkspaceSplitSnapshot)
+
+  var leafCount: Int {
+    switch self {
+    case .leaf:
+      return 1
+    case .split(let split):
+      return split.first.leafCount + split.second.leafCount
+    }
+  }
+}
+
+struct TerminalCustomWorkspaceTabSnapshot: Equatable, Sendable {
+  let title: String
+  let rootPane: TerminalCustomWorkspacePaneSnapshot
+  let focusedLeafIndex: Int
+}
+
+struct TerminalCustomWorkspaceSnapshot: Equatable, Sendable {
+  let restartBehavior: SupatermWorkspaceRestartBehavior
+  let spaceName: String
+  let tabs: [TerminalCustomWorkspaceTabSnapshot]
+  let selectedTabIndex: Int
+}
+
+enum TerminalCustomCommandKindSnapshot: Equatable, Sendable {
+  case command(TerminalCustomTextCommandSnapshot)
+  case workspace(TerminalCustomWorkspaceSnapshot)
+}
+
+struct TerminalCustomCommandSnapshot: Equatable, Identifiable, Sendable {
+  let id: String
+  let title: String
+  let subtitle: String
+  let keywords: [String]
+  let kind: TerminalCustomCommandKindSnapshot
+
+  var requiresFocusedSurface: Bool {
+    switch kind {
+    case .command:
+      return true
+    case .workspace:
+      return false
+    }
+  }
+}
+
+struct TerminalCustomCommandCatalogResult: Equatable, Sendable {
+  let commands: [TerminalCustomCommandSnapshot]
+  let problems: [TerminalCustomCommandProblem]
+
+  static let empty = Self(commands: [], problems: [])
+}
+
+enum TerminalCustomCommandCatalog {
+  static func load(
+    focusedWorkingDirectory: String?,
+    fileManager: FileManager = .default,
+    homeDirectoryPath: String = NSHomeDirectory()
+  ) -> TerminalCustomCommandCatalogResult {
+    let globalURL = SupatermSettings.defaultURL(homeDirectoryPath: homeDirectoryPath)
+      .deletingLastPathComponent()
+      .appendingPathComponent("supaterm.json", isDirectory: false)
+    let localURL = nearestLocalConfigURL(
+      from: focusedWorkingDirectory,
+      excluding: globalURL,
+      fileManager: fileManager
+    )
+
+    let globalResult = decodeFileIfPresent(at: globalURL, fileManager: fileManager)
+    let localResult =
+      localURL.map { decodeFileIfPresent(at: $0, fileManager: fileManager) }
+      ?? DecodedFileResult.empty
+
+    return merge(
+      globalResult: globalResult,
+      localResult: localResult
+    )
+  }
+
+  private struct DecodedFileResult {
+    let commands: [TerminalCustomCommandSnapshot]
+    let problems: [TerminalCustomCommandProblem]
+
+    static let empty = Self(commands: [], problems: [])
+  }
+
+  private static func decodeFileIfPresent(
+    at url: URL,
+    fileManager: FileManager
+  ) -> DecodedFileResult {
+    guard fileManager.fileExists(atPath: url.path(percentEncoded: false)) else {
+      return .empty
+    }
+
+    do {
+      let data = try Data(contentsOf: url)
+      let file = try JSONDecoder().decode(SupatermCustomCommandsFile.self, from: data)
+      return resolve(file: file, sourceURL: url)
+    } catch {
+      return .init(
+        commands: [],
+        problems: [
+          .init(message: "Failed to load \(url.path(percentEncoded: false)): \(error.localizedDescription)")
+        ]
+      )
+    }
+  }
+
+  private static func resolve(
+    file: SupatermCustomCommandsFile,
+    sourceURL: URL
+  ) -> DecodedFileResult {
+    var problems: [TerminalCustomCommandProblem] = []
+    var order: [String] = []
+    var snapshotsByID: [String: TerminalCustomCommandSnapshot] = [:]
+    var seenCounts: [String: Int] = [:]
+
+    for command in file.commands {
+      seenCounts[command.id, default: 0] += 1
+      if seenCounts[command.id] == 1 {
+        order.append(command.id)
+      }
+      do {
+        snapshotsByID[command.id] = try resolve(
+          command: command,
+          sourceURL: sourceURL
+        )
+      } catch {
+        problems.append(
+          .init(
+            message:
+              "Invalid command \(command.id) in \(sourceURL.path(percentEncoded: false)): \(error.localizedDescription)"
+          )
+        )
+      }
+    }
+
+    let duplicateIDs = seenCounts.keys.sorted().filter { (seenCounts[$0] ?? 0) > 1 }
+    if !duplicateIDs.isEmpty {
+      problems.append(
+        .init(
+          message:
+            "Duplicate command ids in \(sourceURL.path(percentEncoded: false)): \(duplicateIDs.joined(separator: ", "))"
+        )
+      )
+    }
+
+    return .init(
+      commands: order.compactMap { snapshotsByID[$0] },
+      problems: problems
+    )
+  }
+
+  private static func resolve(
+    command: SupatermCustomCommand,
+    sourceURL: URL
+  ) throws -> TerminalCustomCommandSnapshot {
+    switch command.kind {
+    case .command:
+      return .init(
+        id: command.id,
+        title: command.name,
+        subtitle: command.description ?? "Command",
+        keywords: command.keywords,
+        kind: .command(.init(command: try required(command.command)))
+      )
+    case .workspace:
+      let workspace = try required(command.workspace)
+      let resolvedWorkspace = try resolve(
+        workspace: workspace,
+        restartBehavior: command.restartBehavior ?? .focusExisting,
+        sourceURL: sourceURL,
+        commandID: command.id
+      )
+      return .init(
+        id: command.id,
+        title: command.name,
+        subtitle: command.description ?? resolvedWorkspace.spaceName,
+        keywords: command.keywords,
+        kind: .workspace(resolvedWorkspace)
+      )
+    }
+  }
+
+  private static func resolve(
+    workspace: SupatermWorkspaceDefinition,
+    restartBehavior: SupatermWorkspaceRestartBehavior,
+    sourceURL: URL,
+    commandID: String
+  ) throws -> TerminalCustomWorkspaceSnapshot {
+    let selectedIndexes = workspace.tabs.enumerated().compactMap { index, tab in
+      tab.selected ? index : nil
+    }
+    let selectedTabIndex = selectedIndexes.first ?? 0
+    var problems: [String] = []
+    if selectedIndexes.count > 1 {
+      problems.append("multiple selected tabs")
+    }
+
+    var resolvedTabs: [TerminalCustomWorkspaceTabSnapshot] = []
+    for tab in workspace.tabs {
+      try resolvedTabs.append(
+        resolve(
+          tab: tab,
+          sourceURL: sourceURL,
+          commandID: commandID,
+          problems: &problems
+        )
+      )
+    }
+
+    if resolvedTabs.isEmpty {
+      throw CatalogError.invalid("workspace must contain at least one tab")
+    }
+
+    if !problems.isEmpty {
+      throw CatalogError.invalid(problems.joined(separator: ", "))
+    }
+
+    return .init(
+      restartBehavior: restartBehavior,
+      spaceName: workspace.spaceName,
+      tabs: resolvedTabs,
+      selectedTabIndex: resolvedTabs.indices.contains(selectedTabIndex) ? selectedTabIndex : 0
+    )
+  }
+
+  private static func resolve(
+    tab: SupatermWorkspaceTabDefinition,
+    sourceURL: URL,
+    commandID: String,
+    problems: inout [String]
+  ) throws -> TerminalCustomWorkspaceTabSnapshot {
+    let resolvedPane = try resolve(
+      pane: tab.rootPane,
+      inheritedWorkingDirectory: tab.cwd,
+      sourceURL: sourceURL,
+      commandID: commandID,
+      problems: &problems
+    )
+    let focusedLeafIndexes = focusedLeafIndexes(in: resolvedPane)
+    if focusedLeafIndexes.count > 1 {
+      problems.append("multiple focused panes in tab \(tab.title)")
+    }
+    return .init(
+      title: tab.title,
+      rootPane: clearedFocusMarkers(in: resolvedPane),
+      focusedLeafIndex: focusedLeafIndexes.first ?? 0
+    )
+  }
+
+  private indirect enum FocusMarkedPane {
+    case leaf(TerminalCustomWorkspaceLeafSnapshot, focused: Bool)
+    case split(
+      direction: SupatermWorkspaceSplitDirection,
+      ratio: Double,
+      first: FocusMarkedPane,
+      second: FocusMarkedPane
+    )
+  }
+
+  private static func resolve(
+    pane: SupatermWorkspacePaneDefinition,
+    inheritedWorkingDirectory: String?,
+    sourceURL: URL,
+    commandID: String,
+    problems: inout [String]
+  ) throws -> FocusMarkedPane {
+    switch pane {
+    case .leaf(let leaf):
+      let workingDirectoryPath = resolvePath(
+        leaf.cwd ?? inheritedWorkingDirectory,
+        relativeTo: sourceURL.deletingLastPathComponent()
+      )
+      let environmentVariables = try resolveEnvironmentVariables(
+        leaf.env,
+        commandID: commandID
+      )
+      return .leaf(
+        .init(
+          title: leaf.title,
+          workingDirectoryPath: workingDirectoryPath,
+          command: leaf.command,
+          environmentVariables: environmentVariables
+        ),
+        focused: leaf.focus
+      )
+    case .split(let split):
+      return .split(
+        direction: split.direction,
+        ratio: split.ratio > 0 && split.ratio < 1 ? split.ratio : 0.5,
+        first: try resolve(
+          pane: split.first,
+          inheritedWorkingDirectory: inheritedWorkingDirectory,
+          sourceURL: sourceURL,
+          commandID: commandID,
+          problems: &problems
+        ),
+        second: try resolve(
+          pane: split.second,
+          inheritedWorkingDirectory: inheritedWorkingDirectory,
+          sourceURL: sourceURL,
+          commandID: commandID,
+          problems: &problems
+        )
+      )
+    }
+  }
+
+  private static func focusedLeafIndexes(
+    in pane: FocusMarkedPane
+  ) -> [Int] {
+    var currentIndex = 0
+    var focusedIndexes: [Int] = []
+
+    func visit(_ pane: FocusMarkedPane) {
+      switch pane {
+      case .leaf(_, let focused):
+        if focused {
+          focusedIndexes.append(currentIndex)
+        }
+        currentIndex += 1
+      case .split(_, _, let first, let second):
+        visit(first)
+        visit(second)
+      }
+    }
+
+    visit(pane)
+    return focusedIndexes
+  }
+
+  private static func clearedFocusMarkers(
+    in pane: FocusMarkedPane
+  ) -> TerminalCustomWorkspacePaneSnapshot {
+    switch pane {
+    case .leaf(let leaf, _):
+      return .leaf(leaf)
+    case .split(let direction, let ratio, let first, let second):
+      return .split(
+        .init(
+          direction: direction,
+          ratio: ratio,
+          first: clearedFocusMarkers(in: first),
+          second: clearedFocusMarkers(in: second)
+        )
+      )
+    }
+  }
+
+  private static func resolveEnvironmentVariables(
+    _ environment: SupatermWorkspaceEnvironment,
+    commandID: String
+  ) throws -> [SupatermCLIEnvironmentVariable] {
+    try environment.values.keys.sorted().map { key in
+      if isReservedEnvironmentKey(key) {
+        throw CatalogError.invalid("reserved environment key \(key) in command \(commandID)")
+      }
+      return .init(
+        key: key,
+        value: environment.values[key] ?? ""
+      )
+    }
+  }
+
+  private static func isReservedEnvironmentKey(_ key: String) -> Bool {
+    let normalized = key.uppercased()
+    return normalized == "PATH" || normalized.hasPrefix("SUPATERM_")
+  }
+
+  private static func resolvePath(
+    _ path: String?,
+    relativeTo baseURL: URL
+  ) -> String? {
+    guard let trimmedPath = trimmed(path) else { return nil }
+    if trimmedPath.hasPrefix("/") {
+      return GhosttySurfaceView.normalizedWorkingDirectoryPath(trimmedPath)
+    }
+    return GhosttySurfaceView.normalizedWorkingDirectoryPath(
+      baseURL.appendingPathComponent(trimmedPath, isDirectory: true).standardizedFileURL.path(percentEncoded: false)
+    )
+  }
+
+  private static func merge(
+    globalResult: DecodedFileResult,
+    localResult: DecodedFileResult
+  ) -> TerminalCustomCommandCatalogResult {
+    var merged = globalResult.commands
+    var indexByID = Dictionary(uniqueKeysWithValues: merged.enumerated().map { ($1.id, $0) })
+
+    for command in localResult.commands {
+      if let existingIndex = indexByID[command.id] {
+        merged[existingIndex] = command
+      } else {
+        indexByID[command.id] = merged.count
+        merged.append(command)
+      }
+    }
+
+    return .init(
+      commands: merged,
+      problems: globalResult.problems + localResult.problems
+    )
+  }
+
+  private static func nearestLocalConfigURL(
+    from focusedWorkingDirectory: String?,
+    excluding globalURL: URL,
+    fileManager: FileManager
+  ) -> URL? {
+    guard let path = trimmed(focusedWorkingDirectory) else { return nil }
+    var currentURL = URL(fileURLWithPath: GhosttySurfaceView.normalizedWorkingDirectoryPath(path), isDirectory: true)
+      .standardizedFileURL
+
+    while true {
+      let candidateURL = currentURL.appendingPathComponent("supaterm.json", isDirectory: false)
+      if candidateURL != globalURL && fileManager.fileExists(atPath: candidateURL.path(percentEncoded: false)) {
+        return candidateURL
+      }
+      let parentURL = currentURL.deletingLastPathComponent()
+      if parentURL == currentURL {
+        return nil
+      }
+      currentURL = parentURL
+    }
+  }
+
+  private static func trimmed(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+      return nil
+    }
+    return value
+  }
+
+  private static func required<T>(_ value: T?) throws -> T {
+    guard let value else {
+      throw CatalogError.invalid("missing required value")
+    }
+    return value
+  }
+
+  private enum CatalogError: LocalizedError {
+    case invalid(String)
+
+    var errorDescription: String? {
+      switch self {
+      case .invalid(let message):
+        return message
+      }
+    }
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -187,6 +187,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     tabID: UUID,
     socketPath: String?,
     cliPath: String?,
+    additionalEnvironmentVariables: [SupatermCLIEnvironmentVariable] = [],
     processEnvironment: [String: String] = ProcessInfo.processInfo.environment
   ) -> [SupatermCLIEnvironmentVariable] {
     var environmentVariables = SupatermCLIContext(
@@ -221,6 +222,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
         )
       )
     }
+    environmentVariables.append(contentsOf: additionalEnvironmentVariables)
     return environmentVariables
   }
 
@@ -234,6 +236,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     initialInput: String? = nil,
     fontSize: Float32? = nil,
     context: ghostty_surface_context_e,
+    additionalEnvironmentVariables: [SupatermCLIEnvironmentVariable] = [],
     managesWindowAppearance: Bool = false
   ) {
     let surfaceID = UUID()
@@ -244,7 +247,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
       surfaceID: surfaceID,
       tabID: tabID,
       socketPath: SupatermProcessSocketEndpoint.current()?.path,
-      cliPath: GhosttyBootstrap.bundledCLIPath(resourcesURL: Bundle.main.resourceURL)
+      cliPath: GhosttyBootstrap.bundledCLIPath(resourcesURL: Bundle.main.resourceURL),
+      additionalEnvironmentVariables: additionalEnvironmentVariables
     )
     self.fontSize = fontSize ?? 0
     self.context = context
@@ -2006,10 +2010,11 @@ final class GhosttySurfaceScrollView: NSView {
   }
 
   override func mouseMoved(with event: NSEvent) {
-    guard Self.shouldFlashLegacyScrollers(
-      scrollerStyle: NSScroller.preferredScrollerStyle,
-      reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-    )
+    guard
+      Self.shouldFlashLegacyScrollers(
+        scrollerStyle: NSScroller.preferredScrollerStyle,
+        reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+      )
     else { return }
     scrollView.flashScrollers()
   }

--- a/apps/mac/supaterm/Features/Terminal/TerminalClient.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalClient.swift
@@ -155,6 +155,24 @@ struct TerminalCreateSpaceRequest: Equatable, Sendable {
   let target: TerminalSpaceNavigationRequest
 }
 
+struct TerminalExecuteCustomCommandRequest: Equatable, Sendable {
+  let command: TerminalCustomCommandSnapshot
+  let isConfirmed: Bool
+
+  init(
+    command: TerminalCustomCommandSnapshot,
+    isConfirmed: Bool = false
+  ) {
+    self.command = command
+    self.isConfirmed = isConfirmed
+  }
+}
+
+enum TerminalExecuteCustomCommandResult: Sendable {
+  case executed
+  case confirmationRequired
+}
+
 struct TerminalNotificationEvent: Equatable, Sendable {
   let attentionState: SupatermNotificationAttentionState
   let body: String
@@ -215,6 +233,10 @@ struct TerminalClient: Sendable {
   var commandPaletteSnapshot: @MainActor @Sendable () -> TerminalCommandPaletteSnapshot
   var createPane: @MainActor @Sendable (TerminalCreatePaneRequest) async throws -> SupatermNewPaneResult
   var events: @MainActor @Sendable () -> AsyncStream<Event>
+  var executeCustomCommand:
+    @MainActor @Sendable (TerminalExecuteCustomCommandRequest) async throws
+      -> TerminalExecuteCustomCommandResult
+  var loadCustomCommands: @MainActor @Sendable () async -> TerminalCustomCommandCatalogResult
   var send: @MainActor @Sendable (Command) -> Void
   var treeSnapshot: @MainActor @Sendable () async -> SupatermTreeSnapshot
 
@@ -271,6 +293,12 @@ struct TerminalClient: Sendable {
       events: {
         host.eventStream()
       },
+      executeCustomCommand: { request in
+        try host.executeCustomCommand(request)
+      },
+      loadCustomCommands: {
+        host.loadCustomCommands()
+      },
       send: { command in
         host.handleCommand(command)
       },
@@ -295,6 +323,10 @@ extension TerminalClient: DependencyKey {
       throw TerminalCreatePaneError.creationFailed
     },
     events: { AsyncStream { $0.finish() } },
+    executeCustomCommand: { _ in
+      .executed
+    },
+    loadCustomCommands: { .empty },
     send: { _ in },
     treeSnapshot: { .init(windows: []) }
   )
@@ -305,6 +337,10 @@ extension TerminalClient: DependencyKey {
       throw TerminalCreatePaneError.creationFailed
     },
     events: { AsyncStream { $0.finish() } },
+    executeCustomCommand: { _ in
+      .executed
+    },
+    loadCustomCommands: { .empty },
     send: { _ in },
     treeSnapshot: { .init(windows: []) }
   )

--- a/apps/mac/supaterm/Features/Terminal/TerminalCommandPalette.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalCommandPalette.swift
@@ -5,9 +5,13 @@ import SwiftUI
 struct TerminalCommandPaletteState: Equatable {
   var query = ""
   var selectedRowID: TerminalCommandPaletteRow.ID?
+  var customRows: [TerminalCommandPaletteRow] = []
+  var problems: [TerminalCustomCommandProblem] = []
+  var isLoading = false
 }
 
 enum TerminalCommandPaletteCommand: Equatable, Sendable {
+  case customCommand(TerminalCustomCommandSnapshot)
   case ghosttyBindingAction(String)
   case toggleSidebar
   case createSpace
@@ -22,10 +26,11 @@ struct TerminalCommandPaletteRow: Equatable, Identifiable, Sendable {
   let title: String
   let subtitle: String
   let shortcut: String?
+  let keywords: [String]
   let command: TerminalCommandPaletteCommand
 
   var searchableText: String {
-    "\(title) \(subtitle)"
+    ([title, subtitle] + keywords).joined(separator: " ")
   }
 }
 
@@ -54,6 +59,13 @@ enum TerminalCommandPalettePresentation {
   private static let toggleSidebarShortcut = KeyboardShortcut("s", modifiers: .command).display
 
   static func rows(from snapshot: TerminalCommandPaletteSnapshot) -> [TerminalCommandPaletteRow] {
+    rows(from: snapshot, customRows: [])
+  }
+
+  static func rows(
+    from snapshot: TerminalCommandPaletteSnapshot,
+    customRows: [TerminalCommandPaletteRow]
+  ) -> [TerminalCommandPaletteRow] {
     var rows: [TerminalCommandPaletteRow] = []
 
     if snapshot.hasFocusedSurface {
@@ -67,12 +79,24 @@ enum TerminalCommandPalettePresentation {
     }
 
     rows.append(
+      contentsOf: customRows.filter { row in
+        switch row.command {
+        case .customCommand(let command):
+          return snapshot.hasFocusedSurface || !command.requiresFocusedSurface
+        default:
+          return true
+        }
+      }
+    )
+
+    rows.append(
       .init(
         id: "supaterm:toggle-sidebar",
         symbol: "sidebar.leading",
         title: "Toggle Sidebar",
         subtitle: "View",
         shortcut: toggleSidebarShortcut,
+        keywords: [],
         command: .toggleSidebar
       )
     )
@@ -83,6 +107,7 @@ enum TerminalCommandPalettePresentation {
         title: "Create Space",
         subtitle: "Spaces",
         shortcut: nil,
+        keywords: [],
         command: .createSpace
       )
     )
@@ -97,6 +122,7 @@ enum TerminalCommandPalettePresentation {
           title: "Rename Space",
           subtitle: selectedSpace.name,
           shortcut: nil,
+          keywords: [],
           command: .renameSpace(selectedSpace)
         )
       )
@@ -111,6 +137,7 @@ enum TerminalCommandPalettePresentation {
           title: "Switch to \(space.name)",
           subtitle: "Space",
           shortcut: nil,
+          keywords: [],
           command: .selectSpace(space.id)
         )
       })
@@ -124,6 +151,7 @@ enum TerminalCommandPalettePresentation {
           title: "Switch to \(tab.title)",
           subtitle: "Tab",
           shortcut: nil,
+          keywords: [],
           command: .selectTab(tab.id)
         )
       })
@@ -207,6 +235,26 @@ enum TerminalCommandPalettePresentation {
   }
 
   private static func ghosttyRow(
+    _ command: TerminalCustomCommandSnapshot
+  ) -> TerminalCommandPaletteRow {
+    .init(
+      id: "custom:\(command.id)",
+      symbol: symbol(for: command),
+      title: command.title,
+      subtitle: command.subtitle,
+      shortcut: nil,
+      keywords: command.keywords,
+      command: .customCommand(command)
+    )
+  }
+
+  static func customRows(
+    from commands: [TerminalCustomCommandSnapshot]
+  ) -> [TerminalCommandPaletteRow] {
+    commands.map(ghosttyRow)
+  }
+
+  private static func ghosttyRow(
     _ command: GhosttyCommand,
     shortcut: String?
   ) -> TerminalCommandPaletteRow {
@@ -216,6 +264,7 @@ enum TerminalCommandPalettePresentation {
       title: command.title,
       subtitle: command.description.isEmpty ? "Terminal" : command.description,
       shortcut: shortcut,
+      keywords: [],
       command: .ghosttyBindingAction(command.action)
     )
   }
@@ -255,6 +304,15 @@ enum TerminalCommandPalettePresentation {
       return "arrow.up.left.and.arrow.down.right"
     default:
       return "terminal"
+    }
+  }
+
+  private static func symbol(for command: TerminalCustomCommandSnapshot) -> String {
+    switch command.kind {
+    case .command:
+      return "terminal"
+    case .workspace:
+      return "square.3.layers.3d.top.filled"
     }
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/TerminalCommandPalette.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalCommandPalette.swift
@@ -234,7 +234,7 @@ enum TerminalCommandPalettePresentation {
     row(atVisibleIndex: slot - 1, in: visibleRows)
   }
 
-  private static func ghosttyRow(
+  private static func customCommandRow(
     _ command: TerminalCustomCommandSnapshot
   ) -> TerminalCommandPaletteRow {
     .init(
@@ -251,7 +251,7 @@ enum TerminalCommandPalettePresentation {
   static func customRows(
     from commands: [TerminalCustomCommandSnapshot]
   ) -> [TerminalCommandPaletteRow] {
-    commands.map(ghosttyRow)
+    commands.map(customCommandRow)
   }
 
   private static func ghosttyRow(

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -589,6 +589,12 @@ final class TerminalHostState {
     )
   }
 
+  func loadCustomCommands() -> TerminalCustomCommandCatalogResult {
+    TerminalCustomCommandCatalog.load(
+      focusedWorkingDirectory: selectedSurfaceView.flatMap(workingDirectoryPath(for:))
+    )
+  }
+
   func sidebarTerminalProgress(for tabID: TerminalTabID) -> TerminalSidebarTerminalProgress? {
     Self.sidebarTerminalProgress(
       state: focusedSurfaceIDByTab[tabID].flatMap { surfaceID in
@@ -1357,6 +1363,43 @@ final class TerminalHostState {
         spaceManager.tabManager(for: resolvedTarget.space.id)?.closeTab(createdTabID)
       }
       throw TerminalCreateTabError.creationFailed
+    }
+  }
+
+  func executeCustomCommand(
+    _ request: TerminalExecuteCustomCommandRequest
+  ) throws -> TerminalExecuteCustomCommandResult {
+    switch request.command.kind {
+    case .command(let command):
+      guard let surface = selectedSurfaceView else {
+        throw TerminalControlError.contextPaneNotFound
+      }
+      surface.bridge.sendCommand(command.command)
+      return .executed
+
+    case .workspace(let workspace):
+      if let existingSpace = existingSpace(named: workspace.spaceName) {
+        switch workspace.restartBehavior {
+        case .focusExisting:
+          selectSpace(existingSpace.id, persistDefaultSelection: true)
+          return .executed
+        case .confirmRecreate:
+          guard request.isConfirmed else {
+            return .confirmationRequired
+          }
+          try materializeCustomWorkspace(workspace, in: existingSpace.id)
+          return .executed
+        case .recreate:
+          try materializeCustomWorkspace(workspace, in: existingSpace.id)
+          return .executed
+        }
+      }
+
+      try materializeCustomWorkspace(
+        workspace,
+        in: createCustomWorkspaceSpace(named: workspace.spaceName)
+      )
+      return .executed
     }
   }
 
@@ -2439,7 +2482,8 @@ final class TerminalHostState {
     initialInput: String?,
     inheritingFromSurfaceID: UUID?,
     workingDirectory: URL? = nil,
-    context: ghostty_surface_context_e
+    context: ghostty_surface_context_e,
+    additionalEnvironmentVariables: [SupatermCLIEnvironmentVariable] = []
   ) -> GhosttySurfaceView {
     guard let runtime else {
       preconditionFailure("TerminalHostState cannot create surfaces without a GhosttyRuntime")
@@ -2453,6 +2497,7 @@ final class TerminalHostState {
       initialInput: initialInput,
       fontSize: inherited.fontSize,
       context: context,
+      additionalEnvironmentVariables: additionalEnvironmentVariables,
       managesWindowAppearance: false
     )
     configureBridgeCallbacks(for: view, tabID: tabID)
@@ -3321,6 +3366,165 @@ final class TerminalHostState {
     }
   }
 
+  private struct CustomWorkspaceNodeBuildResult {
+    let leafSurfaceIDs: [UUID]
+    let node: SplitTree<GhosttySurfaceView>.Node
+  }
+
+  private func materializeCustomWorkspace(
+    _ workspace: TerminalCustomWorkspaceSnapshot,
+    in spaceID: TerminalSpaceID
+  ) throws {
+    try withSessionChangesSuppressed {
+      renameSpace(spaceID, to: workspace.spaceName)
+
+      let previousTabIDs = spaceManager.tabs(in: spaceID).map(\.id)
+      removeTrees(for: previousTabIDs)
+      _ = spaceManager.restoreTabs([], selectedTabID: nil, in: spaceID)
+
+      let tabs = workspace.tabs.map { tab in
+        TerminalTabItem(
+          title: tab.title,
+          icon: "terminal",
+          isPinned: false,
+          isTitleLocked: true
+        )
+      }
+      let selectedTabID =
+        tabs.indices.contains(workspace.selectedTabIndex)
+        ? tabs[workspace.selectedTabIndex].id
+        : tabs[0].id
+      _ = spaceManager.restoreTabs(tabs, selectedTabID: selectedTabID, in: spaceID)
+
+      for (index, tab) in tabs.enumerated() {
+        let buildResult = buildCustomWorkspaceNode(
+          workspace.tabs[index].rootPane,
+          in: tab.id,
+          context: index == 0 ? GHOSTTY_SURFACE_CONTEXT_WINDOW : GHOSTTY_SURFACE_CONTEXT_TAB
+        )
+        trees[tab.id] = .init(root: buildResult.node, zoomed: nil)
+
+        let focusedLeafIndex =
+          buildResult.leafSurfaceIDs.indices.contains(workspace.tabs[index].focusedLeafIndex)
+          ? workspace.tabs[index].focusedLeafIndex
+          : 0
+        applyFocusedSurface(buildResult.leafSurfaceIDs[focusedLeafIndex], in: tab.id)
+        updateRunningState(for: tab.id)
+        updateTabTitle(for: tab.id)
+      }
+
+      _ = applySelectedSpace(spaceID)
+      applySelectedTab(selectedTabID, in: spaceID)
+      persistDefaultSelectedSpaceID(spaceID)
+      finalizeSpaceSelectionChange()
+      sessionDidChange()
+    }
+  }
+
+  private func createCustomWorkspaceSpace(
+    named name: String
+  ) throws -> TerminalSpaceID {
+    guard let normalizedName = Self.trimmedNonEmpty(name) else {
+      throw TerminalControlError.invalidSpaceName
+    }
+    guard spaceManager.isNameAvailable(normalizedName) else {
+      throw TerminalControlError.spaceNameUnavailable
+    }
+
+    let space = PersistedTerminalSpace(name: normalizedName)
+    var updatedSpaceCatalog = spaceCatalog
+    updatedSpaceCatalog.defaultSelectedSpaceID = space.id
+    updatedSpaceCatalog = .init(
+      defaultSelectedSpaceID: updatedSpaceCatalog.defaultSelectedSpaceID,
+      spaces: updatedSpaceCatalog.spaces + [space]
+    )
+    _ = writeSpaceCatalog(updatedSpaceCatalog)
+    return space.id
+  }
+
+  private func existingSpace(named name: String) -> TerminalSpaceItem? {
+    spaces.first {
+      $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame
+    }
+  }
+
+  private func buildCustomWorkspaceNode(
+    _ pane: TerminalCustomWorkspacePaneSnapshot,
+    in tabID: TerminalTabID,
+    context: ghostty_surface_context_e
+  ) -> CustomWorkspaceNodeBuildResult {
+    switch pane {
+    case .leaf(let leaf):
+      let surface = createSurface(
+        tabID: tabID,
+        command: leaf.command,
+        initialInput: nil,
+        inheritingFromSurfaceID: nil,
+        workingDirectory: workspaceWorkingDirectoryURL(for: leaf.workingDirectoryPath),
+        context: context,
+        additionalEnvironmentVariables: leaf.environmentVariables
+      )
+      surface.setTitleOverride(leaf.title)
+      return .init(
+        leafSurfaceIDs: [surface.id],
+        node: .leaf(view: surface)
+      )
+
+    case .split(let split):
+      let first = buildCustomWorkspaceNode(
+        split.first,
+        in: tabID,
+        context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+      )
+      let second = buildCustomWorkspaceNode(
+        split.second,
+        in: tabID,
+        context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+      )
+
+      let direction: SplitTree<GhosttySurfaceView>.Direction
+      let left: CustomWorkspaceNodeBuildResult
+      let right: CustomWorkspaceNodeBuildResult
+      switch split.direction {
+      case .left:
+        direction = .horizontal
+        left = second
+        right = first
+      case .right:
+        direction = .horizontal
+        left = first
+        right = second
+      case .up:
+        direction = .vertical
+        left = second
+        right = first
+      case .down:
+        direction = .vertical
+        left = first
+        right = second
+      }
+
+      return .init(
+        leafSurfaceIDs: left.leafSurfaceIDs + right.leafSurfaceIDs,
+        node: .split(
+          .init(
+            direction: direction,
+            ratio: split.ratio,
+            left: left.node,
+            right: right.node
+          )
+        )
+      )
+    }
+  }
+
+  private func workspaceWorkingDirectoryURL(
+    for path: String?
+  ) -> URL? {
+    guard let path = Self.trimmedNonEmpty(path) else { return nil }
+    return URL(fileURLWithPath: path, isDirectory: true)
+  }
+
   private func clearSessionState() {
     let existingTabIDs = spaces.flatMap { spaceManager.tabs(in: $0.id).map(\.id) }
     removeTrees(for: existingTabIDs)
@@ -3339,13 +3543,13 @@ final class TerminalHostState {
   }
 
   private func withSessionChangesSuppressed<Result>(
-    _ body: () -> Result
-  ) -> Result {
+    _ body: () throws -> Result
+  ) rethrows -> Result {
     suppressesSessionChanges += 1
     defer {
       suppressesSessionChanges -= 1
     }
-    return body()
+    return try body()
   }
 
   private func workingDirectoryPath(for surface: GhosttySurfaceView) -> String? {

--- a/apps/mac/supaterm/Features/Terminal/TerminalView.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalView.swift
@@ -95,7 +95,10 @@ struct TerminalView: View {
         if let commandPalette = store.commandPalette {
           let snapshot = terminal.commandPaletteSnapshot
           let rows = TerminalCommandPalettePresentation.visibleRows(
-            in: TerminalCommandPalettePresentation.rows(from: snapshot),
+            in: TerminalCommandPalettePresentation.rows(
+              from: snapshot,
+              customRows: commandPalette.customRows
+            ),
             query: commandPalette.query
           )
           TerminalCommandPaletteOverlay(

--- a/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
@@ -6,6 +6,7 @@ import SupatermCLIShared
 
 private enum TerminalWindowCancelID {
   static let events = "TerminalWindowFeature.events"
+  static let commandPaletteLoad = "TerminalWindowFeature.commandPaletteLoad"
 }
 
 struct TerminalSpaceDeleteRequest: Equatable, Identifiable {
@@ -86,6 +87,7 @@ struct TerminalWindowFeature {
   enum ConfirmationTarget: Equatable {
     case closeAllWindows([ObjectIdentifier])
     case closeWindow(ObjectIdentifier)
+    case executeCustomCommand(TerminalExecuteCustomCommandRequest)
   }
 
   struct PendingCloseRequest: Equatable, Identifiable {
@@ -126,6 +128,8 @@ struct TerminalWindowFeature {
     case clientEvent(TerminalClient.Event)
     case commandPaletteActivateSelection
     case commandPaletteCloseRequested
+    case commandPaletteCustomCommandConfirmationRequested(TerminalExecuteCustomCommandRequest)
+    case commandPaletteCustomCommandsLoaded(TerminalCustomCommandCatalogResult)
     case commandPaletteQueryChanged(String)
     case commandPaletteSlotActivated(Int)
     case commandPaletteSelectionChanged(Int)
@@ -237,6 +241,20 @@ struct TerminalWindowFeature {
 
       case .commandPaletteCloseRequested:
         state.commandPalette = nil
+        return .cancel(id: TerminalWindowCancelID.commandPaletteLoad)
+
+      case .commandPaletteCustomCommandConfirmationRequested(let request):
+        state.confirmationRequest = confirmationRequest(for: .executeCustomCommand(request))
+        return .none
+
+      case .commandPaletteCustomCommandsLoaded(let result):
+        guard state.commandPalette != nil else { return .none }
+        state.commandPalette?.customRows = TerminalCommandPalettePresentation.customRows(
+          from: result.commands
+        )
+        state.commandPalette?.problems = result.problems
+        state.commandPalette?.isLoading = false
+        refreshCommandPaletteSelection(state: &state)
         return .none
 
       case .commandPaletteQueryChanged(let query):
@@ -257,10 +275,11 @@ struct TerminalWindowFeature {
       case .commandPaletteToggleRequested:
         if state.commandPalette == nil {
           state.commandPalette = openCommandPaletteState()
+          return loadCommandPaletteCustomCommands()
         } else {
           state.commandPalette = nil
+          return .cancel(id: TerminalWindowCancelID.commandPaletteLoad)
         }
-        return .none
 
       case .closeConfirmationCancelButtonTapped:
         state.pendingCloseRequest = nil
@@ -435,7 +454,7 @@ struct TerminalWindowFeature {
         guard let confirmationRequest = state.confirmationRequest else { return .none }
         state.confirmationRequest = nil
         switch confirmationRequest.target {
-        case .closeWindow, .closeAllWindows:
+        case .closeWindow, .closeAllWindows, .executeCustomCommand:
           return .none
         }
 
@@ -451,6 +470,10 @@ struct TerminalWindowFeature {
           return .run { [terminalWindowsClient] _ in
             await terminalWindowsClient.closeWindows(windowIDs)
           }
+        case .executeCustomCommand(let request):
+          return executeCustomCommand(
+            .init(command: request.command, isConfirmed: true)
+          )
         }
 
       case .windowActivityChanged(let activity):
@@ -479,8 +502,17 @@ struct TerminalWindowFeature {
   private func openCommandPaletteState() -> TerminalCommandPaletteState {
     let rows = TerminalCommandPalettePresentation.rows(from: commandPaletteSnapshot())
     return .init(
-      selectedRowID: TerminalCommandPalettePresentation.normalizedSelection(nil, in: rows)
+      selectedRowID: TerminalCommandPalettePresentation.normalizedSelection(nil, in: rows),
+      isLoading: true
     )
+  }
+
+  private func loadCommandPaletteCustomCommands() -> Effect<Action> {
+    .run { [terminalClient] send in
+      let result = await terminalClient.loadCustomCommands()
+      await send(.commandPaletteCustomCommandsLoaded(result))
+    }
+    .cancellable(id: TerminalWindowCancelID.commandPaletteLoad, cancelInFlight: true)
   }
 
   private func commandPaletteSnapshot() -> TerminalCommandPaletteSnapshot {
@@ -491,7 +523,7 @@ struct TerminalWindowFeature {
 
   private func resolvedCommandPalette(for state: State) -> ResolvedCommandPalette? {
     guard let commandPalette = state.commandPalette else { return nil }
-    let rows = TerminalCommandPalettePresentation.rows(from: commandPaletteSnapshot())
+    let rows = commandPaletteRows(for: commandPalette)
     let visibleRows = TerminalCommandPalettePresentation.visibleRows(
       in: rows,
       query: commandPalette.query
@@ -512,15 +544,7 @@ struct TerminalWindowFeature {
   ) {
     guard state.commandPalette != nil else { return }
     state.commandPalette?.query = query
-    let rows = TerminalCommandPalettePresentation.rows(from: commandPaletteSnapshot())
-    let visibleRows = TerminalCommandPalettePresentation.visibleRows(
-      in: rows,
-      query: query
-    )
-    state.commandPalette?.selectedRowID = TerminalCommandPalettePresentation.normalizedSelection(
-      nil,
-      in: visibleRows
-    )
+    refreshCommandPaletteSelection(state: &state, preferredRowID: nil)
   }
 
   private func updateCommandPaletteSelection(
@@ -571,6 +595,8 @@ struct TerminalWindowFeature {
     state.commandPalette = nil
 
     switch command {
+    case .customCommand(let command):
+      return executeCustomCommand(.init(command: command))
     case .ghosttyBindingAction(let action):
       return sendCommand(.performGhosttyBindingActionOnFocusedSurface(action))
     case .toggleSidebar:
@@ -584,6 +610,44 @@ struct TerminalWindowFeature {
     case .selectTab(let tabID):
       return sendCommand(.selectTab(tabID))
     }
+  }
+
+  private func executeCustomCommand(
+    _ request: TerminalExecuteCustomCommandRequest
+  ) -> Effect<Action> {
+    .run { [terminalClient] send in
+      guard let result = try? await terminalClient.executeCustomCommand(request) else {
+        return
+      }
+      guard case .confirmationRequired = result else {
+        return
+      }
+      await send(.commandPaletteCustomCommandConfirmationRequested(request))
+    }
+  }
+
+  private func commandPaletteRows(
+    for commandPalette: TerminalCommandPaletteState
+  ) -> [TerminalCommandPaletteRow] {
+    TerminalCommandPalettePresentation.rows(
+      from: commandPaletteSnapshot(),
+      customRows: commandPalette.customRows
+    )
+  }
+
+  private func refreshCommandPaletteSelection(
+    state: inout State,
+    preferredRowID: TerminalCommandPaletteRow.ID? = nil
+  ) {
+    guard let commandPalette = state.commandPalette else { return }
+    let visibleRows = TerminalCommandPalettePresentation.visibleRows(
+      in: commandPaletteRows(for: commandPalette),
+      query: commandPalette.query
+    )
+    state.commandPalette?.selectedRowID = TerminalCommandPalettePresentation.normalizedSelection(
+      preferredRowID ?? commandPalette.selectedRowID,
+      in: visibleRows
+    )
   }
 
   private func executeClose(for target: TerminalCloseTarget) -> Effect<Action> {
@@ -646,6 +710,13 @@ struct TerminalWindowFeature {
         title: "Close All Windows?",
         message: "All terminal sessions will be terminated.",
         confirmTitle: "Close All Windows"
+      )
+    case .executeCustomCommand(let request):
+      return .init(
+        target: .executeCustomCommand(request),
+        title: "Recreate Workspace?",
+        message: "Replace the existing \(request.command.title) space with a fresh workspace?",
+        confirmTitle: "Recreate"
       )
     }
   }

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalCommandPaletteView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalCommandPaletteView.swift
@@ -61,22 +61,26 @@ struct TerminalCommandPaletteOverlay: View {
 
             ScrollViewReader { proxy in
               ScrollView {
-                LazyVStack(spacing: 5) {
-                  ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                    CommandPaletteRowButton(
-                      row: row,
-                      shortcutHint: shortcutHint(for: row, index: index),
-                      theme: theme,
-                      isHovered: hoveredRowID == row.id,
-                      isSelected: selectedRowID == row.id,
-                      action: {
-                        onSelectionChange(index)
-                        onActivate()
+                if rows.isEmpty {
+                  emptyState
+                } else {
+                  LazyVStack(spacing: 5) {
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                      CommandPaletteRowButton(
+                        row: row,
+                        shortcutHint: shortcutHint(for: row, index: index),
+                        theme: theme,
+                        isHovered: hoveredRowID == row.id,
+                        isSelected: selectedRowID == row.id,
+                        action: {
+                          onSelectionChange(index)
+                          onActivate()
+                        }
+                      )
+                      .id(row.id)
+                      .onHover { isHovering in
+                        hoveredRowID = isHovering ? row.id : nil
                       }
-                    )
-                    .id(row.id)
-                    .onHover { isHovering in
-                      hoveredRowID = isHovering ? row.id : nil
                     }
                   }
                 }
@@ -89,6 +93,19 @@ struct TerminalCommandPaletteOverlay: View {
               .onChange(of: selectedRowID) { _, _ in
                 scrollSelection(into: proxy)
               }
+            }
+
+            if let footerText {
+              RoundedRectangle(cornerRadius: 100, style: .continuous)
+                .fill(theme.separator)
+                .frame(height: 0.5)
+
+              Text(footerText)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.secondaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.bottom, 2)
             }
           }
           .padding(10)
@@ -176,6 +193,30 @@ struct TerminalCommandPaletteOverlay: View {
   private func scrollSelection(into proxy: ScrollViewProxy) {
     guard let selectedRowID else { return }
     proxy.scrollTo(selectedRowID, anchor: .center)
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: 8) {
+      Spacer()
+      Text("No commands found")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(theme.primaryText)
+      if !state.query.isEmpty {
+        Text("Try a different search.")
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(theme.secondaryText)
+      }
+      Spacer()
+    }
+    .frame(maxWidth: .infinity, minHeight: 160)
+  }
+
+  private var footerText: String? {
+    if state.isLoading {
+      return "Loading custom commands..."
+    }
+    guard !state.problems.isEmpty else { return nil }
+    return state.problems[0].message
   }
 
   private func shortcutHint(
@@ -398,6 +439,7 @@ private struct TerminalCommandPalettePreviewColumn: View {
           title: "Split Right",
           subtitle: "Split the focused terminal to the right.",
           shortcut: "⌘D",
+          keywords: [],
           command: .ghosttyBindingAction("new_split:right")
         ),
         .init(
@@ -406,6 +448,7 @@ private struct TerminalCommandPalettePreviewColumn: View {
           title: "Split Down",
           subtitle: "Split the focused terminal below.",
           shortcut: "⌘⇧D",
+          keywords: [],
           command: .ghosttyBindingAction("new_split:down")
         ),
         .init(
@@ -414,6 +457,7 @@ private struct TerminalCommandPalettePreviewColumn: View {
           title: "Toggle Sidebar",
           subtitle: "View",
           shortcut: "⌘S",
+          keywords: [],
           command: .toggleSidebar
         ),
         .init(
@@ -422,6 +466,7 @@ private struct TerminalCommandPalettePreviewColumn: View {
           title: "Rename Space",
           subtitle: "Workspace Alpha",
           shortcut: nil,
+          keywords: [],
           command: .renameSpace(.init(name: "Workspace Alpha"))
         ),
       ],

--- a/apps/mac/supatermTests/GhosttySurfaceViewEnvironmentTests.swift
+++ b/apps/mac/supatermTests/GhosttySurfaceViewEnvironmentTests.swift
@@ -38,6 +38,27 @@ struct GhosttySurfaceViewEnvironmentTests {
   }
 
   @Test
+  func supatermEnvironmentVariablesAppendAdditionalEnvironmentVariables() {
+    let environmentVariables = GhosttySurfaceView.supatermEnvironmentVariables(
+      surfaceID: UUID(),
+      tabID: UUID(),
+      socketPath: nil,
+      cliPath: nil,
+      additionalEnvironmentVariables: [
+        .init(key: "APP_ENV", value: "dev"),
+        .init(key: "LOG_LEVEL", value: "debug"),
+      ],
+      processEnvironment: [:]
+    )
+
+    #expect(
+      environmentVariables.suffix(2) == [
+        .init(key: "APP_ENV", value: "dev"),
+        .init(key: "LOG_LEVEL", value: "debug"),
+      ])
+  }
+
+  @Test
   func prependedPathMovesCliDirectoryToFrontWithoutDuplication() {
     #expect(
       GhosttySurfaceView.prependedPath(

--- a/apps/mac/supatermTests/SPCommandTests.swift
+++ b/apps/mac/supatermTests/SPCommandTests.swift
@@ -176,6 +176,15 @@ struct SPCommandTests {
   }
 
   @Test
+  func internalParserAcceptsGenerateCustomCommandsSchemaSubcommand() throws {
+    let command = try #require(
+      try SP.parseAsRoot(["internal", "generate-custom-commands-schema"]) as? SP.GenerateCustomCommandsSchema
+    )
+
+    #expect(type(of: command) == SP.GenerateCustomCommandsSchema.self)
+  }
+
+  @Test
   func tabFocusAndPaneSendParsersAcceptPublicShape() throws {
     let focusCommand = try #require(
       try SP.parseAsRoot(["tab", "focus", "1/2"]) as? SP.SelectTab

--- a/apps/mac/supatermTests/SPHelpTests.swift
+++ b/apps/mac/supatermTests/SPHelpTests.swift
@@ -143,9 +143,12 @@ struct SPHelpTests {
   func internalHelpShowsSettingsSchemaExample() {
     let help = SP.helpMessage(for: SP.Internal.self, columns: 100)
     let schemaHelp = SP.helpMessage(for: SP.GenerateSettingsSchema.self, columns: 100)
+    let customSchemaHelp = SP.helpMessage(for: SP.GenerateCustomCommandsSchema.self, columns: 100)
 
     #expect(help.contains("sp internal generate-settings-schema"))
     #expect(schemaHelp.contains("sp internal generate-settings-schema"))
+    #expect(help.contains("sp internal generate-custom-commands-schema"))
+    #expect(customSchemaHelp.contains("sp internal generate-custom-commands-schema"))
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermCustomCommandsSchemaTests.swift
+++ b/apps/mac/supatermTests/SupatermCustomCommandsSchemaTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+
+struct SupatermCustomCommandsSchemaTests {
+  @Test
+  func generatedSchemaHasCommandsArrayAndExpectedKinds() throws {
+    let data = Data(try SupatermCustomCommandsSchema.jsonString().utf8)
+    let value = try JSONDecoder().decode(JSONValue.self, from: data)
+    let object = try #require(value.objectValue)
+    let properties = try #require(object["properties"]?.objectValue)
+    let commands = try #require(properties["commands"]?.objectValue)
+    let definitions = try #require(object["$defs"]?.objectValue)
+    let workspaceCommand = try #require(definitions["workspaceCommand"]?.objectValue)
+    let workspaceProperties = try #require(workspaceCommand["properties"]?.objectValue)
+    let restartBehavior = try #require(workspaceProperties["restartBehavior"]?.objectValue)
+
+    #expect(object["$id"]?.stringValue == SupatermCustomCommandsSchema.url)
+    #expect(commands["type"]?.stringValue == "array")
+    #expect(
+      restartBehavior["enum"]?.arrayValue == SupatermWorkspaceRestartBehavior.allCases.map { .string($0.rawValue) })
+  }
+
+  @Test
+  func committedWebSchemaMatchesGeneratedSchema() throws {
+    let fileURL = repoRootURL()
+      .appendingPathComponent("apps/supaterm.com")
+      .appendingPathComponent("public/data/supaterm-custom-commands.schema.json")
+    let committedSchema = try JSONDecoder().decode(
+      JSONValue.self,
+      from: Data(try String(contentsOf: fileURL, encoding: .utf8).utf8)
+    )
+    let generatedSchema = try JSONDecoder().decode(
+      JSONValue.self,
+      from: Data(try SupatermCustomCommandsSchema.jsonString().utf8)
+    )
+
+    #expect(committedSchema == generatedSchema)
+  }
+
+  private func repoRootURL(filePath: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: "\(filePath)")
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}

--- a/apps/mac/supatermTests/TerminalCustomCommandCatalogTests.swift
+++ b/apps/mac/supatermTests/TerminalCustomCommandCatalogTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+@testable import supaterm
+
+struct TerminalCustomCommandCatalogTests {
+  @Test
+  func loadMergesNearestLocalOverGlobalAndResolvesRelativePaths() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = try createHomeDirectory(in: root)
+    let globalDirectory = try createGlobalConfigDirectory(in: home)
+    let project = root.appendingPathComponent("project", isDirectory: true)
+    let nested = try createNestedProjectDirectory(in: project)
+
+    try writeCustomCommandsFile(
+      globalCommandsFile(),
+      to: globalDirectory.appendingPathComponent("supaterm.json", isDirectory: false)
+    )
+
+    try writeCustomCommandsFile(
+      localCommandsFile(),
+      to: project.appendingPathComponent("supaterm.json", isDirectory: false)
+    )
+
+    let result = TerminalCustomCommandCatalog.load(
+      focusedWorkingDirectory: nested.path(percentEncoded: false),
+      homeDirectoryPath: home.path(percentEncoded: false)
+    )
+
+    #expect(result.problems.isEmpty)
+    #expect(result.commands.map(\.id) == ["pwd-here", "global-only", "dev-workspace"])
+    #expect(result.commands.first?.title == "Local PWD")
+
+    guard case .workspace(let workspace) = result.commands.last?.kind else {
+      Issue.record("Expected workspace command")
+      return
+    }
+    #expect(workspace.restartBehavior == .recreate)
+    #expect(workspace.spaceName == "Dev Workspace")
+    #expect(workspace.selectedTabIndex == 0)
+    #expect(workspace.tabs[0].focusedLeafIndex == 0)
+
+    guard case .split(let split) = workspace.tabs[0].rootPane else {
+      Issue.record("Expected split pane")
+      return
+    }
+    guard case .leaf(let server) = split.first else {
+      Issue.record("Expected server leaf")
+      return
+    }
+    guard case .leaf(let logs) = split.second else {
+      Issue.record("Expected logs leaf")
+      return
+    }
+
+    let normalizedProjectPath = GhosttySurfaceView.normalizedWorkingDirectoryPath(
+      project.path(percentEncoded: false)
+    )
+    #expect(server.workingDirectoryPath == normalizedProjectPath)
+    #expect(server.environmentVariables == [.init(key: "APP_ENV", value: "dev")])
+    #expect(logs.workingDirectoryPath == normalizedProjectPath)
+  }
+
+  @Test
+  func loadReportsDuplicateIDsAndReservedEnvironmentKeys() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    let configDirectory =
+      home
+      .appendingPathComponent(".config", isDirectory: true)
+      .appendingPathComponent("supaterm", isDirectory: true)
+    try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+
+    let project = root.appendingPathComponent("project", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+
+    try writeCustomCommandsFile(
+      invalidCommandsFile(),
+      to: project.appendingPathComponent("supaterm.json", isDirectory: false)
+    )
+
+    let result = TerminalCustomCommandCatalog.load(
+      focusedWorkingDirectory: project.path(percentEncoded: false),
+      homeDirectoryPath: home.path(percentEncoded: false)
+    )
+
+    #expect(result.commands.map(\.id) == ["dup"])
+    #expect(result.problems.count == 2)
+    #expect(result.problems.contains { $0.message.contains("Duplicate command ids") })
+    #expect(result.problems.contains { $0.message.contains("reserved environment key PATH") })
+  }
+}
+
+private func writeCustomCommandsFile(
+  _ file: SupatermCustomCommandsFile,
+  to url: URL
+) throws {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+  try encoder.encode(file).write(to: url)
+}
+
+private func temporaryDirectory() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}
+
+private func createHomeDirectory(in root: URL) throws -> URL {
+  let url = root.appendingPathComponent("home", isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}
+
+private func createGlobalConfigDirectory(in home: URL) throws -> URL {
+  let url =
+    home
+    .appendingPathComponent(".config", isDirectory: true)
+    .appendingPathComponent("supaterm", isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}
+
+private func createNestedProjectDirectory(in project: URL) throws -> URL {
+  let url =
+    project
+    .appendingPathComponent("src", isDirectory: true)
+    .appendingPathComponent("feature", isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}
+
+private func globalCommandsFile() -> SupatermCustomCommandsFile {
+  .init(
+    commands: [
+      .init(
+        id: "pwd-here",
+        kind: .command,
+        name: "Global PWD",
+        description: "Global",
+        keywords: ["global"],
+        command: "pwd"
+      ),
+      .init(
+        id: "global-only",
+        kind: .command,
+        name: "Global Only",
+        command: "echo global"
+      ),
+    ]
+  )
+}
+
+private func localCommandsFile() -> SupatermCustomCommandsFile {
+  .init(
+    commands: [
+      .init(
+        id: "pwd-here",
+        kind: .command,
+        name: "Local PWD",
+        description: "Local",
+        keywords: ["local"],
+        command: "pwd && echo local"
+      ),
+      .init(
+        id: "dev-workspace",
+        kind: .workspace,
+        name: "Dev Workspace",
+        restartBehavior: .recreate,
+        workspace: .init(
+          spaceName: "Dev Workspace",
+          tabs: [
+            .init(
+              title: "App",
+              cwd: ".",
+              selected: true,
+              rootPane: .split(
+                .init(
+                  direction: .right,
+                  ratio: 0.5,
+                  first: .leaf(
+                    .init(
+                      title: "Server",
+                      cwd: ".",
+                      command: "pwd",
+                      focus: true,
+                      env: .init(["APP_ENV": "dev"])
+                    )
+                  ),
+                  second: .leaf(
+                    .init(
+                      title: "Logs",
+                      command: "tail -f log.txt"
+                    )
+                  )
+                )
+              ),
+            ),
+          ],
+        )
+      ),
+    ]
+  )
+}
+
+private func invalidCommandsFile() -> SupatermCustomCommandsFile {
+  .init(
+    commands: [
+      .init(
+        id: "dup",
+        kind: .command,
+        name: "One",
+        command: "echo one"
+      ),
+      .init(
+        id: "dup",
+        kind: .command,
+        name: "Two",
+        command: "echo two"
+      ),
+      .init(
+        id: "bad-env",
+        kind: .workspace,
+        name: "Bad Env",
+        workspace: .init(
+          spaceName: "Bad Env",
+          tabs: [
+            .init(
+              title: "App",
+              rootPane: .leaf(
+                .init(
+                  command: "pwd",
+                  env: .init(["PATH": "/tmp/bin"])
+                )
+              ),
+            ),
+          ],
+        )
+      ),
+    ]
+  )
+}

--- a/apps/mac/supatermTests/TerminalCustomCommandExecutionTests.swift
+++ b/apps/mac/supatermTests/TerminalCustomCommandExecutionTests.swift
@@ -1,0 +1,171 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+@testable import supaterm
+
+@MainActor
+struct TerminalCustomCommandExecutionTests {
+  @Test
+  func workspaceFocusExistingSelectsMatchingSpaceCaseInsensitively() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+      _ = try host.createSpace(
+        .init(
+          name: "DEV WORKSPACE",
+          target: .init(contextPaneID: nil, windowIndex: 1)
+        )
+      )
+
+      let workspaceSpaceID = try #require(host.selectedSpaceID)
+      _ = try host.createTab(
+        .init(
+          command: nil,
+          cwd: nil,
+          focus: false,
+          target: .space(windowIndex: 1, spaceIndex: 2)
+        )
+      )
+      let originalTabIDs = host.spaceManager.tabs(in: workspaceSpaceID).map(\.id)
+
+      let result = try host.executeCustomCommand(
+        .init(command: makeWorkspaceCommandSnapshot(restartBehavior: .focusExisting))
+      )
+
+      switch result {
+      case .executed:
+        break
+      case .confirmationRequired:
+        Issue.record("Expected executed result")
+      }
+      #expect(host.selectedSpaceID == workspaceSpaceID)
+      #expect(host.spaceManager.tabs(in: workspaceSpaceID).map(\.id) == originalTabIDs)
+    }
+  }
+
+  @Test
+  func workspaceRecreateRebuildsSingleMatchingSpaceWithoutDummyReplacement() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+      _ = try host.renameSpace(
+        .init(
+          name: "Dev Workspace",
+          target: .space(windowIndex: 1, spaceIndex: 1)
+        )
+      )
+
+      let result = try host.executeCustomCommand(
+        .init(command: makeWorkspaceCommandSnapshot(restartBehavior: .recreate))
+      )
+
+      switch result {
+      case .executed:
+        break
+      case .confirmationRequired:
+        Issue.record("Expected executed result")
+      }
+      #expect(host.spaces.count == 1)
+      #expect(host.selectedSpaceID == host.spaces[0].id)
+
+      let debug = host.debugWindowSnapshot(index: 1)
+      let space = try #require(debug.spaces.first)
+      let tab = try #require(space.tabs.first)
+
+      #expect(space.name == "Dev Workspace")
+      #expect(debug.spaces.count == 1)
+      #expect(space.tabs.count == 1)
+      #expect(tab.title == "App")
+      #expect(tab.panes.map(\.displayTitle) == ["Server", "Logs"])
+      #expect(tab.panes.filter(\.isFocused).count == 1)
+      #expect(tab.panes.first(where: \.isFocused)?.displayTitle == "Server")
+    }
+  }
+
+  @Test
+  func workspaceConfirmRecreateRequestsConfirmationWhenMatchingSpaceExists() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = TerminalHostState()
+      host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+      _ = try host.renameSpace(
+        .init(
+          name: "Dev Workspace",
+          target: .space(windowIndex: 1, spaceIndex: 1)
+        )
+      )
+
+      let result = try host.executeCustomCommand(
+        .init(command: makeWorkspaceCommandSnapshot(restartBehavior: .confirmRecreate))
+      )
+
+      switch result {
+      case .confirmationRequired:
+        break
+      case .executed:
+        Issue.record("Expected confirmation result")
+      }
+      #expect(host.spaces.count == 1)
+      #expect(host.spaceManager.tabs(in: host.spaces[0].id).count == 1)
+    }
+  }
+}
+
+private func makeWorkspaceCommandSnapshot(
+  restartBehavior: SupatermWorkspaceRestartBehavior
+) -> TerminalCustomCommandSnapshot {
+  .init(
+    id: "dev-workspace",
+    title: "Dev Workspace",
+    subtitle: "Workspace",
+    keywords: ["workspace"],
+    kind: .workspace(
+      .init(
+        restartBehavior: restartBehavior,
+        spaceName: "Dev Workspace",
+        tabs: [
+          .init(
+            title: "App",
+            rootPane: .split(
+              .init(
+                direction: .right,
+                ratio: 0.5,
+                first: .leaf(
+                  .init(
+                    title: "Server",
+                    workingDirectoryPath: FileManager.default.temporaryDirectory.path(percentEncoded: false),
+                    command: "pwd",
+                    environmentVariables: [.init(key: "APP_ENV", value: "dev")]
+                  )
+                ),
+                second: .leaf(
+                  .init(
+                    title: "Logs",
+                    workingDirectoryPath: FileManager.default.temporaryDirectory.path(percentEncoded: false),
+                    command: "pwd",
+                    environmentVariables: []
+                  )
+                )
+              )
+            ),
+            focusedLeafIndex: 0,
+          ),
+        ],
+        selectedTabIndex: 0
+      )
+    )
+  )
+}

--- a/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
@@ -60,7 +60,7 @@ struct TerminalWindowFeatureTests {
       recorder.commands == [
         .ensureInitialTab(
           focusing: false,
-          startupInput: "sp onboard\n",
+          startupInput: "sp onboard\n"
         ),
       ]
     )
@@ -466,12 +466,17 @@ struct TerminalWindowFeatureTests {
       TerminalWindowFeature()
     } withDependencies: {
       $0.terminalClient.commandPaletteSnapshot = { snapshot }
+      $0.terminalClient.loadCustomCommands = { .empty }
     }
 
     await store.send(.commandPaletteToggleRequested) {
       $0.commandPalette = .init(
-        selectedRowID: rows.first?.id
+        selectedRowID: rows.first?.id,
+        isLoading: true
       )
+    }
+    await store.receive(\.commandPaletteCustomCommandsLoaded) {
+      $0.commandPalette?.isLoading = false
     }
   }
 
@@ -609,14 +614,135 @@ struct TerminalWindowFeatureTests {
       TerminalWindowFeature()
     } withDependencies: {
       $0.terminalClient.commandPaletteSnapshot = { snapshot }
+      $0.terminalClient.loadCustomCommands = { .empty }
     }
 
     await store.send(.clientEvent(.commandPaletteToggleRequested))
     await store.receive(\.commandPaletteToggleRequested) {
       $0.commandPalette = .init(
-        selectedRowID: rows.first?.id
+        selectedRowID: rows.first?.id,
+        isLoading: true
       )
     }
+    await store.receive(\.commandPaletteCustomCommandsLoaded) {
+      $0.commandPalette?.isLoading = false
+    }
+  }
+
+  @Test
+  func commandPaletteCustomCommandsLoadedUpdatesRowsAndProblems() async {
+    let snapshot = makeCommandPaletteSnapshot()
+    let command = makeCustomCommandSnapshot()
+    let store = TestStore(initialState: TerminalWindowFeature.State()) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.commandPaletteSnapshot = { snapshot }
+      $0.terminalClient.loadCustomCommands = {
+        .init(
+          commands: [command],
+          problems: [.init(message: "Failed to load local supaterm.json")]
+        )
+      }
+    }
+
+    await store.send(.commandPaletteToggleRequested) {
+      $0.commandPalette = .init(
+        selectedRowID: TerminalCommandPalettePresentation.rows(from: snapshot).first?.id,
+        isLoading: true
+      )
+    }
+    await store.receive(\.commandPaletteCustomCommandsLoaded) {
+      $0.commandPalette?.customRows = TerminalCommandPalettePresentation.customRows(from: [command])
+      $0.commandPalette?.problems = [.init(message: "Failed to load local supaterm.json")]
+      $0.commandPalette?.isLoading = false
+    }
+  }
+
+  @Test
+  func commandPaletteActivateSelectionExecutesCustomCommandAndClosesPalette() async {
+    let recorder = TerminalExecuteCustomCommandRecorder()
+    let customCommand = makeCustomCommandSnapshot()
+    var initialState = TerminalWindowFeature.State()
+    initialState.commandPalette = .init(
+      selectedRowID: "custom:\(customCommand.id)",
+      customRows: TerminalCommandPalettePresentation.customRows(from: [customCommand])
+    )
+
+    let store = TestStore(initialState: initialState) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.commandPaletteSnapshot = { makeCommandPaletteSnapshot() }
+      $0.terminalClient.executeCustomCommand = { request in
+        await recorder.record(request)
+        return .executed
+      }
+    }
+
+    await store.send(.commandPaletteActivateSelection) {
+      $0.commandPalette = nil
+    }
+
+    #expect(await recorder.snapshot() == [.init(command: customCommand)])
+  }
+
+  @Test
+  func commandPaletteActivateSelectionRequestsConfirmationForRecreateWorkspace() async {
+    let customCommand = makeConfirmingWorkspaceCommandSnapshot()
+    var initialState = TerminalWindowFeature.State()
+    initialState.commandPalette = .init(
+      selectedRowID: "custom:\(customCommand.id)",
+      customRows: TerminalCommandPalettePresentation.customRows(from: [customCommand])
+    )
+
+    let store = TestStore(initialState: initialState) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.commandPaletteSnapshot = { makeCommandPaletteSnapshot() }
+      $0.terminalClient.executeCustomCommand = { _ in
+        .confirmationRequired
+      }
+    }
+
+    await store.send(.commandPaletteActivateSelection) {
+      $0.commandPalette = nil
+    }
+    await store.receive(\.commandPaletteCustomCommandConfirmationRequested) {
+      $0.confirmationRequest = .init(
+        target: .executeCustomCommand(.init(command: customCommand)),
+        title: "Recreate Workspace?",
+        message: "Replace the existing \(customCommand.title) space with a fresh workspace?",
+        confirmTitle: "Recreate"
+      )
+    }
+  }
+
+  @Test
+  func confirmationConfirmButtonTappedExecutesConfirmedCustomCommand() async {
+    let recorder = TerminalExecuteCustomCommandRecorder()
+    let customCommand = makeConfirmingWorkspaceCommandSnapshot()
+    let request = TerminalExecuteCustomCommandRequest(command: customCommand)
+    var initialState = TerminalWindowFeature.State()
+    initialState.confirmationRequest = .init(
+      target: .executeCustomCommand(request),
+      title: "Recreate Workspace?",
+      message: "Replace the existing \(customCommand.title) space with a fresh workspace?",
+      confirmTitle: "Recreate"
+    )
+
+    let store = TestStore(initialState: initialState) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.executeCustomCommand = { request in
+        await recorder.record(request)
+        return .executed
+      }
+    }
+
+    await store.send(.confirmationConfirmButtonTapped) {
+      $0.confirmationRequest = nil
+    }
+
+    #expect(await recorder.snapshot() == [.init(command: customCommand, isConfirmed: true)])
   }
 
   @Test
@@ -1019,6 +1145,46 @@ private func makeCommandPaletteSnapshot() -> TerminalCommandPaletteSnapshot {
   )
 }
 
+private func makeCustomCommandSnapshot() -> TerminalCustomCommandSnapshot {
+  .init(
+    id: "pwd-here",
+    title: "PWD Here",
+    subtitle: "Print the current directory",
+    keywords: ["pwd"],
+    kind: .command(.init(command: "pwd"))
+  )
+}
+
+private func makeConfirmingWorkspaceCommandSnapshot() -> TerminalCustomCommandSnapshot {
+  .init(
+    id: "dev-workspace",
+    title: "Dev Workspace",
+    subtitle: "Workspace",
+    keywords: ["workspace"],
+    kind: .workspace(
+      .init(
+        restartBehavior: .confirmRecreate,
+        spaceName: "Dev Workspace",
+        tabs: [
+          .init(
+            title: "App",
+            rootPane: .leaf(
+              .init(
+                title: "Server",
+                workingDirectoryPath: "/tmp",
+                command: "pwd",
+                environmentVariables: []
+              )
+            ),
+            focusedLeafIndex: 0,
+          ),
+        ],
+        selectedTabIndex: 0
+      )
+    )
+  )
+}
+
 private actor TerminalDesktopNotificationRecorder {
   private var requests: [DesktopNotificationRequest] = []
 
@@ -1027,6 +1193,18 @@ private actor TerminalDesktopNotificationRecorder {
   }
 
   func snapshot() -> [DesktopNotificationRequest] {
+    requests
+  }
+}
+
+private actor TerminalExecuteCustomCommandRecorder {
+  private var requests: [TerminalExecuteCustomCommandRequest] = []
+
+  func record(_ request: TerminalExecuteCustomCommandRequest) {
+    requests.append(request)
+  }
+
+  func snapshot() -> [TerminalExecuteCustomCommandRequest] {
     requests
   }
 }

--- a/apps/supaterm.com/public/data/supaterm-custom-commands.schema.json
+++ b/apps/supaterm.com/public/data/supaterm-custom-commands.schema.json
@@ -1,0 +1,217 @@
+{
+  "$defs": {
+    "command": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/simpleCommand"
+        },
+        {
+          "$ref": "#/$defs/workspaceCommand"
+        }
+      ]
+    },
+    "leafPane": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "type": "object"
+        },
+        "focus": {
+          "default": false,
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "leaf",
+          "type": "string"
+        }
+      },
+      "required": ["type"],
+      "type": "object"
+    },
+    "pane": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/leafPane"
+        },
+        {
+          "$ref": "#/$defs/splitPane"
+        }
+      ]
+    },
+    "simpleCommand": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "description": "Shell text to send to the focused pane.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional subtitle in the command palette.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable command identifier used for local-over-global overrides.",
+          "type": "string"
+        },
+        "keywords": {
+          "default": [],
+          "description": "Extra search terms for fuzzy matching.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "command",
+          "type": "string"
+        },
+        "name": {
+          "description": "Visible title in the command palette.",
+          "type": "string"
+        }
+      },
+      "required": ["id", "kind", "name", "command"],
+      "type": "object"
+    },
+    "splitPane": {
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "enum": ["left", "right", "up", "down"],
+          "type": "string"
+        },
+        "first": {
+          "$ref": "#/$defs/pane"
+        },
+        "ratio": {
+          "default": 0.5,
+          "type": "number"
+        },
+        "second": {
+          "$ref": "#/$defs/pane"
+        },
+        "type": {
+          "const": "split",
+          "type": "string"
+        }
+      },
+      "required": ["type", "direction", "first", "second"],
+      "type": "object"
+    },
+    "tab": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "description": "Optional working directory for panes in this tab.",
+          "type": "string"
+        },
+        "rootPane": {
+          "$ref": "#/$defs/pane"
+        },
+        "selected": {
+          "default": false,
+          "description": "Whether this tab should be selected after launch.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "The locked title for the tab.",
+          "type": "string"
+        }
+      },
+      "required": ["title", "rootPane"],
+      "type": "object"
+    },
+    "workspace": {
+      "additionalProperties": false,
+      "properties": {
+        "spaceName": {
+          "description": "The target space name for this workspace.",
+          "type": "string"
+        },
+        "tabs": {
+          "items": {
+            "$ref": "#/$defs/tab"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["spaceName", "tabs"],
+      "type": "object"
+    },
+    "workspaceCommand": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "Optional subtitle in the command palette.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable command identifier used for local-over-global overrides.",
+          "type": "string"
+        },
+        "keywords": {
+          "default": [],
+          "description": "Extra search terms for fuzzy matching.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "workspace",
+          "type": "string"
+        },
+        "name": {
+          "description": "Visible title in the command palette.",
+          "type": "string"
+        },
+        "restartBehavior": {
+          "default": "focus_existing",
+          "description": "What to do when a space with the same name already exists.",
+          "enum": ["focus_existing", "recreate", "confirm_recreate"],
+          "type": "string"
+        },
+        "workspace": {
+          "$ref": "#/$defs/workspace"
+        }
+      },
+      "required": ["id", "kind", "name", "workspace"],
+      "type": "object"
+    }
+  },
+  "$id": "https://supaterm.com/data/supaterm-custom-commands.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "User-defined command palette commands and workspaces for Supaterm.",
+  "properties": {
+    "$schema": {
+      "default": "https://supaterm.com/data/supaterm-custom-commands.schema.json",
+      "description": "Optional schema URL for editor completion and validation.",
+      "format": "uri",
+      "type": "string"
+    },
+    "commands": {
+      "description": "The command-palette commands available in this scope.",
+      "items": {
+        "$ref": "#/$defs/command"
+      },
+      "type": "array"
+    }
+  },
+  "required": ["commands"],
+  "title": "supaterm.json",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Problem: the command palette had no path for user-defined commands or repeatable workspace launches from `supaterm.json`
- Why it matters: users could not define reusable project commands or recreate named terminal layouts from the palette
- What changed: added shared custom-command models and schema generation, global plus nearest-local command loading and merge rules, palette integration for resolved custom rows, and host-owned execution for simple commands plus workspace launches
- What did NOT change (scope boundary): no browser panes, no mixed surface layouts, and no new socket-facing workspace request surface

## Rationale

This keeps config discovery, path resolution, merge precedence, environment validation, and workspace sequencing inside one terminal-owned boundary instead of leaking those rules into the palette reducer. The host already had the right space and split-tree primitives, so the cleanest forward path was to compose those directly rather than add another orchestration layer.

## User-visible / Behavior Changes

- Users can define custom command palette entries in `supaterm.json`
- Simple custom commands run in the focused pane
- Workspace commands can create or focus a named space and materialize tabs plus panes with titles, cwd, startup commands, and environment variables
- The palette now shows custom-command load problems without breaking built-in actions

## Diagram (if applicable)

```text
Before:
[cmd-p] -> [built-in rows only] -> [no user-defined execution path]

After:
[cmd-p] -> [built-ins + resolved custom rows]
         -> [select custom command]
         -> [host loads/merges config]
         -> [run in focused pane OR recreate/focus workspace]
```

## Human Verification

- Verified scenarios:
  - ran focused mac tests for the custom-command catalog and palette reducer paths
  - push hooks passed `make web-check` and the full mac `xcodebuild test` suite after rebasing onto `main`
- Edge cases checked:
  - nearest-local config overrides global by `id`
  - reserved environment keys are rejected
  - recreate confirmation flow still routes through the existing confirmation path
- What you did **not** verify:
  - no live manual app run of `cmd-p` with a hand-authored `supaterm.json` in this rebased pass
- How can a human manually verify this:
  - create a `supaterm.json` with one simple command and one workspace command in a project directory
  - launch the app, focus a pane in that directory, press `cmd-p`, and run the custom entries
  - confirm the simple command writes into the focused pane and the workspace command recreates or focuses the named space with the expected layout
