### PR TITLE
Implement SSH-safe OSC 777 remote notifications

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
+++ b/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
@@ -28,7 +28,7 @@ public enum SupatermManagedHookCommand {
   }
 
   static func remoteReceiveHookCommand(for agent: SupatermAgentKind) -> String {
-    #"python3 -c \#(shellQuoted(remoteNotificationPythonSource())) \#(shellQuoted(agent.notificationTitle)) || true;"#
+    #"python3 -c \#(shellQuoted(remoteNotificationPythonSource)) \#(shellQuoted(agent.notificationTitle)) || true;"#
   }
 
   static func isManagedCommand(_ command: String?) -> Bool {
@@ -49,26 +49,24 @@ public enum SupatermManagedHookCommand {
     return trimmed
   }
 
-  private static func remoteNotificationPythonSource() -> String {
-    [
-      "import json, re, sys",
-      "event = json.load(sys.stdin)",
-      "if event.get(\"hook_event_name\") not in (\"Notification\", \"Stop\"):",
-      "    raise SystemExit(0)",
-      "def clean(value):",
-      "    if not isinstance(value, str):",
-      "        return \"\"",
-      "    value = re.sub(r\"[\\x00-\\x1f\\x7f\\x9b;]+\", \" \", value)",
-      "    value = re.sub(r\"\\s+\", \" \", value).strip()",
-      "    return value",
-      "agent_title = clean(sys.argv[1])",
-      "title = clean(event.get(\"title\")) or agent_title",
-      "body = clean(event.get(\"message\") or event.get(\"last_assistant_message\"))",
-      "if not body:",
-      "    raise SystemExit(0)",
-      "sys.stdout.write(f\"\\033]777;notify;{title};{body}\\a\")",
-    ].joined(separator: "\n")
-  }
+  private static let remoteNotificationPythonSource = #"""
+import json, re, sys
+event = json.load(sys.stdin)
+if event.get("hook_event_name") not in ("Notification", "Stop"):
+    raise SystemExit(0)
+def clean(value):
+    if not isinstance(value, str):
+        return ""
+    value = re.sub(r"[\x00-\x1f\x7f\x9b;]+", " ", value)
+    value = re.sub(r"\s+", " ", value).strip()
+    return value
+agent_title = clean(sys.argv[1])
+title = clean(event.get("title")) or agent_title
+body = clean(event.get("message") or event.get("last_assistant_message"))
+if not body:
+    raise SystemExit(0)
+sys.stdout.write(f"\033]777;notify;{title};{body}\a")
+"""#
 
   private static func shellQuoted(_ value: String) -> String {
     "'" + value.replacingOccurrences(of: "'", with: #"'\"'\"'"#) + "'"

--- a/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
+++ b/apps/mac/SupatermCLIShared/SupatermManagedHookCommand.swift
@@ -2,11 +2,33 @@ import Foundation
 
 public enum SupatermManagedHookCommand {
   public static func receiveHookCommand(for agent: SupatermAgentKind) -> String {
-    #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent \#(agent.rawValue) || true"#
+    [
+      "if \(localCommandCondition); then",
+      localReceiveHookCommand(for: agent),
+      "elif \(remoteCommandCondition); then",
+      remoteReceiveHookCommand(for: agent),
+      "else",
+      "true;",
+      "fi",
+    ].joined(separator: " ")
   }
 
   public static func installArguments(for agent: SupatermAgentKind) -> [String] {
     ["agent", "install-hook", agent.rawValue]
+  }
+
+  static let localCommandCondition =
+    #"[ -n "${SUPATERM_SOCKET_PATH:-}" ] && [ -n "${SUPATERM_CLI_PATH:-}" ]"#
+
+  static let remoteCommandCondition =
+    #"[ "${SUPATERM_REMOTE_NOTIFICATIONS:-}" = "1" ] || [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_TTY:-}" ]"#
+
+  static func localReceiveHookCommand(for agent: SupatermAgentKind) -> String {
+    #""${SUPATERM_CLI_PATH}" agent receive-agent-hook --agent \#(agent.rawValue) || true;"#
+  }
+
+  static func remoteReceiveHookCommand(for agent: SupatermAgentKind) -> String {
+    #"python3 -c \#(shellQuoted(remoteNotificationPythonSource())) \#(shellQuoted(agent.notificationTitle)) || true;"#
   }
 
   static func isManagedCommand(_ command: String?) -> Bool {
@@ -25,5 +47,30 @@ public enum SupatermManagedHookCommand {
       return nil
     }
     return trimmed
+  }
+
+  private static func remoteNotificationPythonSource() -> String {
+    [
+      "import json, re, sys",
+      "event = json.load(sys.stdin)",
+      "if event.get(\"hook_event_name\") not in (\"Notification\", \"Stop\"):",
+      "    raise SystemExit(0)",
+      "def clean(value):",
+      "    if not isinstance(value, str):",
+      "        return \"\"",
+      "    value = re.sub(r\"[\\x00-\\x1f\\x7f\\x9b;]+\", \" \", value)",
+      "    value = re.sub(r\"\\s+\", \" \", value).strip()",
+      "    return value",
+      "agent_title = clean(sys.argv[1])",
+      "title = clean(event.get(\"title\")) or agent_title",
+      "body = clean(event.get(\"message\") or event.get(\"last_assistant_message\"))",
+      "if not body:",
+      "    raise SystemExit(0)",
+      "sys.stdout.write(f\"\\033]777;notify;{title};{body}\\a\")",
+    ].joined(separator: "\n")
+  }
+
+  private static func shellQuoted(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: #"'\"'\"'"#) + "'"
   }
 }

--- a/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
@@ -64,6 +64,7 @@ struct ClaudeSettingsInstallerTests {
   func installCanonicalizesDriftedSupatermEntries() throws {
     let homeDirectoryURL = try temporaryHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
+    let command = try jsonStringLiteral(SupatermClaudeHookSettings.command)
 
     try writeSettings(
       """
@@ -75,7 +76,7 @@ struct ClaudeSettingsInstallerTests {
               "hooks": [
                 {
                   "async": false,
-                  "command": "\(SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\""))",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -105,7 +106,7 @@ struct ClaudeSettingsInstallerTests {
     let homeDirectoryURL = try temporaryHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
 
-    let escapedCommand = SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermClaudeHookSettings.command)
     try writeSettings(
       """
       {
@@ -115,7 +116,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 10,
                   "type": "command"
                 }
@@ -125,7 +126,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 20,
                   "type": "command"
                 }
@@ -153,7 +154,7 @@ struct ClaudeSettingsInstallerTests {
   func installReplacesExistingSupatermCommand() throws {
     let homeDirectoryURL = try temporaryHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let command = SupatermClaudeHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermClaudeHookSettings.command)
 
     try writeSettings(
       """
@@ -164,7 +165,7 @@ struct ClaudeSettingsInstallerTests {
               "matcher": "",
               "hooks": [
                 {
-                  "command": "\(command)",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }

--- a/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/CodexSettingsInstallerTests.swift
@@ -70,6 +70,7 @@ struct CodexSettingsInstallerTests {
   func installCanonicalizesDriftedSupatermEntries() throws {
     let homeDirectoryURL = try temporaryCodexHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
+    let command = try jsonStringLiteral(SupatermCodexHookSettings.command)
 
     try writeCodexSettings(
       """
@@ -80,7 +81,7 @@ struct CodexSettingsInstallerTests {
               "matcher": ".*",
               "hooks": [
                 {
-                  "command": "\(SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\""))",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }
@@ -116,7 +117,7 @@ struct CodexSettingsInstallerTests {
     let homeDirectoryURL = try temporaryCodexHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
 
-    let escapedCommand = SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermCodexHookSettings.command)
     try writeCodexSettings(
       """
       {
@@ -125,7 +126,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 10,
                   "type": "command"
                 }
@@ -134,7 +135,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(escapedCommand)",
+                  "command": \(command),
                   "timeout": 20,
                   "type": "command"
                 }
@@ -167,7 +168,7 @@ struct CodexSettingsInstallerTests {
   func installReplacesExistingSupatermCommand() throws {
     let homeDirectoryURL = try temporaryCodexHomeDirectory()
     defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let command = SupatermCodexHookSettings.command.replacingOccurrences(of: "\"", with: "\\\"")
+    let command = try jsonStringLiteral(SupatermCodexHookSettings.command)
 
     try writeCodexSettings(
       """
@@ -177,7 +178,7 @@ struct CodexSettingsInstallerTests {
             {
               "hooks": [
                 {
-                  "command": "\(command)",
+                  "command": \(command),
                   "timeout": 99,
                   "type": "command"
                 }

--- a/apps/mac/supatermTests/CommandExecutionTestSupport.swift
+++ b/apps/mac/supatermTests/CommandExecutionTestSupport.swift
@@ -4,6 +4,12 @@ import Testing
 
 @testable import SupatermCLIShared
 
+struct CommandExecutionResult: Equatable {
+  let status: Int32
+  let standardError: String
+  let standardOutput: String
+}
+
 func writeExecutable(
   at url: URL,
   script: String
@@ -62,6 +68,51 @@ func runExecutable(
     Issue.record("Command failed with status \(process.terminationStatus): \(stderr)")
   }
   return stdout
+}
+
+func runExecutable(
+  at executableURL: URL,
+  arguments: [String],
+  environment: [String: String],
+  standardInput: String
+) throws -> CommandExecutionResult {
+  let process = Process()
+  process.executableURL = executableURL
+  process.arguments = arguments
+  var processEnvironment = ProcessInfo.processInfo.environment
+  for (key, value) in environment {
+    processEnvironment[key] = value
+  }
+  process.environment = processEnvironment
+
+  let stdinPipe = Pipe()
+  let stdoutPipe = Pipe()
+  let stderrPipe = Pipe()
+  process.standardInput = stdinPipe
+  process.standardOutput = stdoutPipe
+  process.standardError = stderrPipe
+
+  try process.run()
+  stdinPipe.fileHandleForWriting.write(Data(standardInput.utf8))
+  try stdinPipe.fileHandleForWriting.close()
+  process.waitUntilExit()
+
+  let standardOutput =
+    String(
+      data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    ) ?? ""
+  let standardError =
+    String(
+      data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    ) ?? ""
+
+  return .init(
+    status: process.terminationStatus,
+    standardError: standardError,
+    standardOutput: standardOutput
+  )
 }
 
 func makeCommandExecutionTemporaryDirectory() throws -> URL {

--- a/apps/mac/supatermTests/JSONTestSupport.swift
+++ b/apps/mac/supatermTests/JSONTestSupport.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+func jsonStringLiteral(_ value: String) throws -> String {
+  let data = try JSONSerialization.data(withJSONObject: [value], options: [])
+  guard let string = String(data: data, encoding: .utf8) else {
+    throw CocoaError(.coderInvalidValue)
+  }
+  guard string.count >= 2 else {
+    throw CocoaError(.coderInvalidValue)
+  }
+  return String(string.dropFirst().dropLast())
+}

--- a/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
@@ -6,10 +6,11 @@ import Testing
 struct SupatermClaudeHookSettingsTests {
   @Test
   func commandStaysStable() {
-    #expect(
-      SupatermClaudeHookSettings.command
-        == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent claude || true"#
-    )
+    let command = SupatermClaudeHookSettings.command
+
+    #expect(command == SupatermManagedHookCommand.receiveHookCommand(for: .claude))
+    #expect(command.contains(SupatermManagedHookCommand.localCommandCondition))
+    #expect(command.contains(SupatermManagedHookCommand.remoteCommandCondition))
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermCodexHookSettingsTests.swift
@@ -6,10 +6,11 @@ import Testing
 struct SupatermCodexHookSettingsTests {
   @Test
   func commandStaysStable() {
-    #expect(
-      SupatermCodexHookSettings.command
-        == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent codex || true"#
-    )
+    let command = SupatermCodexHookSettings.command
+
+    #expect(command == SupatermManagedHookCommand.receiveHookCommand(for: .codex))
+    #expect(command.contains(SupatermManagedHookCommand.localCommandCondition))
+    #expect(command.contains(SupatermManagedHookCommand.remoteCommandCondition))
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermManagedHookCommandTests.swift
+++ b/apps/mac/supatermTests/SupatermManagedHookCommandTests.swift
@@ -13,11 +13,14 @@ struct SupatermManagedHookCommandTests {
   }
 
   @Test
-  func receiveHookCommandBuildsPiCommand() {
-    #expect(
-      SupatermManagedHookCommand.receiveHookCommand(for: .pi)
-        == #"[ -n "${SUPATERM_CLI_PATH:-}" ] && "$SUPATERM_CLI_PATH" agent receive-agent-hook --agent pi || true"#
-    )
+  func receiveHookCommandIncludesLocalAndRemoteBranches() {
+    let command = SupatermManagedHookCommand.receiveHookCommand(for: .pi)
+
+    #expect(command.contains(SupatermManagedHookCommand.localCommandCondition))
+    #expect(command.contains(SupatermManagedHookCommand.remoteCommandCondition))
+    #expect(command.contains(#"agent receive-agent-hook --agent pi"#))
+    #expect(command.contains("python3"))
+    #expect(command.contains("]777;notify;"))
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermManagedHookRemoteNotificationTests.swift
+++ b/apps/mac/supatermTests/SupatermManagedHookRemoteNotificationTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import SupatermCLIShared
+
+struct ManagedHookRemoteNotificationTests {
+  @Test
+  func remoteCommandEmitsOSC777ForNotificationPayload() throws {
+    let result = try runReceiveHookCommand(
+      for: .claude,
+      input: ClaudeHookFixtures.notification,
+      environment: ["SSH_CONNECTION": "remote 1 2"]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.standardError.isEmpty)
+    #expect(
+      result.standardOutput
+        == "\u{001B}]777;notify;Needs input;Claude needs your attention\u{0007}"
+    )
+  }
+
+  @Test
+  func remoteCommandUsesAssistantMessageAndAgentTitleForStopEvent() throws {
+    let result = try runReceiveHookCommand(
+      for: .codex,
+      input: CodexHookFixtures.stop,
+      environment: ["SSH_TTY": "/dev/ttys001"]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.standardError.isEmpty)
+    #expect(result.standardOutput == "\u{001B}]777;notify;Codex;Done.\u{0007}")
+  }
+
+  @Test
+  func remoteCommandSanitizesControlCharactersAndDelimiters() throws {
+    let input = """
+      {
+        "hook_event_name": "Notification",
+        "title": "  Needs;\\u001b  input\\n",
+        "message": "Build;\\u0007\\nfinished\\tsoon"
+      }
+      """
+    let result = try runReceiveHookCommand(
+      for: .claude,
+      input: input,
+      environment: ["SUPATERM_REMOTE_NOTIFICATIONS": "1"]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.standardError.isEmpty)
+    #expect(
+      result.standardOutput
+        == "\u{001B}]777;notify;Needs input;Build finished soon\u{0007}"
+    )
+  }
+
+  @Test
+  func remoteCommandSkipsNonNotificationHooks() throws {
+    let result = try runReceiveHookCommand(
+      for: .codex,
+      input: CodexHookFixtures.preToolUse,
+      environment: ["SSH_CONNECTION": "remote 1 2"]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.standardError.isEmpty)
+    #expect(result.standardOutput.isEmpty)
+  }
+
+  @Test
+  func localCommandWinsWhenSocketPathIsPresent() throws {
+    let directoryURL = try makeCommandExecutionTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let argsURL = directoryURL.appendingPathComponent("args.txt", isDirectory: false)
+    let stdinURL = directoryURL.appendingPathComponent("stdin.json", isDirectory: false)
+    let cliURL = directoryURL.appendingPathComponent("bin/sp", isDirectory: false)
+    try writeExecutable(
+      at: cliURL,
+      script: """
+        #!/bin/sh
+        printf '%s' "$*" > "\(argsURL.path)"
+        cat > "\(stdinURL.path)"
+        """
+    )
+
+    let result = try runReceiveHookCommand(
+      for: .claude,
+      input: ClaudeHookFixtures.notification,
+      environment: [
+        "SSH_CONNECTION": "remote 1 2",
+        "SUPATERM_CLI_PATH": cliURL.path,
+        "SUPATERM_SOCKET_PATH": "/tmp/supaterm.sock",
+      ]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.standardError.isEmpty)
+    #expect(result.standardOutput.isEmpty)
+    #expect(try String(contentsOf: argsURL, encoding: .utf8) == "agent receive-agent-hook --agent claude")
+    #expect(
+      try String(contentsOf: stdinURL, encoding: .utf8)
+        .contains(#""hook_event_name": "Notification""#)
+    )
+  }
+}
+
+private func runReceiveHookCommand(
+  for agent: SupatermAgentKind,
+  input: String,
+  environment: [String: String]
+) throws -> CommandExecutionResult {
+  try runExecutable(
+    at: URL(fileURLWithPath: "/bin/sh", isDirectory: false),
+    arguments: ["-c", SupatermManagedHookCommand.receiveHookCommand(for: agent)],
+    environment: environment,
+    standardInput: input
+  )
+}

--- a/apps/mac/supatermTests/TerminalHostStateNotificationTests.swift
+++ b/apps/mac/supatermTests/TerminalHostStateNotificationTests.swift
@@ -257,6 +257,36 @@ struct TerminalHostStateNotificationTests {
   }
 
   @Test
+  func desktopNotificationCallbackPreservesExplicitTitleAndBody() async throws {
+    initializeGhosttyForTests()
+
+    let host = TerminalHostState()
+    host.windowActivity = .inactive
+    let stream = host.eventStream()
+    var iterator = stream.makeAsyncIterator()
+    host.handleCommand(.ensureInitialTab(focusing: false, startupInput: nil))
+
+    let tabID = try #require(host.selectedTabID)
+    let surface = try #require(host.selectedSurfaceView)
+    surface.bridge.onDesktopNotification?("Needs input", "Claude needs your attention")
+
+    let event = try #require(await iterator.next())
+    guard case .notificationReceived(let notification) = event else {
+      Issue.record("Expected notificationReceived event.")
+      return
+    }
+
+    #expect(notification.attentionState == .unread)
+    #expect(notification.body == "Claude needs your attention")
+    #expect(notification.desktopNotificationDisposition == .deliver)
+    #expect(notification.resolvedTitle == "Needs input")
+    #expect(notification.sourceSurfaceID == surface.id)
+    #expect(notification.subtitle == "")
+    #expect(host.unreadNotificationCount(for: tabID) == 1)
+    #expect(host.latestNotificationText(for: tabID) == "Claude needs your attention")
+  }
+
+  @Test
   func desktopNotificationCallbackKeepsDistinctNotificationAfterStructuredCompletion() throws {
     initializeGhosttyForTests()
 


### PR DESCRIPTION
## Summary

- Problem: agent hooks only worked through the local Unix socket path, so notifications emitted from an SSH session could not reach Supaterm.
- Why it matters: remote coding-agent runs over SSH could finish or request attention without producing a local Supaterm notification.
- What changed: the managed hook command now keeps the local socket path when `SUPATERM_SOCKET_PATH` exists and otherwise falls back to an SSH-safe OSC 777 emitter when `SUPATERM_REMOTE_NOTIFICATIONS=1`, `SSH_CONNECTION`, or `SSH_TTY` is present.
- What changed: added regression coverage for remote payload parsing, title/body fallback selection, control-character sanitization, installer fixtures, command selection, and the existing terminal notification reducer path.
- What did NOT change (scope boundary): no remote busy-state parity, no relay or tunnel architecture, no remote install/bootstrap automation, and no change to local non-SSH hook behavior.

## Rationale

Supaterm already turns terminal desktop-notification actions into app notifications locally. Reusing that path through OSC 777 is the smallest forward-only change that makes SSH notifications work without introducing a relay system or expanding scope beyond notifications.

## User-visible / Behavior Changes

- SSH sessions can now surface agent-hook notifications in Supaterm through OSC 777 when the local socket path is unavailable.
- Local sessions still prefer the structured socket hook path and behave the same as before.
- Existing notification deduplication remains in place.

## Diagram (if applicable)

```text
Before:
[remote agent hook over SSH] -> [local socket unavailable] -> [no Supaterm notification]

After:
[remote agent hook over SSH] -> [managed hook emits OSC 777] -> [Ghostty desktop notification action] -> [Supaterm reducer] -> [tab/UI + system notification]
```

## Human Verification

- Verified scenarios: rebased branch on top of current `main`, inspected the resulting diff against `main`, and reran the repo pre-push validation on the rebased branch.
- Edge cases checked: remote-vs-local command selection, payload fallback from `message` to `last_assistant_message`, control-character sanitization, installer fixture escaping, and notification-path deduplication are covered by the passing test suite.
- What you did **not** verify: I did not manually run a live SSH session against a local Supaterm instance after the rebase.
- How can a human manually verify this: open a Supaterm worktree, SSH into another host from that terminal, run a managed agent hook with no `SUPATERM_SOCKET_PATH`, confirm it emits an OSC 777 notification, and verify the local tab/UI notification appears once.
