### PR TITLE
Fix SUP-54 Tuist dependency-order scheme

### DIFF
--- a/apps/mac/Project.swift
+++ b/apps/mac/Project.swift
@@ -326,6 +326,7 @@ let project = Project(
         ),
       ],
       dependencies: [
+        .target(name: "sp"),
         .target(name: "SupatermCLIShared"),
         .target(name: "SupatermSupport"),
         .target(name: "SupatermTerminalCore"),
@@ -355,7 +356,10 @@ let project = Project(
           "DEAD_CODE_STRIPPING": "YES",
         ],
         defaultSettings: .essential
-      )
+      ),
+      metadata: .metadata(tags: [
+        "tag:build-artifact:sp",
+      ])
     ),
     .target(
       name: "supatermTests",
@@ -399,10 +403,8 @@ let project = Project(
       name: "supaterm",
       buildAction: .buildAction(
         targets: [
-          .target("sp"),
           .target("supaterm"),
         ],
-        buildOrder: .manual,
         runPostActionsOnFailure: true
       ),
       testAction: .targets(

--- a/apps/mac/Tuist.swift
+++ b/apps/mac/Tuist.swift
@@ -2,6 +2,13 @@ import ProjectDescription
 
 let tuist = Tuist(
   fullHandle: "supabitapp/supaterm",
+  inspectOptions: .options(
+    redundantDependencies: .redundantDependencies(
+      ignoreTagsMatching: [
+        "tag:build-artifact:sp",
+      ]
+    )
+  ),
   project: .tuist(
     compatibleXcodeVersions: .upToNextMajor("26.0"),
     swiftVersion: "6.2",


### PR DESCRIPTION

- Remove manual build order from the generated `supaterm` scheme.
- Add the `supaterm` app target dependency on `sp` so the CLI is built through the graph.
- Keep the existing bundled `sp` embed behavior and teach Tuist dependency inspection that this edge is a build artifact dependency.

