### PR TITLE
Add GitHub pull request integration to the mac app

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettings.swift
@@ -4,6 +4,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
+  public var githubIntegrationEnabled: Bool
   public var glowingPaneRingEnabled: Bool
   public var newTabPosition: NewTabPosition
   public var restoreTerminalLayoutEnabled: Bool
@@ -14,6 +15,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     appearanceMode: AppearanceMode,
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
+    githubIntegrationEnabled: Bool = true,
     glowingPaneRingEnabled: Bool = true,
     newTabPosition: NewTabPosition = .end,
     restoreTerminalLayoutEnabled: Bool = true,
@@ -23,6 +25,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     self.appearanceMode = appearanceMode
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
+    self.githubIntegrationEnabled = githubIntegrationEnabled
     self.glowingPaneRingEnabled = glowingPaneRingEnabled
     self.newTabPosition = newTabPosition
     self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
@@ -34,6 +37,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     appearanceMode: .system,
     analyticsEnabled: true,
     crashReportsEnabled: true,
+    githubIntegrationEnabled: true,
     glowingPaneRingEnabled: true,
     newTabPosition: .end,
     restoreTerminalLayoutEnabled: true,
@@ -52,6 +56,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     case appearanceMode
     case analyticsEnabled
     case crashReportsEnabled
+    case githubIntegrationEnabled
     case glowingPaneRingEnabled
     case newTabPosition
     case restoreTerminalLayoutEnabled
@@ -66,6 +71,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
         return "Allow anonymous telemetry."
       case .crashReportsEnabled:
         return "Allow crash reports."
+      case .githubIntegrationEnabled:
+        return "Enable GitHub pull request integration in terminal tabs."
       case .glowingPaneRingEnabled:
         return "Show a glowing ring around panes with unread attention."
       case .newTabPosition:
@@ -103,6 +110,9 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
         try container.decodeIfPresent(Bool.self, forKey: .analyticsEnabled) ?? defaults.analyticsEnabled,
       crashReportsEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .crashReportsEnabled) ?? defaults.crashReportsEnabled,
+      githubIntegrationEnabled:
+        try container.decodeIfPresent(Bool.self, forKey: .githubIntegrationEnabled)
+          ?? defaults.githubIntegrationEnabled,
       glowingPaneRingEnabled:
         try container.decodeIfPresent(Bool.self, forKey: .glowingPaneRingEnabled)
           ?? defaults.glowingPaneRingEnabled,
@@ -141,6 +151,8 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
       return .bool(analyticsEnabled)
     case .crashReportsEnabled:
       return .bool(crashReportsEnabled)
+    case .githubIntegrationEnabled:
+      return .bool(githubIntegrationEnabled)
     case .glowingPaneRingEnabled:
       return .bool(glowingPaneRingEnabled)
     case .newTabPosition:

--- a/apps/mac/supaterm/Features/GitHub/GitRepositoryClient.swift
+++ b/apps/mac/supaterm/Features/GitHub/GitRepositoryClient.swift
@@ -1,0 +1,226 @@
+import ComposableArchitecture
+import Foundation
+
+nonisolated struct GithubRemoteTarget: Equatable, Sendable, Hashable {
+  let remoteName: String
+  let host: String
+  let owner: String
+  let repo: String
+}
+
+nonisolated struct GitRepositoryClient: Sendable {
+  var repositoryRoot: @Sendable (URL) async -> URL?
+  var branchName: @Sendable (URL) async -> String?
+  var githubRemotes: @Sendable (URL) async -> [GithubRemoteTarget]
+  var headURL: @Sendable (URL) -> URL?
+}
+
+extension GitRepositoryClient: DependencyKey {
+  static let liveValue = Self(
+    repositoryRoot: { workingDirectoryURL in
+      GitRepositoryCommandRunner.repositoryRoot(for: workingDirectoryURL)
+    },
+    branchName: { workingDirectoryURL in
+      GitRepositoryCommandRunner.branchName(for: workingDirectoryURL)
+    },
+    githubRemotes: { repositoryRootURL in
+      GitRepositoryCommandRunner.githubRemotes(for: repositoryRootURL)
+    },
+    headURL: { workingDirectoryURL in
+      GitWorktreeHeadResolver.headURL(for: workingDirectoryURL)
+    }
+  )
+
+  static let testValue = Self(
+    repositoryRoot: { _ in nil },
+    branchName: { _ in nil },
+    githubRemotes: { _ in [] },
+    headURL: { _ in nil }
+  )
+}
+
+extension DependencyValues {
+  var gitRepositoryClient: GitRepositoryClient {
+    get { self[GitRepositoryClient.self] }
+    set { self[GitRepositoryClient.self] = newValue }
+  }
+}
+
+extension GitRepositoryClient {
+  static func parseGithubRemoteTarget(
+    remoteName: String,
+    remoteURL: String
+  ) -> GithubRemoteTarget? {
+    GitRepositoryCommandRunner.parseGithubRemoteTarget(
+      remoteName: remoteName,
+      remoteURL: remoteURL
+    )
+  }
+}
+
+private nonisolated enum GitRepositoryCommandRunner {
+  static func repositoryRoot(for workingDirectoryURL: URL) -> URL? {
+    guard
+      let output = try? runGit(
+        ["-C", workingDirectoryURL.path(percentEncoded: false), "rev-parse", "--show-toplevel"]
+      )
+    else {
+      return nil
+    }
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return URL(fileURLWithPath: trimmed).standardizedFileURL
+  }
+
+  static func branchName(for workingDirectoryURL: URL) -> String? {
+    guard
+      let output = try? runGit(
+        ["-C", workingDirectoryURL.path(percentEncoded: false), "branch", "--show-current"]
+      )
+    else {
+      return nil
+    }
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  static func githubRemotes(for repositoryRootURL: URL) -> [GithubRemoteTarget] {
+    guard
+      let output = try? runGit(
+        ["-C", repositoryRootURL.path(percentEncoded: false), "remote"]
+      )
+    else {
+      return []
+    }
+    let remoteNames =
+      output
+      .split(whereSeparator: \.isNewline)
+      .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    var targets: [GithubRemoteTarget] = []
+    for remoteName in orderedRemoteNames(remoteNames) {
+      guard
+        let remoteURL = try? runGit(
+          [
+            "-C",
+            repositoryRootURL.path(percentEncoded: false),
+            "remote",
+            "get-url",
+            remoteName,
+          ]
+        ),
+        let target = parseGithubRemoteTarget(
+          remoteName: remoteName,
+          remoteURL: remoteURL
+        )
+      else {
+        continue
+      }
+      targets.append(target)
+    }
+    return targets
+  }
+
+  private static func orderedRemoteNames(_ remoteNames: [String]) -> [String] {
+    let remainder = remoteNames.filter { $0 != "upstream" && $0 != "origin" }
+      .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    var ordered: [String] = []
+    if remoteNames.contains("upstream") {
+      ordered.append("upstream")
+    }
+    if remoteNames.contains("origin") {
+      ordered.append("origin")
+    }
+    ordered.append(contentsOf: remainder)
+    return ordered
+  }
+
+  static func parseGithubRemoteTarget(
+    remoteName: String,
+    remoteURL: String
+  ) -> GithubRemoteTarget? {
+    let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if let target = parseSSHRemote(remoteName: remoteName, remoteURL: trimmed) {
+      return target
+    }
+    if let target = parseURLRemote(remoteName: remoteName, remoteURL: trimmed) {
+      return target
+    }
+    return nil
+  }
+
+  private static func parseSSHRemote(
+    remoteName: String,
+    remoteURL: String
+  ) -> GithubRemoteTarget? {
+    let components: (host: String, path: String)?
+    if remoteURL.hasPrefix("git@"), let colonIndex = remoteURL.firstIndex(of: ":") {
+      let hostStartIndex = remoteURL.index(remoteURL.startIndex, offsetBy: 4)
+      let host = String(remoteURL[hostStartIndex..<colonIndex])
+      let path = String(remoteURL[remoteURL.index(after: colonIndex)...])
+      components = (host, path)
+    } else if let url = URL(string: remoteURL), url.scheme == "ssh" {
+      let host = url.host ?? ""
+      let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      components = (host, path)
+    } else {
+      components = nil
+    }
+    guard let components else { return nil }
+    return target(
+      remoteName: remoteName,
+      host: components.host,
+      path: components.path
+    )
+  }
+
+  private static func parseURLRemote(
+    remoteName: String,
+    remoteURL: String
+  ) -> GithubRemoteTarget? {
+    guard let url = URL(string: remoteURL), let host = url.host else { return nil }
+    let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    return target(remoteName: remoteName, host: host, path: path)
+  }
+
+  private static func target(
+    remoteName: String,
+    host: String,
+    path: String
+  ) -> GithubRemoteTarget? {
+    let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+    guard !normalizedHost.isEmpty else { return nil }
+    let trimmedPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    let segments = trimmedPath.split(separator: "/").map(String.init)
+    guard segments.count >= 2 else { return nil }
+    let owner = segments[0].trimmingCharacters(in: .whitespacesAndNewlines)
+    var repo = segments[1].trimmingCharacters(in: .whitespacesAndNewlines)
+    if repo.hasSuffix(".git") {
+      repo.removeLast(4)
+    }
+    guard !owner.isEmpty, !repo.isEmpty else { return nil }
+    return GithubRemoteTarget(
+      remoteName: remoteName,
+      host: normalizedHost,
+      owner: owner,
+      repo: repo
+    )
+  }
+
+  private static func runGit(_ arguments: [String]) throws -> String {
+    let result = try ProcessRunner.run(
+      executableURL: URL(fileURLWithPath: "/usr/bin/git"),
+      arguments: arguments
+    )
+    guard result.status == 0 else {
+      throw GitRepositoryError.commandFailed(result.errorMessage)
+    }
+    return result.standardOutput
+  }
+}
+
+private nonisolated enum GitRepositoryError: Error {
+  case commandFailed(String)
+}

--- a/apps/mac/supaterm/Features/GitHub/GitWorktreeHeadResolver.swift
+++ b/apps/mac/supaterm/Features/GitHub/GitWorktreeHeadResolver.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+nonisolated enum GitWorktreeHeadResolver {
+  static func headURL(for worktreeURL: URL, fileManager: FileManager = .default) -> URL? {
+    let gitURL = worktreeURL.appending(path: ".git")
+    var isDirectory = ObjCBool(false)
+    guard
+      fileManager.fileExists(
+        atPath: gitURL.path(percentEncoded: false),
+        isDirectory: &isDirectory
+      )
+    else {
+      return nil
+    }
+    if isDirectory.boolValue {
+      return gitURL.appending(path: "HEAD")
+    }
+    guard let contents = try? String(contentsOf: gitURL, encoding: .utf8) else {
+      return nil
+    }
+    guard let line = contents.split(whereSeparator: \.isNewline).first else {
+      return nil
+    }
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    let prefix = "gitdir:"
+    guard trimmed.hasPrefix(prefix) else {
+      return nil
+    }
+    let pathPart = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !pathPart.isEmpty else {
+      return nil
+    }
+    return URL(fileURLWithPath: String(pathPart), relativeTo: worktreeURL)
+      .standardizedFileURL
+      .appending(path: "HEAD")
+  }
+}

--- a/apps/mac/supaterm/Features/GitHub/GithubCLIClient.swift
+++ b/apps/mac/supaterm/Features/GitHub/GithubCLIClient.swift
@@ -1,0 +1,357 @@
+import ComposableArchitecture
+import Darwin
+import Foundation
+
+nonisolated struct GithubCLIClient: Sendable {
+  var isAvailable: @Sendable () async -> Bool
+  var authStatus: @Sendable () async throws -> GithubAuthStatus?
+  var batchPullRequests: @Sendable (GithubRemoteTarget, [String]) async throws -> [String: GithubPullRequest]
+}
+
+extension GithubCLIClient: DependencyKey {
+  static let liveValue = live()
+
+  static func live() -> GithubCLIClient {
+    let resolver = GithubCLIExecutableResolver()
+    let availabilityCache = GithubCLIAvailabilityCache()
+    return GithubCLIClient(
+      isAvailable: {
+        await availabilityCache.value {
+          do {
+            _ = try GithubCLIRunner.run(
+              resolver: resolver,
+              arguments: ["--version"]
+            )
+            return true
+          } catch {
+            return false
+          }
+        }
+      },
+      authStatus: {
+        let output = try GithubCLIRunner.run(
+          resolver: resolver,
+          arguments: ["auth", "status", "--json", "hosts"]
+        )
+        let data = Data(output.utf8)
+        let response = try JSONDecoder().decode(GithubAuthStatusResponse.self, from: data)
+        for (host, accounts) in response.hosts.sorted(by: { $0.key < $1.key }) {
+          if let account = accounts.first(where: { $0.active }) {
+            return GithubAuthStatus(username: account.login, host: host)
+          }
+        }
+        return nil
+      },
+      batchPullRequests: { remote, branches in
+        let deduplicated = GithubCLIRunner.deduplicatedBranches(branches)
+        guard !deduplicated.isEmpty else { return [:] }
+        let chunks = GithubCLIRunner.makeBranchChunks(
+          deduplicated,
+          chunkSize: 25
+        )
+        var results: [String: GithubPullRequest] = [:]
+        for chunk in chunks {
+          let (query, aliasMap) = GithubCLIRunner.makeBatchPullRequestsQuery(branches: chunk)
+          let output = try GithubCLIRunner.run(
+            resolver: resolver,
+            arguments: [
+              "api",
+              "graphql",
+              "--hostname",
+              remote.host,
+              "-f",
+              "query=\(query)",
+              "-f",
+              "owner=\(remote.owner)",
+              "-f",
+              "repo=\(remote.repo)",
+            ]
+          )
+          guard !output.isEmpty else { continue }
+          let decoder = JSONDecoder()
+          decoder.dateDecodingStrategy = .iso8601
+          let response = try decoder.decode(
+            GithubGraphQLPullRequestResponse.self,
+            from: Data(output.utf8)
+          )
+          let chunkResults = response.pullRequestsByBranch(
+            aliasMap: aliasMap,
+            owner: remote.owner,
+            repo: remote.repo
+          )
+          results.merge(chunkResults) { current, _ in current }
+        }
+        return results
+      }
+    )
+  }
+
+  static let testValue = GithubCLIClient(
+    isAvailable: { true },
+    authStatus: { GithubAuthStatus(username: "test", host: "github.com") },
+    batchPullRequests: { _, _ in [:] }
+  )
+}
+
+extension DependencyValues {
+  var githubCLIClient: GithubCLIClient {
+    get { self[GithubCLIClient.self] }
+    set { self[GithubCLIClient.self] = newValue }
+  }
+}
+
+private actor GithubCLIAvailabilityCache {
+  private struct Entry {
+    let value: Bool
+    let fetchedAt: ContinuousClock.Instant
+  }
+
+  private let clock = ContinuousClock()
+  private let ttl: Duration = .seconds(30)
+  private var cachedEntry: Entry?
+  private var inFlightTask: Task<Bool, Never>?
+
+  func value(fetch: @Sendable @escaping () async -> Bool) async -> Bool {
+    let now = clock.now
+    if let cachedEntry, cachedEntry.fetchedAt.duration(to: now) < ttl {
+      return cachedEntry.value
+    }
+    if let inFlightTask {
+      return await inFlightTask.value
+    }
+    let task = Task { await fetch() }
+    inFlightTask = task
+    let value = await task.value
+    cachedEntry = Entry(value: value, fetchedAt: clock.now)
+    inFlightTask = nil
+    return value
+  }
+}
+
+private nonisolated final class GithubCLIExecutableResolver: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cachedExecutableURL: URL?
+
+  func executableURL() throws -> URL {
+    lock.lock()
+    defer { lock.unlock() }
+    if let cachedExecutableURL {
+      return cachedExecutableURL
+    }
+    let executableURL = try GithubCLIRunner.resolveExecutableURL()
+    cachedExecutableURL = executableURL
+    return executableURL
+  }
+}
+
+private nonisolated struct GithubAuthStatusResponse: Decodable {
+  let hosts: [String: [GithubAuthAccount]]
+
+  struct GithubAuthAccount: Decodable {
+    let active: Bool
+    let login: String
+  }
+}
+
+private nonisolated enum GithubCLIRunner {
+  static func run(
+    resolver: GithubCLIExecutableResolver,
+    arguments: [String]
+  ) throws -> String {
+    let executableURL = try resolver.executableURL()
+    let result = try runLoginShellCommand(
+      executableURL: executableURL,
+      arguments: arguments
+    )
+    guard result.status == 0 else {
+      if isOutdated(result) {
+        throw GithubCLIError.outdated
+      }
+      throw GithubCLIError.commandFailed(result.errorMessage)
+    }
+    return result.standardOutput
+  }
+
+  static func resolveExecutableURL() throws -> URL {
+    if let direct = locateExecutableURL(useLoginShell: false) {
+      return direct
+    }
+    if let login = locateExecutableURL(useLoginShell: true) {
+      return login
+    }
+    throw GithubCLIError.unavailable
+  }
+
+  private static func locateExecutableURL(useLoginShell: Bool) -> URL? {
+    let whichURL = URL(fileURLWithPath: "/usr/bin/which")
+    let result: ProcessResult
+    do {
+      if useLoginShell {
+        result = try runLoginShellCommand(
+          executableURL: whichURL,
+          arguments: ["gh"],
+          useWhichMode: true
+        )
+      } else {
+        result = try ProcessRunner.run(
+          executableURL: whichURL,
+          arguments: ["gh"]
+        )
+      }
+    } catch {
+      return nil
+    }
+    guard result.status == 0 else { return nil }
+    let trimmed = result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return URL(fileURLWithPath: trimmed)
+  }
+
+  static func deduplicatedBranches(_ branches: [String]) -> [String] {
+    var seen = Set<String>()
+    return branches.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+
+  static func makeBranchChunks(
+    _ branches: [String],
+    chunkSize: Int
+  ) -> [[String]] {
+    guard !branches.isEmpty else { return [] }
+    var chunks: [[String]] = []
+    var index = 0
+    while index < branches.count {
+      let end = min(index + chunkSize, branches.count)
+      chunks.append(Array(branches[index..<end]))
+      index = end
+    }
+    return chunks
+  }
+
+  static func makeBatchPullRequestsQuery(
+    branches: [String]
+  ) -> (query: String, aliasMap: [String: String]) {
+    var aliasMap: [String: String] = [:]
+    var selections: [String] = []
+    for (index, branch) in branches.enumerated() {
+      let alias = "branch\(index)"
+      aliasMap[alias] = branch
+      let escapedBranch = escapeGraphQLString(branch)
+      selections.append(
+        """
+          \(alias): pullRequests(
+            first: 5,
+            states: [OPEN, MERGED],
+            headRefName: "\(escapedBranch)",
+            orderBy: {field: UPDATED_AT, direction: DESC}
+          ) {
+            nodes {
+              number
+              title
+              state
+              isDraft
+              reviewDecision
+              mergeable
+              mergeStateStatus
+              url
+              updatedAt
+              headRefName
+              baseRefName
+              headRepository {
+                name
+                owner { login }
+              }
+              statusCheckRollup {
+                contexts(first: 100) {
+                  nodes {
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      context
+                      state
+                      targetUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """
+      )
+    }
+    let selectionBlock = selections.joined(separator: "\n")
+    let query = """
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+      \(selectionBlock)
+        }
+      }
+      """
+    return (query, aliasMap)
+  }
+
+  private static func escapeGraphQLString(_ value: String) -> String {
+    value
+      .replacing("\\", with: "\\\\")
+      .replacing("\"", with: "\\\"")
+      .replacing("\n", with: "\\n")
+      .replacing("\r", with: "\\r")
+      .replacing("\t", with: "\\t")
+  }
+
+  private static func isOutdated(_ result: ProcessResult) -> Bool {
+    let combined = "\(result.standardOutput)\n\(result.standardError)".lowercased()
+    if combined.contains("unknown flag: --json") {
+      return true
+    }
+    if combined.contains("unknown shorthand flag") && combined.contains("json") {
+      return true
+    }
+    return false
+  }
+
+  private static func runLoginShellCommand(
+    executableURL: URL,
+    arguments: [String],
+    useWhichMode: Bool = false
+  ) throws -> ProcessResult {
+    let shellURL = loginShellURL()
+    let command: String
+    if useWhichMode {
+      command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
+    } else {
+      let escapedExecutable = shellEscaped(executableURL.path(percentEncoded: false))
+      let escapedArguments = arguments.map(shellEscaped).joined(separator: " ")
+      command = [escapedExecutable, escapedArguments]
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+    }
+    return try ProcessRunner.run(
+      executableURL: shellURL,
+      arguments: ["-l", "-c", command]
+    )
+  }
+
+  private static func loginShellURL() -> URL {
+    let shellPath =
+      currentUserShellPath()
+      ?? ProcessInfo.processInfo.environment["SHELL"]
+      ?? "/bin/zsh"
+    return URL(fileURLWithPath: shellPath)
+  }
+
+  private static func currentUserShellPath() -> String? {
+    guard let entry = getpwuid(getuid()), let shell = entry.pointee.pw_shell else {
+      return nil
+    }
+    let value = String(cString: shell).trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+  }
+
+  private static func shellEscaped(_ value: String) -> String {
+    "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+  }
+}

--- a/apps/mac/supaterm/Features/GitHub/GithubCLIError.swift
+++ b/apps/mac/supaterm/Features/GitHub/GithubCLIError.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum GithubCLIError: Error, Equatable, LocalizedError {
+  case unavailable
+  case outdated
+  case commandFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .unavailable:
+      return "GitHub CLI is unavailable."
+    case .outdated:
+      return "GitHub CLI is outdated. Update `gh` to continue."
+    case .commandFailed(let message):
+      return message.isEmpty ? "GitHub CLI command failed." : message
+    }
+  }
+}

--- a/apps/mac/supaterm/Features/GitHub/GithubPullRequest.swift
+++ b/apps/mac/supaterm/Features/GitHub/GithubPullRequest.swift
@@ -32,27 +32,13 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
     let normalizedRepo = repo.lowercased()
     var results: [String: GithubPullRequest] = [:]
     for (alias, connection) in data.repository.pullRequestsByAlias {
-      guard let branch = aliasMap[alias] else { continue }
-      let upstreamCandidates = connection.nodes.filter {
-        $0.matches(owner: normalizedOwner, repo: normalizedRepo)
+      guard
+        let branch = aliasMap[alias],
+        let node = connection.preferredNode(owner: normalizedOwner, repo: normalizedRepo)
+      else {
+        continue
       }
-      let candidates =
-        upstreamCandidates.isEmpty
-        ? connection.nodes.filter { $0.headRepository != nil }
-        : upstreamCandidates
-      if let node = candidates.max(by: { left, right in
-        if left.stateRank != right.stateRank {
-          return left.stateRank < right.stateRank
-        }
-        let leftDate = left.updatedAt ?? .distantPast
-        let rightDate = right.updatedAt ?? .distantPast
-        if leftDate != rightDate {
-          return leftDate < rightDate
-        }
-        return left.number < right.number
-      }) {
-        results[branch] = node.pullRequest
-      }
+      results[branch] = node.pullRequest
     }
     return results
   }
@@ -91,6 +77,12 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
 
   struct PullRequestConnection: Decodable {
     let nodes: [PullRequestNode]
+
+    func preferredNode(owner: String, repo: String) -> PullRequestNode? {
+      let matchingNodes = nodes.filter { $0.matches(owner: owner, repo: repo) }
+      let candidates = matchingNodes.isEmpty ? nodes.filter(\.hasHeadRepository) : matchingNodes
+      return candidates.max(by: { $0.isLowerPriority(than: $1) })
+    }
   }
 
   struct PullRequestNode: Decodable {
@@ -107,6 +99,10 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
     let baseRefName: String?
     let statusCheckRollup: GithubPullRequestStatusCheckRollup?
     let headRepository: HeadRepository?
+
+    var hasHeadRepository: Bool {
+      headRepository != nil
+    }
 
     var pullRequest: GithubPullRequest {
       GithubPullRequest(
@@ -134,6 +130,18 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
       default:
         return 0
       }
+    }
+
+    func isLowerPriority(than other: PullRequestNode) -> Bool {
+      if stateRank != other.stateRank {
+        return stateRank < other.stateRank
+      }
+      let updatedAt = updatedAt ?? .distantPast
+      let otherUpdatedAt = other.updatedAt ?? .distantPast
+      if updatedAt != otherUpdatedAt {
+        return updatedAt < otherUpdatedAt
+      }
+      return number < other.number
     }
 
     func matches(owner: String, repo: String) -> Bool {

--- a/apps/mac/supaterm/Features/GitHub/GithubPullRequest.swift
+++ b/apps/mac/supaterm/Features/GitHub/GithubPullRequest.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+nonisolated struct GithubAuthStatus: Equatable, Sendable {
+  let username: String
+  let host: String
+}
+
+nonisolated struct GithubPullRequest: Decodable, Equatable, Hashable, Sendable {
+  let number: Int
+  let title: String
+  let state: String
+  let url: String
+  let isDraft: Bool
+  let reviewDecision: String?
+  let mergeable: String?
+  let mergeStateStatus: String?
+  let updatedAt: Date?
+  let headRefName: String?
+  let baseRefName: String?
+  let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+}
+
+nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
+  let data: DataContainer
+
+  func pullRequestsByBranch(
+    aliasMap: [String: String],
+    owner: String,
+    repo: String
+  ) -> [String: GithubPullRequest] {
+    let normalizedOwner = owner.lowercased()
+    let normalizedRepo = repo.lowercased()
+    var results: [String: GithubPullRequest] = [:]
+    for (alias, connection) in data.repository.pullRequestsByAlias {
+      guard let branch = aliasMap[alias] else { continue }
+      let upstreamCandidates = connection.nodes.filter {
+        $0.matches(owner: normalizedOwner, repo: normalizedRepo)
+      }
+      let candidates =
+        upstreamCandidates.isEmpty
+        ? connection.nodes.filter { $0.headRepository != nil }
+        : upstreamCandidates
+      if let node = candidates.max(by: { left, right in
+        if left.stateRank != right.stateRank {
+          return left.stateRank < right.stateRank
+        }
+        let leftDate = left.updatedAt ?? .distantPast
+        let rightDate = right.updatedAt ?? .distantPast
+        if leftDate != rightDate {
+          return leftDate < rightDate
+        }
+        return left.number < right.number
+      }) {
+        results[branch] = node.pullRequest
+      }
+    }
+    return results
+  }
+
+  struct DataContainer: Decodable {
+    let repository: Repository
+  }
+
+  struct Repository: Decodable {
+    let pullRequestsByAlias: [String: PullRequestConnection]
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: DynamicKey.self)
+      var results: [String: PullRequestConnection] = [:]
+      for key in container.allKeys {
+        results[key.stringValue] = try container.decode(PullRequestConnection.self, forKey: key)
+      }
+      pullRequestsByAlias = results
+    }
+  }
+
+  struct DynamicKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+      self.stringValue = stringValue
+      self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+      self.stringValue = "\(intValue)"
+      self.intValue = intValue
+    }
+  }
+
+  struct PullRequestConnection: Decodable {
+    let nodes: [PullRequestNode]
+  }
+
+  struct PullRequestNode: Decodable {
+    let number: Int
+    let title: String
+    let state: String
+    let isDraft: Bool
+    let reviewDecision: String?
+    let mergeable: String?
+    let mergeStateStatus: String?
+    let updatedAt: Date?
+    let url: String
+    let headRefName: String?
+    let baseRefName: String?
+    let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+    let headRepository: HeadRepository?
+
+    var pullRequest: GithubPullRequest {
+      GithubPullRequest(
+        number: number,
+        title: title,
+        state: state,
+        url: url,
+        isDraft: isDraft,
+        reviewDecision: reviewDecision,
+        mergeable: mergeable,
+        mergeStateStatus: mergeStateStatus,
+        updatedAt: updatedAt,
+        headRefName: headRefName,
+        baseRefName: baseRefName,
+        statusCheckRollup: statusCheckRollup
+      )
+    }
+
+    var stateRank: Int {
+      switch state.uppercased() {
+      case "OPEN":
+        return 2
+      case "MERGED":
+        return 1
+      default:
+        return 0
+      }
+    }
+
+    func matches(owner: String, repo: String) -> Bool {
+      guard let headRepository else { return false }
+      return headRepository.owner.login.lowercased() == owner
+        && headRepository.name.lowercased() == repo
+    }
+  }
+
+  struct HeadRepository: Decodable {
+    let name: String
+    let owner: HeadRepositoryOwner
+  }
+
+  struct HeadRepositoryOwner: Decodable {
+    let login: String
+  }
+}

--- a/apps/mac/supaterm/Features/GitHub/GithubPullRequestStatusCheck.swift
+++ b/apps/mac/supaterm/Features/GitHub/GithubPullRequestStatusCheck.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+nonisolated struct GithubPullRequestStatusCheck: Decodable, Equatable, Hashable, Sendable {
+  let name: String?
+  let detailsUrl: String?
+  let status: String?
+  let conclusion: String?
+  let state: String?
+
+  init(
+    name: String? = nil,
+    detailsUrl: String? = nil,
+    status: String? = nil,
+    conclusion: String? = nil,
+    state: String? = nil
+  ) {
+    self.name = name
+    self.detailsUrl = detailsUrl
+    self.status = status
+    self.conclusion = conclusion
+    self.state = state
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case context
+    case detailsUrl
+    case targetUrl
+    case status
+    case conclusion
+    case state
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let name = try container.decodeIfPresent(String.self, forKey: .name)
+    let context = try container.decodeIfPresent(String.self, forKey: .context)
+    self.name = name ?? context
+    let detailsUrl = try container.decodeIfPresent(String.self, forKey: .detailsUrl)
+    let targetUrl = try container.decodeIfPresent(String.self, forKey: .targetUrl)
+    self.detailsUrl = detailsUrl ?? targetUrl
+    self.status = try container.decodeIfPresent(String.self, forKey: .status)
+    self.conclusion = try container.decodeIfPresent(String.self, forKey: .conclusion)
+    self.state = try container.decodeIfPresent(String.self, forKey: .state)
+  }
+
+  var checkState: GithubPullRequestCheckState {
+    if let status, status.uppercased() != "COMPLETED" {
+      return .inProgress
+    }
+    if let state {
+      switch state.uppercased() {
+      case "SUCCESS":
+        return .success
+      case "FAILURE", "ERROR":
+        return .failure
+      case "EXPECTED":
+        return .expected
+      case "PENDING":
+        return .inProgress
+      default:
+        return .inProgress
+      }
+    }
+    if let conclusion {
+      switch conclusion.uppercased() {
+      case "SUCCESS", "NEUTRAL":
+        return .success
+      case "CANCELLED", "SKIPPED":
+        return .skipped
+      case "FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
+        return .failure
+      default:
+        return .inProgress
+      }
+    }
+    return .inProgress
+  }
+}
+
+nonisolated enum GithubPullRequestCheckState: Equatable, Hashable, Sendable {
+  case success
+  case failure
+  case inProgress
+  case expected
+  case skipped
+}
+
+nonisolated struct GithubPullRequestStatusCheckRollup: Decodable, Equatable, Hashable, Sendable {
+  let checks: [GithubPullRequestStatusCheck]
+
+  init(checks: [GithubPullRequestStatusCheck]) {
+    self.checks = checks
+  }
+
+  init(from decoder: Decoder) throws {
+    if let checks = try? [GithubPullRequestStatusCheck](from: decoder) {
+      self.checks = checks
+      return
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    if let checks = try? container.decode([GithubPullRequestStatusCheck].self, forKey: .contexts) {
+      self.checks = checks
+      return
+    }
+    if let contexts = try? container.decode(Contexts.self, forKey: .contexts) {
+      self.checks = contexts.nodes
+      return
+    }
+    self.checks = []
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case contexts
+  }
+
+  private struct Contexts: Decodable, Equatable {
+    let nodes: [GithubPullRequestStatusCheck]
+  }
+}
+
+nonisolated struct GithubPullRequestCheckBreakdown: Equatable, Sendable {
+  let passed: Int
+  let failed: Int
+  let inProgress: Int
+  let expected: Int
+  let skipped: Int
+
+  var total: Int {
+    passed + failed + inProgress + expected + skipped
+  }
+
+  var summaryText: String? {
+    guard total > 0 else { return nil }
+    var parts: [String] = []
+    if failed > 0 {
+      parts.append("\(failed) failed")
+    }
+    if inProgress > 0 {
+      parts.append("\(inProgress) pending")
+    }
+    if expected > 0 {
+      parts.append("\(expected) expected")
+    }
+    if skipped > 0 {
+      parts.append("\(skipped) skipped")
+    }
+    parts.append("\(passed) passed")
+    return parts.joined(separator: ", ")
+  }
+
+  init(checks: [GithubPullRequestStatusCheck]) {
+    var passed = 0
+    var failed = 0
+    var inProgress = 0
+    var expected = 0
+    var skipped = 0
+    for check in checks {
+      switch check.checkState {
+      case .success:
+        passed += 1
+      case .failure:
+        failed += 1
+      case .inProgress:
+        inProgress += 1
+      case .expected:
+        expected += 1
+      case .skipped:
+        skipped += 1
+      }
+    }
+    self.passed = passed
+    self.failed = failed
+    self.inProgress = inProgress
+    self.expected = expected
+    self.skipped = skipped
+  }
+}

--- a/apps/mac/supaterm/Features/GitHub/ProcessRunner.swift
+++ b/apps/mac/supaterm/Features/GitHub/ProcessRunner.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+nonisolated struct ProcessResult: Equatable, Sendable {
+  let status: Int32
+  let standardOutput: String
+  let standardError: String
+
+  var errorMessage: String {
+    let trimmedError = standardError.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedError.isEmpty {
+      return trimmedError
+    }
+    return standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+nonisolated enum ProcessRunner {
+  static func run(
+    executableURL: URL,
+    arguments: [String]
+  ) throws -> ProcessResult {
+    let process = Process()
+    process.executableURL = executableURL
+    process.arguments = arguments
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    return ProcessResult(
+      status: process.terminationStatus,
+      standardOutput: normalizedOutput(from: outputPipe),
+      standardError: normalizedOutput(from: errorPipe)
+    )
+  }
+
+  private static func normalizedOutput(from pipe: Pipe) -> String {
+    String(
+      bytes: pipe.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    ) ?? ""
+  }
+}

--- a/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
@@ -46,6 +46,22 @@ enum SettingsAgentIntegrationResult: Equatable {
   case success(Bool)
 }
 
+enum SettingsGithubIntegrationStatus: Equatable {
+  case disabled
+  case checking
+  case unavailable(String)
+  case unauthenticated(String)
+  case authenticated(username: String, host: String)
+  case failure(String)
+
+  var isChecking: Bool {
+    if case .checking = self {
+      return true
+    }
+    return false
+  }
+}
+
 @Reducer
 struct SettingsFeature {
   @ObservableState
@@ -63,6 +79,9 @@ struct SettingsFeature {
       settingsPath: SupatermAgentKind.pi.settingsPathDescription
     )
     var crashReportsEnabled = SupatermSettings.default.crashReportsEnabled
+    var githubIntegrationEnabled = SupatermSettings.default.githubIntegrationEnabled
+    var githubIntegrationStatus: SettingsGithubIntegrationStatus =
+      SupatermSettings.default.githubIntegrationEnabled ? .checking : .disabled
     var glowingPaneRingEnabled = SupatermSettings.default.glowingPaneRingEnabled
     var newTabPosition = SupatermSettings.default.newTabPosition
     var restoreTerminalLayoutEnabled = SupatermSettings.default.restoreTerminalLayoutEnabled
@@ -84,6 +103,9 @@ struct SettingsFeature {
     case analyticsEnabledChanged(Bool)
     case checkForUpdatesButtonTapped
     case crashReportsEnabledChanged(Bool)
+    case githubIntegrationEnabledChanged(Bool)
+    case githubIntegrationStatusRefreshRequested
+    case githubIntegrationStatusRefreshed(SettingsGithubIntegrationStatus)
     case glowingPaneRingEnabledChanged(Bool)
     case newTabPositionSelected(NewTabPosition)
     case restoreTerminalLayoutEnabledChanged(Bool)
@@ -161,6 +183,7 @@ struct SettingsFeature {
   @Dependency(PiSettingsClient.self) var piSettingsClient
   @Dependency(AnalyticsClient.self) var analyticsClient
   @Dependency(DesktopNotificationClient.self) var desktopNotificationClient
+  @Dependency(GithubCLIClient.self) var githubCLIClient
   @Dependency(GhosttyTerminalSettingsClient.self) var ghosttyTerminalSettingsClient
   @Dependency(UpdateClient.self) var updateClient
 
@@ -175,6 +198,7 @@ struct SettingsFeature {
           .send(.agentIntegrationStatusRefreshRequested(.claude)),
           .send(.agentIntegrationStatusRefreshRequested(.codex)),
           .send(.agentIntegrationStatusRefreshRequested(.pi)),
+          .send(.githubIntegrationStatusRefreshRequested),
           .run { [updateClient] send in
             await updateClient.start()
             let stream = await updateClient.observe()
@@ -189,6 +213,8 @@ struct SettingsFeature {
         state.appearanceMode = supatermSettings.appearanceMode
         state.analyticsEnabled = supatermSettings.analyticsEnabled
         state.crashReportsEnabled = supatermSettings.crashReportsEnabled
+        state.githubIntegrationEnabled = supatermSettings.githubIntegrationEnabled
+        state.githubIntegrationStatus = supatermSettings.githubIntegrationEnabled ? .checking : .disabled
         state.glowingPaneRingEnabled = supatermSettings.glowingPaneRingEnabled
         state.newTabPosition = supatermSettings.newTabPosition
         state.restoreTerminalLayoutEnabled = supatermSettings.restoreTerminalLayoutEnabled
@@ -403,6 +429,81 @@ struct SettingsFeature {
         state.crashReportsEnabled = isEnabled
         return persist(state)
 
+      case .githubIntegrationEnabledChanged(let isEnabled):
+        state.githubIntegrationEnabled = isEnabled
+        state.githubIntegrationStatus = isEnabled ? state.githubIntegrationStatus : .disabled
+        if isEnabled {
+          return .merge(
+            persist(state),
+            .send(.githubIntegrationStatusRefreshRequested)
+          )
+        }
+        return persist(state)
+
+      case .githubIntegrationStatusRefreshRequested:
+        guard state.githubIntegrationEnabled else {
+          state.githubIntegrationStatus = .disabled
+          return .none
+        }
+        state.githubIntegrationStatus = .checking
+        let githubCLIClient = githubCLIClient
+        return .run { send in
+          guard await githubCLIClient.isAvailable() else {
+            await send(
+              .githubIntegrationStatusRefreshed(
+                .unavailable("Install `gh` to enable pull request integration.")
+              )
+            )
+            return
+          }
+          do {
+            if let status = try await githubCLIClient.authStatus() {
+              await send(
+                .githubIntegrationStatusRefreshed(
+                  .authenticated(username: status.username, host: status.host)
+                )
+              )
+            } else {
+              await send(
+                .githubIntegrationStatusRefreshed(
+                  .unauthenticated("Run `gh auth login` in a terminal to authenticate.")
+                )
+              )
+            }
+          } catch let error as GithubCLIError {
+            switch error {
+            case .unavailable:
+              await send(
+                .githubIntegrationStatusRefreshed(
+                  .unavailable("Install `gh` to enable pull request integration.")
+                )
+              )
+            case .outdated:
+              await send(
+                .githubIntegrationStatusRefreshed(
+                  .failure(error.localizedDescription)
+                )
+              )
+            case .commandFailed:
+              await send(
+                .githubIntegrationStatusRefreshed(
+                  .failure(error.localizedDescription)
+                )
+              )
+            }
+          } catch {
+            await send(.githubIntegrationStatusRefreshed(.failure(error.localizedDescription)))
+          }
+        }
+
+      case .githubIntegrationStatusRefreshed(let status):
+        guard state.githubIntegrationEnabled else {
+          state.githubIntegrationStatus = .disabled
+          return .none
+        }
+        state.githubIntegrationStatus = status
+        return .none
+
       case .glowingPaneRingEnabledChanged(let isEnabled):
         state.glowingPaneRingEnabled = isEnabled
         return persist(state)
@@ -498,6 +599,7 @@ struct SettingsFeature {
       appearanceMode: state.appearanceMode,
       analyticsEnabled: state.analyticsEnabled,
       crashReportsEnabled: state.crashReportsEnabled,
+      githubIntegrationEnabled: state.githubIntegrationEnabled,
       glowingPaneRingEnabled: state.glowingPaneRingEnabled,
       newTabPosition: state.newTabPosition,
       restoreTerminalLayoutEnabled: state.restoreTerminalLayoutEnabled,

--- a/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
@@ -111,7 +111,8 @@ struct SettingsFeature {
     case restoreTerminalLayoutEnabledChanged(Bool)
     case settingsLoaded(SupatermSettings)
     case systemNotificationsAuthorizationChecked(DesktopNotificationClient.AuthorizationStatus)
-    case systemNotificationsAuthorizationResult(DesktopNotificationClient.AuthorizationRequestResult)
+    case systemNotificationsAuthorizationResult(
+      DesktopNotificationClient.AuthorizationRequestResult)
     case systemNotificationsEnabledChanged(Bool)
     case tabSelected(Tab)
     case task
@@ -214,7 +215,8 @@ struct SettingsFeature {
         state.analyticsEnabled = supatermSettings.analyticsEnabled
         state.crashReportsEnabled = supatermSettings.crashReportsEnabled
         state.githubIntegrationEnabled = supatermSettings.githubIntegrationEnabled
-        state.githubIntegrationStatus = supatermSettings.githubIntegrationEnabled ? .checking : .disabled
+        state.githubIntegrationStatus =
+          supatermSettings.githubIntegrationEnabled ? .checking : .disabled
         state.glowingPaneRingEnabled = supatermSettings.glowingPaneRingEnabled
         state.newTabPosition = supatermSettings.newTabPosition
         state.restoreTerminalLayoutEnabled = supatermSettings.restoreTerminalLayoutEnabled
@@ -342,7 +344,8 @@ struct SettingsFeature {
             }
             await send(.agentIntegrationStatusRefreshed(agent, .success(try await loadStatus())))
           } catch {
-            await send(.agentIntegrationStatusRefreshed(agent, .failure(error.localizedDescription)))
+            await send(
+              .agentIntegrationStatusRefreshed(agent, .failure(error.localizedDescription)))
           }
         }
 
@@ -447,53 +450,12 @@ struct SettingsFeature {
         }
         state.githubIntegrationStatus = .checking
         let githubCLIClient = githubCLIClient
-        return .run { send in
-          guard await githubCLIClient.isAvailable() else {
-            await send(
-              .githubIntegrationStatusRefreshed(
-                .unavailable("Install `gh` to enable pull request integration.")
-              )
+        return .run { [loadGithubIntegrationStatus] send in
+          await send(
+            .githubIntegrationStatusRefreshed(
+              await loadGithubIntegrationStatus(githubCLIClient)
             )
-            return
-          }
-          do {
-            if let status = try await githubCLIClient.authStatus() {
-              await send(
-                .githubIntegrationStatusRefreshed(
-                  .authenticated(username: status.username, host: status.host)
-                )
-              )
-            } else {
-              await send(
-                .githubIntegrationStatusRefreshed(
-                  .unauthenticated("Run `gh auth login` in a terminal to authenticate.")
-                )
-              )
-            }
-          } catch let error as GithubCLIError {
-            switch error {
-            case .unavailable:
-              await send(
-                .githubIntegrationStatusRefreshed(
-                  .unavailable("Install `gh` to enable pull request integration.")
-                )
-              )
-            case .outdated:
-              await send(
-                .githubIntegrationStatusRefreshed(
-                  .failure(error.localizedDescription)
-                )
-              )
-            case .commandFailed:
-              await send(
-                .githubIntegrationStatusRefreshed(
-                  .failure(error.localizedDescription)
-                )
-              )
-            }
-          } catch {
-            await send(.githubIntegrationStatusRefreshed(.failure(error.localizedDescription)))
-          }
+          )
         }
 
       case .githubIntegrationStatusRefreshed(let status):
@@ -704,6 +666,39 @@ struct SettingsFeature {
     case .pi:
       return PiSettingsInstallerError.piUnavailable.localizedDescription
     }
+  }
+
+  private func loadGithubIntegrationStatus(
+    using githubCLIClient: GithubCLIClient
+  ) async -> SettingsGithubIntegrationStatus {
+    guard await githubCLIClient.isAvailable() else {
+      return .unavailable(githubIntegrationUnavailableMessage)
+    }
+    do {
+      guard let status = try await githubCLIClient.authStatus() else {
+        return .unauthenticated(githubIntegrationUnauthenticatedMessage)
+      }
+      return .authenticated(username: status.username, host: status.host)
+    } catch {
+      return githubIntegrationStatus(for: error)
+    }
+  }
+
+  private func githubIntegrationStatus(
+    for error: Error
+  ) -> SettingsGithubIntegrationStatus {
+    if case GithubCLIError.unavailable = error {
+      return .unavailable(githubIntegrationUnavailableMessage)
+    }
+    return .failure(error.localizedDescription)
+  }
+
+  private var githubIntegrationUnavailableMessage: String {
+    "Install `gh` to enable pull request integration."
+  }
+
+  private var githubIntegrationUnauthenticatedMessage: String {
+    "Run `gh auth login` in a terminal to authenticate."
   }
 
   private func updateTerminalState(

--- a/apps/mac/supaterm/Features/Settings/SettingsView.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsView.swift
@@ -197,6 +197,15 @@ private struct SettingsGeneralView: View {
     )
   }
 
+  private var githubIntegrationEnabled: Binding<Bool> {
+    Binding(
+      get: { store.githubIntegrationEnabled },
+      set: { newValue in
+        _ = store.send(.githubIntegrationEnabledChanged(newValue))
+      }
+    )
+  }
+
   var body: some View {
     Form {
       Section {
@@ -234,9 +243,107 @@ private struct SettingsGeneralView: View {
           isOn: restoreTerminalLayoutEnabled
         )
       }
+
+      Section {
+        SettingsToggleRow(
+          title: "GitHub Integration",
+          subtitle: "Show pull requests and checks for the current branch in terminal tabs.",
+          isOn: githubIntegrationEnabled
+        )
+
+        SettingsGithubIntegrationStatusView(
+          isEnabled: store.githubIntegrationEnabled,
+          status: store.githubIntegrationStatus
+        )
+      } footer: {
+        Text("Supaterm uses the GitHub CLI to resolve pull requests from the current repository and branch.")
+      }
     }
     .navigationTitle("General")
     .settingsFormLayout()
+  }
+}
+
+private struct SettingsGithubIntegrationStatusView: View {
+  let isEnabled: Bool
+  let status: SettingsGithubIntegrationStatus
+
+  var body: some View {
+    switch status {
+    case .disabled:
+      EmptyView()
+
+    case .checking:
+      HStack(spacing: 10) {
+        ProgressView()
+          .controlSize(.small)
+        Text("Checking GitHub CLI status…")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      }
+
+    case .unavailable(let message):
+      SettingsStatusMessageView(
+        title: "GitHub CLI unavailable",
+        message: message,
+        tone: .red
+      )
+
+    case .unauthenticated(let message):
+      SettingsStatusMessageView(
+        title: "GitHub CLI not authenticated",
+        message: message,
+        tone: .orange
+      )
+
+    case .authenticated(let username, let host):
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Connected as \(username)")
+          .font(.callout.weight(.semibold))
+        Text(host)
+          .font(.callout.monospaced())
+          .foregroundStyle(.secondary)
+      }
+
+    case .failure(let message):
+      SettingsStatusMessageView(
+        title: isEnabled ? "GitHub integration error" : "GitHub integration disabled",
+        message: message,
+        tone: .red
+      )
+    }
+  }
+}
+
+private struct SettingsStatusMessageView: View {
+  enum Tone {
+    case orange
+    case red
+
+    var color: Color {
+      switch self {
+      case .orange:
+        return .orange
+      case .red:
+        return .red
+      }
+    }
+  }
+
+  let title: String
+  let message: String
+  let tone: Tone
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(title)
+        .font(.callout.weight(.semibold))
+        .foregroundStyle(tone.color)
+      Text(message)
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
   }
 }
 

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+GitHub.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+GitHub.swift
@@ -83,53 +83,56 @@ extension TerminalHostState {
 
   private func refreshGithubWorkspace(for tabID: TerminalTabID) async {
     githubWorkspaceRefreshTasksByTab.removeValue(forKey: tabID)
-    guard supatermSettings.githubIntegrationEnabled else {
-      clearGithubWorkspace(for: tabID)
-      return
-    }
-    guard managesTerminalSurfaces else {
-      clearGithubWorkspace(for: tabID)
-      return
-    }
     guard
-      let surfaceID = contextSurfaceID(for: tabID),
-      let surface = surfaces[surfaceID],
-      let workingDirectoryPath = workingDirectoryPath(for: surface)
+      supatermSettings.githubIntegrationEnabled,
+      let workspace = await loadGithubWorkspace(for: tabID)
     else {
       clearGithubWorkspace(for: tabID)
       return
     }
-    let workingDirectoryURL = URL(fileURLWithPath: workingDirectoryPath, isDirectory: true)
-    guard let repositoryRootURL = await gitRepositoryClient.repositoryRoot(workingDirectoryURL) else {
-      clearGithubWorkspace(for: tabID)
-      return
-    }
-    let branchName = await gitRepositoryClient.branchName(workingDirectoryURL)
-    let remotes = await gitRepositoryClient.githubRemotes(repositoryRootURL)
-    let headURL = gitRepositoryClient.headURL(workingDirectoryURL)
     let previousWorkspace = githubWorkspaceByTab[tabID]
-    let workspace = TerminalGithubWorkspace(
-      tabID: tabID,
-      surfaceID: surfaceID,
-      workingDirectoryURL: workingDirectoryURL,
-      repositoryRootURL: repositoryRootURL,
-      branchName: branchName,
-      headURL: headURL,
-      remotes: remotes
-    )
     githubWorkspaceByTab[tabID] = workspace
     if previousWorkspace?.repositoryRootURL != workspace.repositoryRootURL
       || previousWorkspace?.branchName != workspace.branchName
     {
       githubPullRequestByTab.removeValue(forKey: tabID)
     }
-    updateGithubHeadWatcher(for: tabID, headURL: headURL)
+    updateGithubHeadWatcher(for: tabID, headURL: workspace.headURL)
     if let previousWorkspace, previousWorkspace.repositoryRootURL != workspace.repositoryRootURL {
       refreshGithubRepositorySchedule(for: previousWorkspace.repositoryRootURL)
       requestGithubRepositoryRefresh(previousWorkspace.repositoryRootURL)
     }
     refreshGithubRepositorySchedule(for: workspace.repositoryRootURL)
     requestGithubRepositoryRefresh(workspace.repositoryRootURL)
+  }
+
+  private func loadGithubWorkspace(for tabID: TerminalTabID) async -> TerminalGithubWorkspace? {
+    guard managesTerminalSurfaces else {
+      return nil
+    }
+    guard
+      let surfaceID = contextSurfaceID(for: tabID),
+      let surface = surfaces[surfaceID],
+      let workingDirectoryPath = workingDirectoryPath(for: surface)
+    else {
+      return nil
+    }
+    let workingDirectoryURL = URL(fileURLWithPath: workingDirectoryPath, isDirectory: true)
+    guard let repositoryRootURL = await gitRepositoryClient.repositoryRoot(workingDirectoryURL)
+    else {
+      return nil
+    }
+    async let branchName = gitRepositoryClient.branchName(workingDirectoryURL)
+    async let remotes = gitRepositoryClient.githubRemotes(repositoryRootURL)
+    return TerminalGithubWorkspace(
+      tabID: tabID,
+      surfaceID: surfaceID,
+      workingDirectoryURL: workingDirectoryURL,
+      repositoryRootURL: repositoryRootURL,
+      branchName: await branchName,
+      headURL: gitRepositoryClient.headURL(workingDirectoryURL),
+      remotes: await remotes
+    )
   }
 
   func clearGithubWorkspace(for tabID: TerminalTabID) {
@@ -203,7 +206,9 @@ extension TerminalHostState {
       return
     }
     let interval = githubRefreshInterval(for: repositoryRootURL)
-    if let existing = githubRepositoryRefreshTasksByRootURL[repositoryRootURL], existing.interval == interval {
+    if let existing = githubRepositoryRefreshTasksByRootURL[repositoryRootURL],
+      existing.interval == interval
+    {
       return
     }
     githubRepositoryRefreshTasksByRootURL.removeValue(forKey: repositoryRootURL)?.task.cancel()

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+GitHub.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+GitHub.swift
@@ -1,0 +1,382 @@
+import AppKit
+import Darwin
+import Dispatch
+import Foundation
+import Observation
+
+struct TerminalGithubWorkspace: Equatable, Sendable {
+  let tabID: TerminalTabID
+  let surfaceID: UUID
+  let workingDirectoryURL: URL
+  let repositoryRootURL: URL
+  let branchName: String?
+  let headURL: URL?
+  let remotes: [GithubRemoteTarget]
+}
+
+struct TerminalGithubHeadWatcher {
+  let headURL: URL
+  let source: DispatchSourceFileSystemObject
+}
+
+struct TerminalGithubRefreshTask {
+  let interval: Duration
+  let task: Task<Void, Never>
+}
+
+@MainActor
+extension TerminalHostState {
+  func observeSupatermSettings() {
+    supatermSettingsObservationTask?.cancel()
+    supatermSettingsObservationTask = Task { @MainActor [weak self] in
+      let observations = Observations { [weak self] in
+        self?.supatermSettings ?? .default
+      }
+      for await settings in observations {
+        guard let self else { return }
+        self.applySupatermSettings(settings)
+      }
+    }
+  }
+
+  private func applySupatermSettings(_ settings: SupatermSettings) {
+    if settings.githubIntegrationEnabled {
+      refreshAllGithubWorkspaces()
+    } else {
+      clearAllGithubState()
+    }
+  }
+
+  @discardableResult
+  func openPullRequest(for tabID: TerminalTabID) -> Bool {
+    guard
+      let urlString = githubPullRequestByTab[tabID]?.url,
+      let url = URL(string: urlString)
+    else {
+      return false
+    }
+    return NSWorkspace.shared.open(url)
+  }
+
+  func scheduleGithubWorkspaceRefresh(
+    for tabID: TerminalTabID,
+    delay: Duration = .milliseconds(150)
+  ) {
+    guard supatermSettings.githubIntegrationEnabled else {
+      clearGithubWorkspace(for: tabID)
+      return
+    }
+    githubWorkspaceRefreshTasksByTab[tabID]?.cancel()
+    githubWorkspaceRefreshTasksByTab[tabID] = Task { @MainActor [weak self] in
+      try? await ContinuousClock().sleep(for: delay)
+      guard let self, !Task.isCancelled else { return }
+      await self.refreshGithubWorkspace(for: tabID)
+    }
+  }
+
+  private func refreshAllGithubWorkspaces() {
+    for tab in tabs {
+      scheduleGithubWorkspaceRefresh(for: tab.id, delay: .zero)
+    }
+    refreshGithubRepositorySchedules()
+  }
+
+  private func refreshGithubWorkspace(for tabID: TerminalTabID) async {
+    githubWorkspaceRefreshTasksByTab.removeValue(forKey: tabID)
+    guard supatermSettings.githubIntegrationEnabled else {
+      clearGithubWorkspace(for: tabID)
+      return
+    }
+    guard managesTerminalSurfaces else {
+      clearGithubWorkspace(for: tabID)
+      return
+    }
+    guard
+      let surfaceID = contextSurfaceID(for: tabID),
+      let surface = surfaces[surfaceID],
+      let workingDirectoryPath = workingDirectoryPath(for: surface)
+    else {
+      clearGithubWorkspace(for: tabID)
+      return
+    }
+    let workingDirectoryURL = URL(fileURLWithPath: workingDirectoryPath, isDirectory: true)
+    guard let repositoryRootURL = await gitRepositoryClient.repositoryRoot(workingDirectoryURL) else {
+      clearGithubWorkspace(for: tabID)
+      return
+    }
+    let branchName = await gitRepositoryClient.branchName(workingDirectoryURL)
+    let remotes = await gitRepositoryClient.githubRemotes(repositoryRootURL)
+    let headURL = gitRepositoryClient.headURL(workingDirectoryURL)
+    let previousWorkspace = githubWorkspaceByTab[tabID]
+    let workspace = TerminalGithubWorkspace(
+      tabID: tabID,
+      surfaceID: surfaceID,
+      workingDirectoryURL: workingDirectoryURL,
+      repositoryRootURL: repositoryRootURL,
+      branchName: branchName,
+      headURL: headURL,
+      remotes: remotes
+    )
+    githubWorkspaceByTab[tabID] = workspace
+    if previousWorkspace?.repositoryRootURL != workspace.repositoryRootURL
+      || previousWorkspace?.branchName != workspace.branchName
+    {
+      githubPullRequestByTab.removeValue(forKey: tabID)
+    }
+    updateGithubHeadWatcher(for: tabID, headURL: headURL)
+    if let previousWorkspace, previousWorkspace.repositoryRootURL != workspace.repositoryRootURL {
+      refreshGithubRepositorySchedule(for: previousWorkspace.repositoryRootURL)
+      requestGithubRepositoryRefresh(previousWorkspace.repositoryRootURL)
+    }
+    refreshGithubRepositorySchedule(for: workspace.repositoryRootURL)
+    requestGithubRepositoryRefresh(workspace.repositoryRootURL)
+  }
+
+  func clearGithubWorkspace(for tabID: TerminalTabID) {
+    githubWorkspaceRefreshTasksByTab.removeValue(forKey: tabID)?.cancel()
+    githubPullRequestByTab.removeValue(forKey: tabID)
+    cancelGithubHeadWatcher(for: tabID)
+    guard let workspace = githubWorkspaceByTab.removeValue(forKey: tabID) else {
+      refreshGithubRepositorySchedules()
+      return
+    }
+    refreshGithubRepositorySchedule(for: workspace.repositoryRootURL)
+    requestGithubRepositoryRefresh(workspace.repositoryRootURL)
+  }
+
+  private func clearAllGithubState() {
+    for task in githubWorkspaceRefreshTasksByTab.values {
+      task.cancel()
+    }
+    githubWorkspaceRefreshTasksByTab.removeAll()
+    for task in githubRepositoryRefreshTasksByRootURL.values {
+      task.task.cancel()
+    }
+    githubRepositoryRefreshTasksByRootURL.removeAll()
+    for task in githubRepositoryRefreshOperationsByRootURL.values {
+      task.cancel()
+    }
+    githubRepositoryRefreshOperationsByRootURL.removeAll()
+    queuedGithubRepositoryRefreshRootURLs.removeAll()
+    for tabID in Array(githubHeadWatchersByTab.keys) {
+      cancelGithubHeadWatcher(for: tabID)
+    }
+    githubHeadWatchersByTab.removeAll()
+    for task in githubHeadWatcherRestartTasksByTab.values {
+      task.cancel()
+    }
+    githubHeadWatcherRestartTasksByTab.removeAll()
+    githubWorkspaceByTab.removeAll()
+    githubPullRequestByTab.removeAll()
+  }
+
+  func refreshGithubRepositorySchedules() {
+    let trackedRoots = Set(
+      githubWorkspaceByTab.values.compactMap { workspace -> URL? in
+        guard workspace.branchName != nil, !workspace.remotes.isEmpty else { return nil }
+        return workspace.repositoryRootURL
+      }
+    )
+    for repositoryRootURL in githubRepositoryRefreshTasksByRootURL.keys
+    where !trackedRoots.contains(repositoryRootURL) {
+      githubRepositoryRefreshTasksByRootURL.removeValue(forKey: repositoryRootURL)?.task.cancel()
+      githubRepositoryRefreshOperationsByRootURL.removeValue(forKey: repositoryRootURL)?.cancel()
+      queuedGithubRepositoryRefreshRootURLs.remove(repositoryRootURL)
+      clearGithubPullRequests(in: repositoryRootURL)
+    }
+    for repositoryRootURL in trackedRoots {
+      refreshGithubRepositorySchedule(for: repositoryRootURL)
+    }
+  }
+
+  private func refreshGithubRepositorySchedule(for repositoryRootURL: URL) {
+    guard supatermSettings.githubIntegrationEnabled else {
+      githubRepositoryRefreshTasksByRootURL.removeValue(forKey: repositoryRootURL)?.task.cancel()
+      return
+    }
+    let workspaces = githubWorkspaces(in: repositoryRootURL)
+    guard workspaces.contains(where: { $0.branchName != nil && !$0.remotes.isEmpty }) else {
+      githubRepositoryRefreshTasksByRootURL.removeValue(forKey: repositoryRootURL)?.task.cancel()
+      githubRepositoryRefreshOperationsByRootURL.removeValue(forKey: repositoryRootURL)?.cancel()
+      queuedGithubRepositoryRefreshRootURLs.remove(repositoryRootURL)
+      clearGithubPullRequests(in: repositoryRootURL)
+      return
+    }
+    let interval = githubRefreshInterval(for: repositoryRootURL)
+    if let existing = githubRepositoryRefreshTasksByRootURL[repositoryRootURL], existing.interval == interval {
+      return
+    }
+    githubRepositoryRefreshTasksByRootURL.removeValue(forKey: repositoryRootURL)?.task.cancel()
+    let task = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        try? await ContinuousClock().sleep(for: interval)
+        guard let self, !Task.isCancelled else { return }
+        self.requestGithubRepositoryRefresh(repositoryRootURL)
+      }
+    }
+    githubRepositoryRefreshTasksByRootURL[repositoryRootURL] = TerminalGithubRefreshTask(
+      interval: interval,
+      task: task
+    )
+  }
+
+  private func githubRefreshInterval(for repositoryRootURL: URL) -> Duration {
+    guard
+      let selectedTabID,
+      githubWorkspaceByTab[selectedTabID]?.repositoryRootURL == repositoryRootURL
+    else {
+      return .seconds(60)
+    }
+    return .seconds(30)
+  }
+
+  private func requestGithubRepositoryRefresh(_ repositoryRootURL: URL) {
+    guard supatermSettings.githubIntegrationEnabled else {
+      clearGithubPullRequests(in: repositoryRootURL)
+      return
+    }
+    let workspaces = githubWorkspaces(in: repositoryRootURL)
+    let branches = Array(Set(workspaces.compactMap(\.branchName))).sorted()
+    guard !branches.isEmpty else {
+      clearGithubPullRequests(in: repositoryRootURL)
+      return
+    }
+    guard let remotes = workspaces.first?.remotes, !remotes.isEmpty else {
+      clearGithubPullRequests(in: repositoryRootURL)
+      return
+    }
+    if githubRepositoryRefreshOperationsByRootURL[repositoryRootURL] != nil {
+      queuedGithubRepositoryRefreshRootURLs.insert(repositoryRootURL)
+      return
+    }
+    let githubCLIClient = self.githubCLIClient
+    githubRepositoryRefreshOperationsByRootURL[repositoryRootURL] = Task { [weak self] in
+      let isAvailable = await githubCLIClient.isAvailable()
+      var pullRequestsByBranch: [String: GithubPullRequest] = [:]
+      if isAvailable {
+        var unresolvedBranches = Set(branches)
+        for remote in remotes {
+          let unresolved = unresolvedBranches.sorted()
+          guard !unresolved.isEmpty else { break }
+          do {
+            let batch = try await githubCLIClient.batchPullRequests(remote, unresolved)
+            for branch in batch.keys {
+              unresolvedBranches.remove(branch)
+            }
+            pullRequestsByBranch.merge(batch) { current, _ in current }
+          } catch {
+            continue
+          }
+        }
+      }
+      await MainActor.run {
+        guard let self else { return }
+        self.githubRepositoryRefreshOperationsByRootURL.removeValue(forKey: repositoryRootURL)
+        if !isAvailable {
+          self.clearGithubPullRequests(in: repositoryRootURL)
+        } else {
+          self.applyGithubPullRequests(
+            pullRequestsByBranch,
+            in: repositoryRootURL
+          )
+        }
+        if self.queuedGithubRepositoryRefreshRootURLs.remove(repositoryRootURL) != nil {
+          self.requestGithubRepositoryRefresh(repositoryRootURL)
+        }
+      }
+    }
+  }
+
+  private func applyGithubPullRequests(
+    _ pullRequestsByBranch: [String: GithubPullRequest],
+    in repositoryRootURL: URL
+  ) {
+    for workspace in githubWorkspaces(in: repositoryRootURL) {
+      guard let branchName = workspace.branchName else {
+        githubPullRequestByTab.removeValue(forKey: workspace.tabID)
+        continue
+      }
+      if let pullRequest = pullRequestsByBranch[branchName] {
+        githubPullRequestByTab[workspace.tabID] = pullRequest
+      } else {
+        githubPullRequestByTab.removeValue(forKey: workspace.tabID)
+      }
+    }
+  }
+
+  private func clearGithubPullRequests(in repositoryRootURL: URL) {
+    for workspace in githubWorkspaces(in: repositoryRootURL) {
+      githubPullRequestByTab.removeValue(forKey: workspace.tabID)
+    }
+  }
+
+  private func githubWorkspaces(in repositoryRootURL: URL) -> [TerminalGithubWorkspace] {
+    githubWorkspaceByTab.values
+      .filter { $0.repositoryRootURL == repositoryRootURL }
+      .sorted { $0.tabID.rawValue.uuidString < $1.tabID.rawValue.uuidString }
+  }
+
+  private func updateGithubHeadWatcher(for tabID: TerminalTabID, headURL: URL?) {
+    guard supatermSettings.githubIntegrationEnabled else {
+      cancelGithubHeadWatcher(for: tabID)
+      return
+    }
+    guard let headURL else {
+      cancelGithubHeadWatcher(for: tabID)
+      return
+    }
+    if githubHeadWatchersByTab[tabID]?.headURL == headURL {
+      return
+    }
+    cancelGithubHeadWatcher(for: tabID)
+    let path = headURL.path(percentEncoded: false)
+    let fileDescriptor = open(path, O_EVTONLY)
+    guard fileDescriptor >= 0 else { return }
+    let queue = DispatchQueue(label: "supaterm.github.head.\(tabID.rawValue.uuidString)")
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .rename, .delete, .attrib],
+      queue: queue
+    )
+    source.setEventHandler { [weak self, weak source] in
+      guard let source else { return }
+      let event = source.data
+      Task { @MainActor in
+        self?.handleGithubHeadWatcherEvent(
+          for: tabID,
+          event: event
+        )
+      }
+    }
+    source.setCancelHandler {
+      close(fileDescriptor)
+    }
+    source.resume()
+    githubHeadWatchersByTab[tabID] = TerminalGithubHeadWatcher(
+      headURL: headURL,
+      source: source
+    )
+  }
+
+  private func handleGithubHeadWatcherEvent(
+    for tabID: TerminalTabID,
+    event: DispatchSource.FileSystemEvent
+  ) {
+    if event.contains(.delete) || event.contains(.rename) {
+      cancelGithubHeadWatcher(for: tabID)
+      githubHeadWatcherRestartTasksByTab[tabID]?.cancel()
+      githubHeadWatcherRestartTasksByTab[tabID] = Task { @MainActor [weak self] in
+        try? await ContinuousClock().sleep(for: .seconds(1))
+        guard let self, !Task.isCancelled else { return }
+        await self.refreshGithubWorkspace(for: tabID)
+      }
+    } else {
+      scheduleGithubWorkspaceRefresh(for: tabID)
+    }
+  }
+
+  private func cancelGithubHeadWatcher(for tabID: TerminalTabID) {
+    githubHeadWatchersByTab.removeValue(forKey: tabID)?.source.cancel()
+    githubHeadWatcherRestartTasksByTab.removeValue(forKey: tabID)?.cancel()
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -186,9 +186,6 @@ final class TerminalHostState {
   @Shared(.supatermSettings)
   var supatermSettings = .default
   @ObservationIgnored
-  @Shared(.supatermSettings)
-  private var supatermSettings = .default
-  @ObservationIgnored
   private var eventContinuation: AsyncStream<TerminalClient.Event>.Continuation?
   @ObservationIgnored
   @Shared(.terminalSpaceCatalog)

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Dispatch
 import Foundation
 import GhosttyKit
 import Observation
@@ -180,7 +181,10 @@ final class TerminalHostState {
   @ObservationIgnored
   private let runtime: GhosttyRuntime?
   @ObservationIgnored
-  private let managesTerminalSurfaces: Bool
+  let managesTerminalSurfaces: Bool
+  @ObservationIgnored
+  @Shared(.supatermSettings)
+  var supatermSettings = .default
   @ObservationIgnored
   @Shared(.supatermSettings)
   private var supatermSettings = .default
@@ -192,9 +196,15 @@ final class TerminalHostState {
   @ObservationIgnored
   private var spaceCatalogObservationTask: Task<Void, Never>?
   @ObservationIgnored
+  var supatermSettingsObservationTask: Task<Void, Never>?
+  @ObservationIgnored
   private var runtimeConfigObserver: NSObjectProtocol?
   @ObservationIgnored
   private var lastAppliedSpaceCatalog = TerminalSpaceCatalog.default
+  @ObservationIgnored
+  let gitRepositoryClient: GitRepositoryClient
+  @ObservationIgnored
+  let githubCLIClient: GithubCLIClient
   @ObservationIgnored
   var onSessionChange: @MainActor () -> Void = {}
   @ObservationIgnored
@@ -203,12 +213,14 @@ final class TerminalHostState {
 
   private var pendingEvents: [TerminalClient.Event] = []
   private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
-  private var surfaces: [UUID: GhosttySurfaceView] = [:]
+  var surfaces: [UUID: GhosttySurfaceView] = [:]
   private var focusedSurfaceIDByTab: [TerminalTabID: UUID] = [:]
   private var previousFocusedSurfaceIDByTab: [TerminalTabID: UUID] = [:]
   private var paneNotifications: [UUID: [PaneNotification]] = [:]
   private var agentActivityByTab: [TerminalTabID: AgentActivity] = [:]
   private var agentActivitySurfaceIDByTab: [TerminalTabID: UUID] = [:]
+  var githubPullRequestByTab: [TerminalTabID: GithubPullRequest] = [:]
+  var githubWorkspaceByTab: [TerminalTabID: TerminalGithubWorkspace] = [:]
   private var previousSelectedTabIDBySpace: [TerminalSpaceID: TerminalTabID] = [:]
   private var previousSelectedSpaceID: TerminalSpaceID?
   private var lastEmittedFocusSurfaceID: UUID?
@@ -216,15 +228,31 @@ final class TerminalHostState {
   private var suppressesSessionChanges = 0
   @ObservationIgnored
   private var recentStructuredNotificationsBySurfaceID: [UUID: RecentStructuredNotification] = [:]
+  @ObservationIgnored
+  var githubWorkspaceRefreshTasksByTab: [TerminalTabID: Task<Void, Never>] = [:]
+  @ObservationIgnored
+  var githubHeadWatchersByTab: [TerminalTabID: TerminalGithubHeadWatcher] = [:]
+  @ObservationIgnored
+  var githubHeadWatcherRestartTasksByTab: [TerminalTabID: Task<Void, Never>] = [:]
+  @ObservationIgnored
+  var githubRepositoryRefreshTasksByRootURL: [URL: TerminalGithubRefreshTask] = [:]
+  @ObservationIgnored
+  var githubRepositoryRefreshOperationsByRootURL: [URL: Task<Void, Never>] = [:]
+  @ObservationIgnored
+  var queuedGithubRepositoryRefreshRootURLs: Set<URL> = []
 
   var windowActivity = WindowActivityState.inactive
 
   init(
     runtime: GhosttyRuntime? = nil,
-    managesTerminalSurfaces: Bool = true
+    managesTerminalSurfaces: Bool = true,
+    gitRepositoryClient: GitRepositoryClient = .liveValue,
+    githubCLIClient: GithubCLIClient = .liveValue
   ) {
     self.managesTerminalSurfaces = managesTerminalSurfaces
     self.runtime = managesTerminalSurfaces ? (runtime ?? GhosttyRuntime()) : runtime
+    self.gitRepositoryClient = gitRepositoryClient
+    self.githubCLIClient = githubCLIClient
 
     let initialSpaceCatalog = TerminalSpaceCatalog.sanitized(spaceCatalog)
     if initialSpaceCatalog != spaceCatalog {
@@ -237,10 +265,12 @@ final class TerminalHostState {
     )
     observeRuntimeConfig()
     observeSpaceCatalog()
+    observeSupatermSettings()
   }
 
   isolated deinit {
     spaceCatalogObservationTask?.cancel()
+    supatermSettingsObservationTask?.cancel()
     if let runtimeConfigObserver {
       NotificationCenter.default.removeObserver(runtimeConfigObserver)
     }
@@ -685,6 +715,15 @@ final class TerminalHostState {
     agentActivityByTab[tabID]
   }
 
+  func githubPullRequest(for tabID: TerminalTabID) -> GithubPullRequest? {
+    githubPullRequestByTab[tabID]
+  }
+
+  func githubCheckSummary(for tabID: TerminalTabID) -> String? {
+    guard let checks = githubPullRequestByTab[tabID]?.statusCheckRollup?.checks else { return nil }
+    return GithubPullRequestCheckBreakdown(checks: checks).summaryText
+  }
+
   func showsAgentActivityDetail(for tabID: TerminalTabID) -> Bool {
     guard let activitySurfaceID = agentActivitySurfaceIDByTab[tabID] else { return false }
     return focusedSurfaceIDByTab[tabID] == activitySurfaceID
@@ -780,6 +819,7 @@ final class TerminalHostState {
     if sessionChangesEnabled {
       sessionDidChange()
     }
+    scheduleGithubWorkspaceRefresh(for: tabID)
     return tabID
   }
 
@@ -814,6 +854,7 @@ final class TerminalHostState {
     applySelectedTab(tabID, in: space.id)
     focusSurface(in: tabID)
     syncFocus(windowActivity)
+    refreshGithubRepositorySchedules()
     sessionDidChange()
   }
 
@@ -909,6 +950,7 @@ final class TerminalHostState {
       throw TerminalControlError.spaceNotFound(windowIndex: 1, spaceIndex: spaces.count + 1)
     }
     finalizeSpaceSelectionChange()
+    refreshGithubRepositorySchedules()
     sessionDidChange()
     return space.id
   }
@@ -926,6 +968,7 @@ final class TerminalHostState {
       persistDefaultSelectedSpaceID(spaceID)
     }
     finalizeSpaceSelectionChange()
+    refreshGithubRepositorySchedules()
     sessionDidChange()
   }
 
@@ -972,6 +1015,7 @@ final class TerminalHostState {
     )
     _ = writeSpaceCatalog(updatedSpaceCatalog)
     finalizeSpaceSelectionChange()
+    refreshGithubRepositorySchedules()
     sessionDidChange()
   }
 
@@ -1067,6 +1111,7 @@ final class TerminalHostState {
   private func updateWindowActivity(_ activity: WindowActivityState) {
     windowActivity = activity
     syncFocus(activity)
+    refreshGithubRepositorySchedules()
     clearUnreadOnFocusedSurfaceIfNeeded()
   }
 
@@ -2473,6 +2518,7 @@ final class TerminalHostState {
     view.bridge.onPathChange = { [weak self] in
       guard let self else { return }
       self.updateTabTitle(for: tabID)
+      self.scheduleGithubWorkspaceRefresh(for: tabID)
       self.sessionDidChange()
     }
     view.bridge.onTabTitleChange = { [weak self] title in
@@ -2520,6 +2566,7 @@ final class TerminalHostState {
     view.bridge.onCommandFinished = { [weak self, weak view] in
       guard let self, let view else { return }
       _ = self.clearAgentActivity(for: view.id)
+      self.scheduleGithubWorkspaceRefresh(for: tabID)
       self.onCommandFinished(view.id)
     }
     view.bridge.onCloseRequest = { [weak self, weak view] processAlive in
@@ -2892,6 +2939,8 @@ final class TerminalHostState {
     applyFocusedSurface(surface.id, in: tabID)
     updateTabTitle(for: tabID)
     clearNotificationAttention(for: surface.id)
+    scheduleGithubWorkspaceRefresh(for: tabID)
+    refreshGithubRepositorySchedules()
     guard tabID == spaceManager.selectedTabID else { return }
     let fromSurface = previousSurface === surface ? nil : previousSurface
     GhosttySurfaceView.moveFocus(to: surface, from: fromSurface)
@@ -2965,6 +3014,7 @@ final class TerminalHostState {
   }
 
   private func removeTree(for tabID: TerminalTabID) {
+    clearGithubWorkspace(for: tabID)
     guard let tree = trees.removeValue(forKey: tabID) else { return }
     for surface in tree.leaves() {
       paneNotifications.removeValue(forKey: surface.id)
@@ -2972,6 +3022,7 @@ final class TerminalHostState {
       surface.closeSurface()
       surfaces.removeValue(forKey: surface.id)
     }
+    githubPullRequestByTab.removeValue(forKey: tabID)
     agentActivityByTab.removeValue(forKey: tabID)
     agentActivitySurfaceIDByTab.removeValue(forKey: tabID)
     focusedSurfaceIDByTab.removeValue(forKey: tabID)
@@ -3331,6 +3382,8 @@ final class TerminalHostState {
     previousSelectedTabIDBySpace.removeAll()
     previousSelectedSpaceID = nil
     lastEmittedFocusSurfaceID = nil
+    githubPullRequestByTab.removeAll()
+    githubWorkspaceByTab.removeAll()
   }
 
   private func sessionDidChange() {
@@ -3348,7 +3401,7 @@ final class TerminalHostState {
     return body()
   }
 
-  private func workingDirectoryPath(for surface: GhosttySurfaceView) -> String? {
+  func workingDirectoryPath(for surface: GhosttySurfaceView) -> String? {
     guard let path = Self.trimmedNonEmpty(surface.bridge.state.pwd) else { return nil }
     return GhosttySurfaceView.normalizedWorkingDirectoryPath(path)
   }

--- a/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
@@ -824,6 +824,8 @@ struct TerminalSidebarTabRow: View {
 
   private struct AnimatedPresentation: Equatable {
     let agentActivity: TerminalHostState.AgentActivity?
+    let githubCheckSummary: String?
+    let githubPullRequest: GithubPullRequest?
     let showsAgentActivityDetail: Bool
     let notificationPreviewMarkdown: String?
     let notificationMarkdown: String?
@@ -869,6 +871,14 @@ struct TerminalSidebarTabRow: View {
     terminal.selectedTabID == tab.id
   }
 
+  private var githubPullRequest: GithubPullRequest? {
+    terminal.githubPullRequest(for: tab.id)
+  }
+
+  private var githubCheckSummary: String? {
+    terminal.githubCheckSummary(for: tab.id)
+  }
+
   private var contextSurfaceID: UUID? {
     terminal.contextSurfaceID(for: tab.id)
   }
@@ -883,53 +893,38 @@ struct TerminalSidebarTabRow: View {
   }
 
   var body: some View {
-    Button(action: select) {
-      HStack(spacing: 8) {
-        let summary = TerminalSidebarTabSummaryView(
-          tab: tab,
-          palette: palette,
-          isSelected: isSelected,
-          notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
-          paneWorkingDirectories: paneWorkingDirectories,
-          unreadCount: unreadCount,
-          agentActivity: terminal.agentActivity(for: tab.id),
-          showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
-          terminalProgress: terminalProgress,
-          shortcutHint: shortcutHint,
-          showsShortcutHint: showsShortcutHint,
-          isRowHovering: isHovering
-        )
-        .lineLimit(8)
-        if let helpText = TerminalSidebarTabSummaryView.helpText(
-          paneWorkingDirectories: paneWorkingDirectories
-        ) {
-          summary.help(helpText)
-        } else {
-          summary
-        }
-
-        if isHovering && !showsShortcutHint {
-          Button(action: close) {
-            Image(systemName: "xmark")
-              .font(.system(size: 12, weight: .heavy))
-              .foregroundStyle(isSelected ? palette.selectedText : palette.primaryText)
-              .frame(width: 24, height: 24)
-              .accessibilityHidden(true)
-              .background(
-                isCloseHovering
-                  ? (isSelected ? palette.clearFill : palette.rowFill)
-                  : .clear,
-                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-              )
+    ZStack(alignment: .topTrailing) {
+      VStack(alignment: .leading, spacing: 4) {
+        selectButton
+        if let githubPullRequest {
+          Button(action: openPullRequest) {
+            HStack(spacing: 6) {
+              Image(systemName: "arrow.up.right.square")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(prLineColor)
+                .accessibilityHidden(true)
+              Text("PR #\(githubPullRequest.number) \(githubPullRequest.title)")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(prLineColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
           }
           .buttonStyle(.plain)
-          .onHover { isCloseHovering = $0 }
+        }
+        if let githubCheckSummary {
+          Text(githubCheckSummary)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(checkSummaryColor)
+            .lineLimit(1)
+            .truncationMode(.tail)
         }
       }
       .padding(.horizontal, TerminalSidebarLayout.tabRowHorizontalPadding)
       .padding(.vertical, TerminalSidebarLayout.tabRowVerticalPadding)
       .frame(minHeight: TerminalSidebarLayout.tabRowMinHeight)
-      .frame(maxWidth: .infinity)
+      .frame(maxWidth: .infinity, alignment: .leading)
       .background(backgroundColor)
       .clipShape(
         RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
@@ -938,8 +933,27 @@ struct TerminalSidebarTabRow: View {
       .contentShape(
         RoundedRectangle(cornerRadius: TerminalSidebarLayout.tabRowCornerRadius, style: .continuous)
       )
+
+      if isHovering && !showsShortcutHint {
+        Button(action: close) {
+          Image(systemName: "xmark")
+            .font(.system(size: 12, weight: .heavy))
+            .foregroundStyle(isSelected ? palette.selectedText : palette.primaryText)
+            .frame(width: 24, height: 24)
+            .accessibilityHidden(true)
+            .background(
+              isCloseHovering
+                ? (isSelected ? palette.clearFill : palette.rowFill)
+                : .clear,
+              in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isCloseHovering = $0 }
+        .padding(.top, 8)
+        .padding(.trailing, 8)
+      }
     }
-    .buttonStyle(.plain)
     .animation(rowAnimation, value: animatedPresentation)
     .background {
       SidebarPopoverPresenter(
@@ -1019,6 +1033,38 @@ struct TerminalSidebarTabRow: View {
     }
   }
 
+  private var selectButton: some View {
+    let summary = TerminalSidebarTabSummaryView(
+      tab: tab,
+      palette: palette,
+      isSelected: isSelected,
+      notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
+      paneWorkingDirectories: paneWorkingDirectories,
+      unreadCount: unreadCount,
+      agentActivity: terminal.agentActivity(for: tab.id),
+      showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
+      terminalProgress: terminalProgress,
+      shortcutHint: shortcutHint,
+      showsShortcutHint: showsShortcutHint,
+      isRowHovering: isHovering
+    )
+    .lineLimit(8)
+
+    return Button(action: select) {
+      Group {
+        if let helpText = TerminalSidebarTabSummaryView.helpText(
+          paneWorkingDirectories: paneWorkingDirectories
+        ) {
+          summary.help(helpText)
+        } else {
+          summary
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .buttonStyle(.plain)
+  }
+
   private var backgroundColor: Color {
     if isSelected {
       return palette.selectedFill
@@ -1032,6 +1078,8 @@ struct TerminalSidebarTabRow: View {
   private var animatedPresentation: AnimatedPresentation {
     .init(
       agentActivity: terminal.agentActivity(for: tab.id),
+      githubCheckSummary: githubCheckSummary,
+      githubPullRequest: githubPullRequest,
       showsAgentActivityDetail: terminal.showsAgentActivityDetail(for: tab.id),
       notificationPreviewMarkdown: notificationPresentation?.previewMarkdown,
       notificationMarkdown: notificationPresentation?.markdown,
@@ -1057,8 +1105,20 @@ struct TerminalSidebarTabRow: View {
     isHovering && popoverMarkdown != nil
   }
 
+  private var prLineColor: Color {
+    isSelected ? palette.selectedText : palette.primaryText
+  }
+
+  private var checkSummaryColor: Color {
+    isSelected ? palette.selectedText.opacity(0.72) : palette.secondaryText
+  }
+
   private func select() {
     _ = store.send(.tabSelected(tab.id))
+  }
+
+  private func openPullRequest() {
+    _ = terminal.openPullRequest(for: tab.id)
   }
 
   private func close() {

--- a/apps/mac/supatermTests/GitRepositoryClientTests.swift
+++ b/apps/mac/supatermTests/GitRepositoryClientTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import supaterm
+
+struct GitRepositoryClientTests {
+  @Test
+  func githubRemotesPreferUpstreamThenOriginThenOthers() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    try runGit(["init"], in: rootURL)
+    try runGit(["remote", "add", "zebra", "git@github.com:other/tools.git"], in: rootURL)
+    try runGit(["remote", "add", "origin", "git@github.com:khoi/supaterm.git"], in: rootURL)
+    try runGit(["remote", "add", "upstream", "git@github.com:supabitapp/supaterm.git"], in: rootURL)
+    try runGit(["remote", "add", "alpha", "https://github.example.com/org/infra.git"], in: rootURL)
+
+    let remotes = await GitRepositoryClient.liveValue.githubRemotes(rootURL)
+
+    #expect(remotes.map(\.remoteName) == ["upstream", "origin", "alpha", "zebra"])
+    #expect(remotes.map(\.host) == ["github.com", "github.com", "github.example.com", "github.com"])
+  }
+
+  @Test
+  func parsesGithubRemoteTargetsFromSshAndHttps() {
+    let ssh = GitRepositoryClient.parseGithubRemoteTarget(
+      remoteName: "upstream",
+      remoteURL: "git@github.com:supabitapp/supaterm.git"
+    )
+    let https = GitRepositoryClient.parseGithubRemoteTarget(
+      remoteName: "origin",
+      remoteURL: "https://github.example.com/team/product.git"
+    )
+
+    #expect(
+      ssh == GithubRemoteTarget(remoteName: "upstream", host: "github.com", owner: "supabitapp", repo: "supaterm"))
+    #expect(
+      https == GithubRemoteTarget(remoteName: "origin", host: "github.example.com", owner: "team", repo: "product"))
+  }
+
+  private func runGit(_ arguments: [String], in directoryURL: URL) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    process.currentDirectoryURL = directoryURL
+
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = outputPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    if process.terminationStatus != 0 {
+      let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+      throw GitTestError.commandFailed(String(data: data, encoding: .utf8) ?? "")
+    }
+  }
+}
+
+private enum GitTestError: Error {
+  case commandFailed(String)
+}

--- a/apps/mac/supatermTests/GithubPullRequestCheckBreakdownTests.swift
+++ b/apps/mac/supatermTests/GithubPullRequestCheckBreakdownTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import supaterm
+
+struct GithubPullRequestCheckBreakdownTests {
+  @Test
+  func summaryIncludesEachVisibleBucket() {
+    let breakdown = GithubPullRequestCheckBreakdown(
+      checks: [
+        .init(name: "build", conclusion: "SUCCESS"),
+        .init(name: "tests", conclusion: "FAILURE"),
+        .init(name: "lint", status: "IN_PROGRESS"),
+        .init(name: "deploy", state: "EXPECTED"),
+        .init(name: "optional", conclusion: "SKIPPED"),
+      ]
+    )
+
+    #expect(breakdown.summaryText == "1 failed, 1 pending, 1 expected, 1 skipped, 1 passed")
+  }
+}

--- a/apps/mac/supatermTests/GithubPullRequestParsingTests.swift
+++ b/apps/mac/supatermTests/GithubPullRequestParsingTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+@testable import supaterm
+
+struct GithubPullRequestParsingTests {
+  @Test
+  func parserPrefersOwnerRepoMatchAndOpenState() throws {
+    let response = try decodeResponse(
+      #"""
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 30,
+                  "title": "Fork PR",
+                  "state": "OPEN",
+                  "isDraft": false,
+                  "reviewDecision": "APPROVED",
+                  "mergeable": "MERGEABLE",
+                  "mergeStateStatus": "CLEAN",
+                  "updatedAt": "2026-04-09T08:00:00Z",
+                  "url": "https://github.com/supabitapp/supaterm/pull/30",
+                  "headRefName": "feature",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "supaterm",
+                    "owner": { "login": "forker" }
+                  }
+                },
+                {
+                  "number": 31,
+                  "title": "Upstream PR",
+                  "state": "OPEN",
+                  "isDraft": false,
+                  "reviewDecision": "REVIEW_REQUIRED",
+                  "mergeable": "CONFLICTING",
+                  "mergeStateStatus": "DIRTY",
+                  "updatedAt": "2026-04-09T07:00:00Z",
+                  "url": "https://github.com/supabitapp/supaterm/pull/31",
+                  "headRefName": "feature",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "supaterm",
+                    "owner": { "login": "supabitapp" }
+                  }
+                }
+              ]
+            },
+            "branch1": {
+              "nodes": [
+                {
+                  "number": 40,
+                  "title": "Merged fallback",
+                  "state": "MERGED",
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "mergeable": null,
+                  "mergeStateStatus": null,
+                  "updatedAt": "2026-04-09T06:00:00Z",
+                  "url": "https://github.com/supabitapp/supaterm/pull/40",
+                  "headRefName": "fork-branch",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "supaterm-fork",
+                    "owner": { "login": "forker" }
+                  }
+                },
+                {
+                  "number": 41,
+                  "title": "Open fallback",
+                  "state": "OPEN",
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "mergeable": null,
+                  "mergeStateStatus": null,
+                  "updatedAt": "2026-04-09T05:00:00Z",
+                  "url": "https://github.com/supabitapp/supaterm/pull/41",
+                  "headRefName": "fork-branch",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "supaterm-fork",
+                    "owner": { "login": "forker" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """#
+    )
+
+    let result = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feature", "branch1": "fork-branch"],
+      owner: "supabitapp",
+      repo: "supaterm"
+    )
+
+    #expect(result["feature"]?.number == 31)
+    #expect(result["fork-branch"]?.number == 41)
+  }
+
+  private func decodeResponse(_ json: String) throws -> GithubGraphQLPullRequestResponse {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(GithubGraphQLPullRequestResponse.self, from: Data(json.utf8))
+  }
+}

--- a/apps/mac/supatermTests/SettingsFeatureTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureTests.swift
@@ -79,9 +79,6 @@ struct SettingsFeatureTests {
         $0.piIntegration.isPending = true
       }
       await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
-      await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
-        $0.terminal = terminalSettingsState()
-      }
       await store.receive(
         .githubIntegrationStatusRefreshed(
           .authenticated(username: "khoi", host: "github.com")
@@ -89,6 +86,9 @@ struct SettingsFeatureTests {
         timeout: 0
       ) {
         $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
+      }
+      await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
+        $0.terminal = terminalSettingsState()
       }
       await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
         $0.claudeIntegration.isPending = false
@@ -134,9 +134,6 @@ struct SettingsFeatureTests {
       $0.piIntegration.isPending = true
     }
     await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
-    await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
-      $0.terminal = terminalSettingsState()
-    }
     await store.receive(
       .githubIntegrationStatusRefreshed(
         .authenticated(username: "khoi", host: "github.com")
@@ -144,6 +141,9 @@ struct SettingsFeatureTests {
       timeout: 0
     ) {
       $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
+    }
+    await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
+      $0.terminal = terminalSettingsState()
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
       $0.claudeIntegration.isPending = false
@@ -391,7 +391,8 @@ struct SettingsFeatureTests {
   func notificationPermissionAlertOpensSystemSettings() async {
     let recorder = SettingsNotificationPermissionRecorder()
     var state = SettingsFeature.State()
-    state.alert = notificationPermissionAlert("Supaterm cannot send system notifications.\n\nError: Mock request error")
+    state.alert = notificationPermissionAlert(
+      "Supaterm cannot send system notifications.\n\nError: Mock request error")
 
     let store = TestStore(initialState: state) {
       SettingsFeature()
@@ -567,9 +568,6 @@ struct SettingsFeatureTests {
       $0.piIntegration.isPending = true
     }
     await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
-    await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
-      $0.terminal = terminalSettingsState()
-    }
     await store.receive(
       .githubIntegrationStatusRefreshed(
         .authenticated(username: "khoi", host: "github.com")
@@ -577,6 +575,9 @@ struct SettingsFeatureTests {
       timeout: 0
     ) {
       $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
+    }
+    await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
+      $0.terminal = terminalSettingsState()
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(true)), timeout: 0) {
       $0.claudeIntegration.confirmedEnabled = true
@@ -661,7 +662,9 @@ struct SettingsFeatureTests {
     let store = TestStore(initialState: SettingsFeature.State()) {
       SettingsFeature()
     } withDependencies: {
-      $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.example.com") }
+      $0.githubCLIClient.authStatus = {
+        GithubAuthStatus(username: "khoi", host: "github.example.com")
+      }
       $0.githubCLIClient.isAvailable = { true }
     }
 
@@ -673,6 +676,26 @@ struct SettingsFeatureTests {
       timeout: 0
     ) {
       $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.example.com")
+    }
+  }
+
+  @Test
+  func githubIntegrationCommandFailureShowsFailure() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.githubCLIClient.authStatus = { throw GithubCLIError.commandFailed("boom") }
+      $0.githubCLIClient.isAvailable = { true }
+    }
+
+    await store.send(.githubIntegrationStatusRefreshRequested)
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .failure("boom")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .failure("boom")
     }
   }
 
@@ -848,7 +871,8 @@ struct SettingsFeatureTests {
         .failure("Claude settings must be valid JSON before Supaterm can install hooks.")
       )
     ) {
-      $0.claudeIntegration.errorMessage = "Claude settings must be valid JSON before Supaterm can install hooks."
+      $0.claudeIntegration.errorMessage =
+        "Claude settings must be valid JSON before Supaterm can install hooks."
       $0.claudeIntegration.isEnabled = false
       $0.claudeIntegration.isPending = false
     }
@@ -901,7 +925,9 @@ struct SettingsFeatureTests {
     await store.receive(
       .agentIntegrationToggleFinished(
         .codex,
-        .failure("Codex must be installed and available in your login shell before Supaterm can install hooks.")
+        .failure(
+          "Codex must be installed and available in your login shell before Supaterm can install hooks."
+        )
       )
     ) {
       $0.codexIntegration.errorMessage =
@@ -926,7 +952,9 @@ struct SettingsFeatureTests {
     await store.receive(
       .agentIntegrationStatusRefreshed(
         .pi,
-        .unavailable("Pi must be installed and available in your login shell before Supaterm can manage the package.")
+        .unavailable(
+          "Pi must be installed and available in your login shell before Supaterm can manage the package."
+        )
       )
     ) {
       $0.piIntegration.errorMessage =

--- a/apps/mac/supatermTests/SettingsFeatureTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureTests.swift
@@ -34,6 +34,7 @@ struct SettingsFeatureTests {
           appearanceMode: .dark,
           analyticsEnabled: false,
           crashReportsEnabled: true,
+          githubIntegrationEnabled: true,
           glowingPaneRingEnabled: false,
           newTabPosition: .current,
           restoreTerminalLayoutEnabled: false,
@@ -47,6 +48,8 @@ struct SettingsFeatureTests {
       } withDependencies: {
         $0.claudeSettingsClient.hasSupatermHooks = { false }
         $0.codexSettingsClient.hasSupatermHooks = { false }
+        $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.com") }
+        $0.githubCLIClient.isAvailable = { true }
         $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
         $0.piSettingsClient.hasSupatermIntegration = { false }
       }
@@ -56,6 +59,7 @@ struct SettingsFeatureTests {
         $0.appearanceMode = .dark
         $0.analyticsEnabled = false
         $0.crashReportsEnabled = true
+        $0.githubIntegrationEnabled = true
         $0.glowingPaneRingEnabled = false
         $0.newTabPosition = .current
         $0.restoreTerminalLayoutEnabled = false
@@ -74,8 +78,17 @@ struct SettingsFeatureTests {
       await store.receive(.agentIntegrationStatusRefreshRequested(.pi), timeout: 0) {
         $0.piIntegration.isPending = true
       }
+      await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
       await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
         $0.terminal = terminalSettingsState()
+      }
+      await store.receive(
+        .githubIntegrationStatusRefreshed(
+          .authenticated(username: "khoi", host: "github.com")
+        ),
+        timeout: 0
+      ) {
+        $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
       }
       await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
         $0.claudeIntegration.isPending = false
@@ -98,6 +111,8 @@ struct SettingsFeatureTests {
     } withDependencies: {
       $0.claudeSettingsClient.hasSupatermHooks = { false }
       $0.codexSettingsClient.hasSupatermHooks = { false }
+      $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.com") }
+      $0.githubCLIClient.isAvailable = { true }
       $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
       $0.piSettingsClient.hasSupatermIntegration = { false }
       $0.updateClient.observe = { stream }
@@ -118,8 +133,17 @@ struct SettingsFeatureTests {
     await store.receive(.agentIntegrationStatusRefreshRequested(.pi), timeout: 0) {
       $0.piIntegration.isPending = true
     }
+    await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
     await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
       $0.terminal = terminalSettingsState()
+    }
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .authenticated(username: "khoi", host: "github.com")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(false)), timeout: 0) {
       $0.claudeIntegration.isPending = false
@@ -522,6 +546,8 @@ struct SettingsFeatureTests {
     } withDependencies: {
       $0.claudeSettingsClient.hasSupatermHooks = { true }
       $0.codexSettingsClient.hasSupatermHooks = { false }
+      $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.com") }
+      $0.githubCLIClient.isAvailable = { true }
       $0.ghosttyTerminalSettingsClient.load = { terminalSettingsSnapshot() }
       $0.piSettingsClient.hasSupatermIntegration = { true }
     }
@@ -540,8 +566,17 @@ struct SettingsFeatureTests {
     await store.receive(.agentIntegrationStatusRefreshRequested(.pi), timeout: 0) {
       $0.piIntegration.isPending = true
     }
+    await store.receive(.githubIntegrationStatusRefreshRequested, timeout: 0)
     await store.receive(.terminalSettingsLoaded(terminalSettingsSnapshot()), timeout: 0) {
       $0.terminal = terminalSettingsState()
+    }
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .authenticated(username: "khoi", host: "github.com")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.com")
     }
     await store.receive(.agentIntegrationStatusRefreshed(.claude, .success(true)), timeout: 0) {
       $0.claudeIntegration.confirmedEnabled = true
@@ -555,6 +590,89 @@ struct SettingsFeatureTests {
       $0.piIntegration.confirmedEnabled = true
       $0.piIntegration.isEnabled = true
       $0.piIntegration.isPending = false
+    }
+  }
+
+  @Test
+  func githubIntegrationTogglePersistsPrefs() async throws {
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let store = TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      } withDependencies: {
+        $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.com") }
+        $0.githubCLIClient.isAvailable = { true }
+      }
+
+      await store.send(.githubIntegrationEnabledChanged(false)) {
+        $0.githubIntegrationEnabled = false
+        $0.githubIntegrationStatus = .disabled
+      }
+
+      @Shared(.supatermSettings) var supatermSettings = .default
+      #expect(!supatermSettings.githubIntegrationEnabled)
+    }
+  }
+
+  @Test
+  func githubIntegrationUnavailableShowsExplicitState() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.githubCLIClient.isAvailable = { false }
+    }
+
+    await store.send(.githubIntegrationStatusRefreshRequested)
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .unavailable("Install `gh` to enable pull request integration.")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .unavailable("Install `gh` to enable pull request integration.")
+    }
+  }
+
+  @Test
+  func githubIntegrationUnauthenticatedShowsExplicitState() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.githubCLIClient.authStatus = { nil }
+      $0.githubCLIClient.isAvailable = { true }
+    }
+
+    await store.send(.githubIntegrationStatusRefreshRequested)
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .unauthenticated("Run `gh auth login` in a terminal to authenticate.")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .unauthenticated(
+        "Run `gh auth login` in a terminal to authenticate."
+      )
+    }
+  }
+
+  @Test
+  func githubIntegrationAuthenticatedShowsAccount() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.githubCLIClient.authStatus = { GithubAuthStatus(username: "khoi", host: "github.example.com") }
+      $0.githubCLIClient.isAvailable = { true }
+    }
+
+    await store.send(.githubIntegrationStatusRefreshRequested)
+    await store.receive(
+      .githubIntegrationStatusRefreshed(
+        .authenticated(username: "khoi", host: "github.example.com")
+      ),
+      timeout: 0
+    ) {
+      $0.githubIntegrationStatus = .authenticated(username: "khoi", host: "github.example.com")
     }
   }
 

--- a/apps/mac/supatermTests/SupatermSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsTests.swift
@@ -21,6 +21,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .system)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubIntegrationEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
@@ -45,6 +46,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubIntegrationEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
@@ -65,6 +67,7 @@ struct SupatermSettingsTests {
         "analyticsEnabled",
         "appearanceMode",
         "crashReportsEnabled",
+        "githubIntegrationEnabled",
         "glowingPaneRingEnabled",
         "newTabPosition",
         "restoreTerminalLayoutEnabled",
@@ -120,6 +123,7 @@ struct SupatermSettingsTests {
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
     #expect(prefs.crashReportsEnabled)
+    #expect(prefs.githubIntegrationEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)

--- a/apps/supaterm.com/public/data/supaterm-settings.schema.json
+++ b/apps/supaterm.com/public/data/supaterm-settings.schema.json
@@ -26,6 +26,11 @@
       "description": "Allow crash reports.",
       "type": "boolean"
     },
+    "githubIntegrationEnabled": {
+      "default": true,
+      "description": "Enable GitHub pull request integration in terminal tabs.",
+      "type": "boolean"
+    },
     "glowingPaneRingEnabled": {
       "default": true,
       "description": "Show a glowing ring around panes with unread attention.",


### PR DESCRIPTION
## Summary

- Problem: Supaterm had no native pull request awareness in the macOS terminal UI, and branch-to-PR resolution could be inefficient or wrong for multi-workspace repos and fork workflows.
- Why it matters: users could not see the active PR and checks state in the sidebar, and forked repos could resolve the fork PR instead of the upstream PR.
- What changed: added a `gh`-backed GitHub integration with explicit availability and auth states, repo-level batched PR refresh, upstream-first multi-remote resolution, richer PR and check models, and sidebar presentation plus open-PR action.
- What did NOT change (scope boundary): no non-GitHub provider support, no migration layer, and no expansion beyond the current macOS app sidebar and settings flow.

## Rationale

The implementation keeps branch watching close to each workspace but moves PR refresh to the repository level so multiple workspaces in the same repo share one GitHub lookup path. It also preserves fork correctness by preferring `upstream`, then `origin`, then other GitHub remotes, and carrying host, owner, and repo data through the lookup path so GitHub Enterprise hosts work the same way.

## User-visible / Behavior Changes

- Terminal tabs can show the current branch pull request and a compact checks summary in the sidebar.
- Clicking the PR opens it.
- Settings now expose explicit GitHub integration states: disabled, checking, unavailable, unauthenticated, authenticated, and failure.
- Repositories with multiple workspaces refresh PR state in batches instead of one lookup per workspace.

## Diagram (if applicable)

```text
Before:
[branch/worktree change] -> [per-workspace probing] -> [stale or fork-mismatched PR state]

After:
[branch/worktree change] -> [workspace HEAD watcher] -> [repo-level refresh queue]
-> [upstream-first remote resolution] -> [batched gh GraphQL lookup]
-> [sidebar PR + checks state]
```

## Human Verification

- Verified scenarios: focused `SettingsFeatureTests` and `GithubPullRequestParsingTests`, `make mac-lint`, and the full pre-push path: `make web-check`, `make web-test`, and `make mac-test`.
- Edge cases checked: unauthenticated or missing `gh`, GitHub CLI command failure handling, upstream-vs-fork PR selection, and settings reducer task ordering.
- What you did **not** verify: manual end-to-end UI interaction in the macOS app against a live GitHub repo after the final rebase.
- How can a human manually verify this: enable GitHub integration in Settings, open a repo with an upstream PR, switch branches and workspaces, confirm the sidebar updates and clears correctly, and click the PR row to open it.
