### PR TITLE
[fix] Respect reduced motion in terminal UI

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/TerminalView.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalView.swift
@@ -11,6 +11,7 @@ struct TerminalView: View {
   let updateStore: StoreOf<UpdateFeature>
   @Bindable var terminal: TerminalHostState
   @Shared(.supatermSettings) private var supatermSettings = .default
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State private var window: NSWindow?
 
@@ -197,14 +198,36 @@ struct TerminalView: View {
       } message: {
         Text(spaceDeleteMessage)
       }
-      .animation(.spring(response: 0.2, dampingFraction: 1.0), value: store.isSidebarCollapsed)
-      .animation(.easeOut(duration: 0.1), value: store.isFloatingSidebarVisible)
-      .animation(.easeOut(duration: 0.12), value: store.commandPalette != nil)
-      .animation(.spring(response: 0.3, dampingFraction: 0.82), value: store.confirmationRequest)
-      .animation(
-        .spring(response: 0.28, dampingFraction: 0.82), value: terminal.visibleTabs.map(\.id)
+      .terminalAnimation(
+        .spring(response: 0.2, dampingFraction: 1.0),
+        value: store.isSidebarCollapsed,
+        reduceMotion: reduceMotion
       )
-      .animation(.spring(response: 0.28, dampingFraction: 0.82), value: terminal.spaces.map(\.id))
+      .terminalAnimation(
+        .easeOut(duration: 0.1),
+        value: store.isFloatingSidebarVisible,
+        reduceMotion: reduceMotion
+      )
+      .terminalAnimation(
+        .easeOut(duration: 0.12),
+        value: store.commandPalette != nil,
+        reduceMotion: reduceMotion
+      )
+      .terminalAnimation(
+        .spring(response: 0.3, dampingFraction: 0.82),
+        value: store.confirmationRequest,
+        reduceMotion: reduceMotion
+      )
+      .terminalAnimation(
+        .spring(response: 0.28, dampingFraction: 0.82),
+        value: terminal.visibleTabs.map(\.id),
+        reduceMotion: reduceMotion
+      )
+      .terminalAnimation(
+        .spring(response: 0.28, dampingFraction: 0.82),
+        value: terminal.spaces.map(\.id),
+        reduceMotion: reduceMotion
+      )
       .environment(\.colorScheme, chromeColorScheme)
   }
 
@@ -274,7 +297,7 @@ struct TerminalView: View {
   }
 
   private func collapseSidebar() {
-    withAnimation(.spring(response: 0.2, dampingFraction: 1.0)) {
+    TerminalMotion.animate(.spring(response: 0.2, dampingFraction: 1.0), reduceMotion: reduceMotion) {
       _ = store.send(.collapseSidebarButtonTapped)
     }
   }

--- a/apps/mac/supaterm/Features/Terminal/Views/DialogOverlays.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/DialogOverlays.swift
@@ -9,6 +9,8 @@ struct ConfirmationOverlay: View {
   let onConfirm: () -> Void
   let onCancel: () -> Void
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
   private static let transition: AnyTransition = .asymmetric(
     insertion: .offset(y: -16).combined(with: .scale(scale: 0.96)).combined(with: .opacity),
     removal: .offset(y: -16).combined(with: .scale(scale: 0.96)).combined(with: .opacity)
@@ -72,7 +74,7 @@ struct ConfirmationOverlay: View {
       .padding(3)
       .background(palette.dialogOuterBackground, in: .rect(cornerRadius: 14))
       .shadow(color: .black.opacity(0.25), radius: 20, y: 8)
-      .transition(Self.transition)
+      .terminalTransition(Self.transition, reduceMotion: reduceMotion)
     }
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
@@ -5,6 +5,7 @@ struct GhosttySurfaceProgressBar: View {
   let progressState: ghostty_action_progress_report_state_e
   let progressValue: Int?
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var position: CGFloat = 0
 
   var body: some View {
@@ -44,7 +45,7 @@ struct GhosttySurfaceProgressBar: View {
               width: geometry.size.width * CGFloat(progress) / 100,
               height: geometry.size.height
             )
-            .animation(.easeInOut(duration: 0.2), value: progress)
+            .terminalAnimation(.easeInOut(duration: 0.2), value: progress, reduceMotion: reduceMotion)
         } else {
           ZStack(alignment: .leading) {
             Rectangle()
@@ -55,15 +56,28 @@ struct GhosttySurfaceProgressBar: View {
               .offset(x: position * (geometry.size.width * 0.75))
           }
           .onAppear {
-            withAnimation(
+            guard !reduceMotion else { return }
+            TerminalMotion.animate(
               .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true)
+                .repeatForever(autoreverses: true),
+              reduceMotion: reduceMotion
             ) {
               position = 1
             }
           }
           .onDisappear {
             position = 0
+          }
+          .onChange(of: reduceMotion) { _, reduceMotion in
+            position = 0
+            guard !reduceMotion else { return }
+            TerminalMotion.animate(
+              .easeInOut(duration: 1.2)
+                .repeatForever(autoreverses: true),
+              reduceMotion: reduceMotion
+            ) {
+              position = 1
+            }
           }
         }
       }

--- a/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
@@ -56,28 +56,13 @@ struct GhosttySurfaceProgressBar: View {
               .offset(x: position * (geometry.size.width * 0.75))
           }
           .onAppear {
-            guard !reduceMotion else { return }
-            TerminalMotion.animate(
-              .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true),
-              reduceMotion: reduceMotion
-            ) {
-              position = 1
-            }
+            startIndeterminateAnimation(reduceMotion: reduceMotion)
           }
           .onDisappear {
             position = 0
           }
           .onChange(of: reduceMotion) { _, reduceMotion in
-            position = 0
-            guard !reduceMotion else { return }
-            TerminalMotion.animate(
-              .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true),
-              reduceMotion: reduceMotion
-            ) {
-              position = 1
-            }
+            restartIndeterminateAnimation(reduceMotion: reduceMotion)
           }
         }
       }
@@ -89,5 +74,22 @@ struct GhosttySurfaceProgressBar: View {
     .accessibilityAddTraits(.updatesFrequently)
     .accessibilityLabel(accessibilityLabel)
     .accessibilityValue(accessibilityValue)
+  }
+
+  private var indeterminateAnimation: Animation {
+    .easeInOut(duration: 1.2)
+      .repeatForever(autoreverses: true)
+  }
+
+  private func startIndeterminateAnimation(reduceMotion: Bool) {
+    guard !reduceMotion else { return }
+    TerminalMotion.animate(indeterminateAnimation, reduceMotion: reduceMotion) {
+      position = 1
+    }
+  }
+
+  private func restartIndeterminateAnimation(reduceMotion: Bool) {
+    position = 0
+    startIndeterminateAnimation(reduceMotion: reduceMotion)
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressOverlay.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceProgressOverlay.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct GhosttySurfaceProgressOverlay: View {
   @Bindable var state: GhosttySurfaceState
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
   init(state: GhosttySurfaceState) {
     self._state = Bindable(state)
   }
@@ -17,7 +19,7 @@ struct GhosttySurfaceProgressOverlay: View {
         progressState: progressState,
         progressValue: state.progressValue
       )
-      .transition(.opacity)
+      .terminalTransition(.opacity, reduceMotion: reduceMotion)
     }
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -5,6 +5,7 @@ struct GhosttySurfaceSearchOverlay: View {
   let surfaceView: GhosttySurfaceView
   @Bindable var state: GhosttySurfaceState
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var searchText: String
   @State private var corner: GhosttySearchCorner = .topRight
   @State private var dragOffset: CGSize = .zero
@@ -104,7 +105,7 @@ struct GhosttySurfaceSearchOverlay: View {
                 y: centerPos.y + value.translation.height
               )
               let newCorner = closestCorner(to: newCenter, in: geo.size)
-              withAnimation(.easeOut(duration: 0.2)) {
+              TerminalMotion.animate(.easeOut(duration: 0.2), reduceMotion: reduceMotion) {
                 corner = newCorner
                 dragOffset = .zero
               }

--- a/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
@@ -87,7 +87,7 @@ struct TerminalSidebarChromeView: View {
   let terminal: TerminalHostState
 
   @Environment(CommandHoldObserver.self) private var commandHoldObserver
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
   @StateObject private var dragSession = TerminalSidebarDragSession()
@@ -187,7 +187,7 @@ struct TerminalSidebarChromeView: View {
             ) {
               TerminalMotion.animate(
                 .easeInOut(duration: 0.3),
-                reduceMotion: accessibilityReduceMotion
+                reduceMotion: reduceMotion
               ) {
                 proxy.scrollTo(terminalSidebarScrollTopID, anchor: .top)
               }
@@ -338,7 +338,7 @@ struct TerminalSidebarChromeView: View {
       .terminalAnimation(
         .spring(response: 0.3, dampingFraction: 0.8),
         value: dragSession.insertionIndex[zoneID],
-        reduceMotion: accessibilityReduceMotion
+        reduceMotion: reduceMotion
       )
     }
   }
@@ -355,7 +355,7 @@ struct TerminalSidebarChromeView: View {
   }
 
   private func newTab() {
-    TerminalMotion.animate(.easeInOut(duration: 0.2), reduceMotion: accessibilityReduceMotion) {
+    TerminalMotion.animate(.easeInOut(duration: 0.2), reduceMotion: reduceMotion) {
       _ = store.send(
         .newTabButtonTapped(inheritingFromSurfaceID: terminal.selectedSurfaceView?.id)
       )
@@ -365,7 +365,7 @@ struct TerminalSidebarChromeView: View {
   private func scrollToBottom(
     using proxy: ScrollViewProxy
   ) {
-    TerminalMotion.animate(.easeInOut(duration: 0.3), reduceMotion: accessibilityReduceMotion) {
+    TerminalMotion.animate(.easeInOut(duration: 0.3), reduceMotion: reduceMotion) {
       if let selectedTabID = terminal.selectedTabID {
         proxy.scrollTo(selectedTabID, anchor: .bottom)
       } else {
@@ -463,7 +463,7 @@ struct TerminalSidebarTabSummaryView: View {
   let showsShortcutHint: Bool
   let isRowHovering: Bool
 
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   static func statusAccessory(
     isPinned: Bool,
@@ -592,10 +592,10 @@ struct TerminalSidebarTabSummaryView: View {
           .lineLimit(2)
           .truncationMode(.tail)
           .multilineTextAlignment(.leading)
-          .terminalContentTransition(.opacity, reduceMotion: accessibilityReduceMotion)
+          .terminalContentTransition(.opacity, reduceMotion: reduceMotion)
           .terminalTransition(
             .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading)),
-            reduceMotion: accessibilityReduceMotion
+            reduceMotion: reduceMotion
           )
 
       case .notification(let notificationPreviewMarkdown):
@@ -607,10 +607,10 @@ struct TerminalSidebarTabSummaryView: View {
           .lineLimit(2)
           .truncationMode(.tail)
           .multilineTextAlignment(.leading)
-          .terminalContentTransition(.opacity, reduceMotion: accessibilityReduceMotion)
+          .terminalContentTransition(.opacity, reduceMotion: reduceMotion)
           .terminalTransition(
             .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading)),
-            reduceMotion: accessibilityReduceMotion
+            reduceMotion: reduceMotion
           )
 
       case nil:
@@ -720,7 +720,7 @@ private struct TerminalSidebarProgressIndicatorView: View {
   let isSelected: Bool
   let palette: TerminalPalette
 
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var rotation = Angle.zero
 
   var body: some View {
@@ -742,7 +742,7 @@ private struct TerminalSidebarProgressIndicatorView: View {
               .terminalAnimation(
                 .easeInOut(duration: 0.2),
                 value: fraction,
-                reduceMotion: accessibilityReduceMotion
+                reduceMotion: reduceMotion
               )
           } else {
             Circle()
@@ -768,41 +768,35 @@ private struct TerminalSidebarProgressIndicatorView: View {
       }
     }
     .onAppear {
-      guard progress.indicatorStyle == .ring, progress.fraction == nil, !accessibilityReduceMotion else {
-        return
-      }
-      TerminalMotion.animate(
-        .linear(duration: 0.9).repeatForever(autoreverses: false),
-        reduceMotion: accessibilityReduceMotion
-      ) {
-        rotation = .degrees(360)
-      }
+      startRotation(reduceMotion: reduceMotion)
     }
-    .onChange(of: progress.fraction == nil) { _, isIndeterminate in
-      rotation = .zero
-      guard progress.indicatorStyle == .ring, isIndeterminate, !accessibilityReduceMotion else {
-        return
-      }
-      TerminalMotion.animate(
-        .linear(duration: 0.9).repeatForever(autoreverses: false),
-        reduceMotion: accessibilityReduceMotion
-      ) {
-        rotation = .degrees(360)
-      }
+    .onChange(of: progress.fraction == nil) { _, _ in
+      restartRotation(reduceMotion: reduceMotion)
     }
-    .onChange(of: accessibilityReduceMotion) { _, reduceMotion in
-      rotation = .zero
-      guard progress.indicatorStyle == .ring, progress.fraction == nil, !reduceMotion else {
-        return
-      }
-      TerminalMotion.animate(
-        .linear(duration: 0.9).repeatForever(autoreverses: false),
-        reduceMotion: reduceMotion
-      ) {
-        rotation = .degrees(360)
-      }
+    .onChange(of: reduceMotion) { _, reduceMotion in
+      restartRotation(reduceMotion: reduceMotion)
     }
     .accessibilityHidden(true)
+  }
+
+  private var isIndeterminateRing: Bool {
+    progress.indicatorStyle == .ring && progress.fraction == nil
+  }
+
+  private var rotationAnimation: Animation {
+    .linear(duration: 0.9).repeatForever(autoreverses: false)
+  }
+
+  private func startRotation(reduceMotion: Bool) {
+    guard isIndeterminateRing, !reduceMotion else { return }
+    TerminalMotion.animate(rotationAnimation, reduceMotion: reduceMotion) {
+      rotation = .degrees(360)
+    }
+  }
+
+  private func restartRotation(reduceMotion: Bool) {
+    rotation = .zero
+    startRotation(reduceMotion: reduceMotion)
   }
 
   private var trackColor: Color {
@@ -898,7 +892,7 @@ struct TerminalSidebarTabRow: View {
     return items
   }
 
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isHovering = false
   @State private var isCloseHovering = false
 
@@ -984,7 +978,7 @@ struct TerminalSidebarTabRow: View {
     .terminalAnimation(
       .spring(response: 0.24, dampingFraction: 0.88),
       value: animatedPresentation,
-      reduceMotion: accessibilityReduceMotion
+      reduceMotion: reduceMotion
     )
     .background {
       SidebarPopoverPresenter(
@@ -1109,7 +1103,7 @@ struct TerminalSidebarTabRow: View {
   }
 
   private func close() {
-    TerminalMotion.animate(.easeInOut(duration: 0.15), reduceMotion: accessibilityReduceMotion) {
+    TerminalMotion.animate(.easeInOut(duration: 0.15), reduceMotion: reduceMotion) {
       _ = store.send(.closeTabRequested(tab.id))
     }
   }
@@ -1120,7 +1114,7 @@ private struct TerminalSidebarAgentActivityView: View {
   let isSelected: Bool
   let palette: TerminalPalette
 
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isAnimating = false
 
   var body: some View {
@@ -1145,30 +1139,13 @@ private struct TerminalSidebarAgentActivityView: View {
         }
       }
       .onAppear {
-        guard !accessibilityReduceMotion else { return }
-        if let animation {
-          TerminalMotion.animate(animation, reduceMotion: accessibilityReduceMotion) {
-            isAnimating = true
-          }
-        }
+        startActivityAnimation(reduceMotion: reduceMotion)
       }
       .onChange(of: activity) { _, _ in
-        isAnimating = false
-        guard !accessibilityReduceMotion else { return }
-        if let animation {
-          TerminalMotion.animate(animation, reduceMotion: accessibilityReduceMotion) {
-            isAnimating = true
-          }
-        }
+        restartActivityAnimation(reduceMotion: reduceMotion)
       }
-      .onChange(of: accessibilityReduceMotion) { _, reduceMotion in
-        isAnimating = false
-        guard !reduceMotion else { return }
-        if let animation {
-          TerminalMotion.animate(animation, reduceMotion: reduceMotion) {
-            isAnimating = true
-          }
-        }
+      .onChange(of: reduceMotion) { _, reduceMotion in
+        restartActivityAnimation(reduceMotion: reduceMotion)
       }
   }
 
@@ -1185,9 +1162,21 @@ private struct TerminalSidebarAgentActivityView: View {
     }
   }
 
+  private func startActivityAnimation(reduceMotion: Bool) {
+    guard !reduceMotion, let animation else { return }
+    TerminalMotion.animate(animation, reduceMotion: reduceMotion) {
+      isAnimating = true
+    }
+  }
+
+  private func restartActivityAnimation(reduceMotion: Bool) {
+    isAnimating = false
+    startActivityAnimation(reduceMotion: reduceMotion)
+  }
+
   private var runningIndicator: some View {
     Group {
-      if accessibilityReduceMotion {
+      if reduceMotion {
         runningDots(phase: 0)
       } else {
         TimelineView(.periodic(from: .now, by: 0.24)) { context in
@@ -1212,25 +1201,11 @@ private struct TerminalSidebarAgentActivityView: View {
   }
 
   private var scale: CGFloat {
-    switch activity.phase {
-    case .needsInput:
-      return isAnimating ? 1.14 : 1
-    case .running:
-      return 1
-    case .idle:
-      return 1
-    }
+    activity.phase == .needsInput && isAnimating ? 1.14 : 1
   }
 
   private var verticalOffset: CGFloat {
-    switch activity.phase {
-    case .needsInput:
-      return isAnimating ? -1 : 0
-    case .running:
-      return 0
-    case .idle:
-      return 0
-    }
+    activity.phase == .needsInput && isAnimating ? -1 : 0
   }
 
   private func runningPhase(at date: Date) -> Int {
@@ -1247,7 +1222,7 @@ private struct TerminalSidebarAgentActivityView: View {
           .opacity(runningDotOpacity(for: index, phase: phase))
       }
     }
-    .terminalAnimation(.smooth(duration: 0.16), value: phase, reduceMotion: accessibilityReduceMotion)
+    .terminalAnimation(.smooth(duration: 0.16), value: phase, reduceMotion: reduceMotion)
     .accessibilityHidden(true)
   }
 
@@ -1374,7 +1349,7 @@ private struct TerminalSidebarSpaceBar: View {
   let palette: TerminalPalette
   let terminal: TerminalHostState
 
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var availableWidth: CGFloat = 0
   @State private var hoveredSpaceID: TerminalSpaceID?
   @State private var showPreview = false
@@ -1429,7 +1404,7 @@ private struct TerminalSidebarSpaceBar: View {
                 .id(hoveredSpace.id)
                 .terminalTransition(
                   .opacity.combined(with: .scale(scale: 0.96)),
-                  reduceMotion: accessibilityReduceMotion
+                  reduceMotion: reduceMotion
                 )
                 .offset(y: -20)
             }
@@ -1469,7 +1444,7 @@ private struct TerminalSidebarSpaceBar: View {
                     if hoveredSpaceID == space.id && isHoveringList {
                       TerminalMotion.animate(
                         .easeInOut(duration: 0.2),
-                        reduceMotion: accessibilityReduceMotion
+                        reduceMotion: reduceMotion
                       ) {
                         showPreview = true
                       }
@@ -1483,7 +1458,7 @@ private struct TerminalSidebarSpaceBar: View {
             onSelect: {
               TerminalMotion.animate(
                 .easeOut(duration: 0.1),
-                reduceMotion: accessibilityReduceMotion
+                reduceMotion: reduceMotion
               ) {
                 _ = store.send(.selectSpaceButtonTapped(space.id))
               }
@@ -1584,7 +1559,7 @@ private struct TerminalSidebarScrollIndicatorButton: View {
 }
 
 private struct TerminalSidebarRectButtonStyle: ButtonStyle {
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @State private var isHovering = false
@@ -1601,12 +1576,12 @@ private struct TerminalSidebarRectButtonStyle: ButtonStyle {
       .terminalAnimation(
         .easeInOut(duration: 0.1),
         value: configuration.isPressed,
-        reduceMotion: accessibilityReduceMotion
+        reduceMotion: reduceMotion
       )
       .terminalAnimation(
         .easeInOut(duration: 0.15),
         value: isHovering,
-        reduceMotion: accessibilityReduceMotion
+        reduceMotion: reduceMotion
       )
       .onHover { isHovering = $0 }
   }
@@ -1620,7 +1595,7 @@ private struct TerminalSidebarRectButtonStyle: ButtonStyle {
 }
 
 private struct TerminalSidebarIconButtonStyle: ButtonStyle {
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.controlSize) private var controlSize
@@ -1639,12 +1614,12 @@ private struct TerminalSidebarIconButtonStyle: ButtonStyle {
     .terminalAnimation(
       .easeInOut(duration: 0.1),
       value: configuration.isPressed,
-      reduceMotion: accessibilityReduceMotion
+      reduceMotion: reduceMotion
     )
     .terminalAnimation(
       .easeInOut(duration: 0.15),
       value: isHovering,
-      reduceMotion: accessibilityReduceMotion
+      reduceMotion: reduceMotion
     )
     .onHover { isHovering = $0 }
   }
@@ -1669,7 +1644,7 @@ private struct TerminalSidebarIconButtonStyle: ButtonStyle {
 }
 
 private struct TerminalSidebarSpaceButtonStyle: ButtonStyle {
-  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.controlSize) private var controlSize
@@ -1689,12 +1664,12 @@ private struct TerminalSidebarSpaceButtonStyle: ButtonStyle {
     .terminalAnimation(
       .easeInOut(duration: 0.1),
       value: configuration.isPressed,
-      reduceMotion: accessibilityReduceMotion
+      reduceMotion: reduceMotion
     )
     .terminalAnimation(
       .easeInOut(duration: 0.15),
       value: isHovering,
-      reduceMotion: accessibilityReduceMotion
+      reduceMotion: reduceMotion
     )
     .onHover { isHovering = $0 }
   }

--- a/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/Sidebar/TerminalSidebarChromeView.swift
@@ -87,6 +87,7 @@ struct TerminalSidebarChromeView: View {
   let terminal: TerminalHostState
 
   @Environment(CommandHoldObserver.self) private var commandHoldObserver
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
   @StateObject private var dragSession = TerminalSidebarDragSession()
@@ -184,7 +185,10 @@ struct TerminalSidebarChromeView: View {
               symbol: "chevron.up",
               palette: palette
             ) {
-              withAnimation(.easeInOut(duration: 0.3)) {
+              TerminalMotion.animate(
+                .easeInOut(duration: 0.3),
+                reduceMotion: accessibilityReduceMotion
+              ) {
                 proxy.scrollTo(terminalSidebarScrollTopID, anchor: .top)
               }
             }
@@ -331,9 +335,10 @@ struct TerminalSidebarChromeView: View {
       }
       .opacity(dragSession.draggedItem?.tabID == tab.id ? 0 : 1)
       .offset(y: dragSession.reorderOffset(for: zoneID, tabID: tab.id))
-      .animation(
+      .terminalAnimation(
         .spring(response: 0.3, dampingFraction: 0.8),
-        value: dragSession.insertionIndex[zoneID]
+        value: dragSession.insertionIndex[zoneID],
+        reduceMotion: accessibilityReduceMotion
       )
     }
   }
@@ -350,7 +355,7 @@ struct TerminalSidebarChromeView: View {
   }
 
   private func newTab() {
-    withAnimation(.easeInOut(duration: 0.2)) {
+    TerminalMotion.animate(.easeInOut(duration: 0.2), reduceMotion: accessibilityReduceMotion) {
       _ = store.send(
         .newTabButtonTapped(inheritingFromSurfaceID: terminal.selectedSurfaceView?.id)
       )
@@ -360,7 +365,7 @@ struct TerminalSidebarChromeView: View {
   private func scrollToBottom(
     using proxy: ScrollViewProxy
   ) {
-    withAnimation(.easeInOut(duration: 0.3)) {
+    TerminalMotion.animate(.easeInOut(duration: 0.3), reduceMotion: accessibilityReduceMotion) {
       if let selectedTabID = terminal.selectedTabID {
         proxy.scrollTo(selectedTabID, anchor: .bottom)
       } else {
@@ -457,6 +462,8 @@ struct TerminalSidebarTabSummaryView: View {
   let shortcutHint: String?
   let showsShortcutHint: Bool
   let isRowHovering: Bool
+
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
 
   static func statusAccessory(
     isPinned: Bool,
@@ -585,9 +592,10 @@ struct TerminalSidebarTabSummaryView: View {
           .lineLimit(2)
           .truncationMode(.tail)
           .multilineTextAlignment(.leading)
-          .contentTransition(.opacity)
-          .transition(
-            .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading))
+          .terminalContentTransition(.opacity, reduceMotion: accessibilityReduceMotion)
+          .terminalTransition(
+            .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading)),
+            reduceMotion: accessibilityReduceMotion
           )
 
       case .notification(let notificationPreviewMarkdown):
@@ -599,9 +607,10 @@ struct TerminalSidebarTabSummaryView: View {
           .lineLimit(2)
           .truncationMode(.tail)
           .multilineTextAlignment(.leading)
-          .contentTransition(.opacity)
-          .transition(
-            .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading))
+          .terminalContentTransition(.opacity, reduceMotion: accessibilityReduceMotion)
+          .terminalTransition(
+            .opacity.combined(with: .scale(scale: 0.98, anchor: .topLeading)),
+            reduceMotion: accessibilityReduceMotion
           )
 
       case nil:
@@ -730,7 +739,11 @@ private struct TerminalSidebarProgressIndicatorView: View {
                 style: StrokeStyle(lineWidth: 2, lineCap: .round)
               )
               .rotationEffect(.degrees(-90))
-              .animation(.easeInOut(duration: 0.2), value: fraction)
+              .terminalAnimation(
+                .easeInOut(duration: 0.2),
+                value: fraction,
+                reduceMotion: accessibilityReduceMotion
+              )
           } else {
             Circle()
               .trim(from: 0.14, to: 0.64)
@@ -758,7 +771,10 @@ private struct TerminalSidebarProgressIndicatorView: View {
       guard progress.indicatorStyle == .ring, progress.fraction == nil, !accessibilityReduceMotion else {
         return
       }
-      withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+      TerminalMotion.animate(
+        .linear(duration: 0.9).repeatForever(autoreverses: false),
+        reduceMotion: accessibilityReduceMotion
+      ) {
         rotation = .degrees(360)
       }
     }
@@ -767,7 +783,10 @@ private struct TerminalSidebarProgressIndicatorView: View {
       guard progress.indicatorStyle == .ring, isIndeterminate, !accessibilityReduceMotion else {
         return
       }
-      withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+      TerminalMotion.animate(
+        .linear(duration: 0.9).repeatForever(autoreverses: false),
+        reduceMotion: accessibilityReduceMotion
+      ) {
         rotation = .degrees(360)
       }
     }
@@ -776,7 +795,10 @@ private struct TerminalSidebarProgressIndicatorView: View {
       guard progress.indicatorStyle == .ring, progress.fraction == nil, !reduceMotion else {
         return
       }
-      withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+      TerminalMotion.animate(
+        .linear(duration: 0.9).repeatForever(autoreverses: false),
+        reduceMotion: reduceMotion
+      ) {
         rotation = .degrees(360)
       }
     }
@@ -959,7 +981,11 @@ struct TerminalSidebarTabRow: View {
       )
     }
     .buttonStyle(.plain)
-    .animation(rowAnimation, value: animatedPresentation)
+    .terminalAnimation(
+      .spring(response: 0.24, dampingFraction: 0.88),
+      value: animatedPresentation,
+      reduceMotion: accessibilityReduceMotion
+    )
     .background {
       SidebarPopoverPresenter(
         isPresented: showsPopover,
@@ -1066,10 +1092,6 @@ struct TerminalSidebarTabRow: View {
     )
   }
 
-  private var rowAnimation: Animation? {
-    accessibilityReduceMotion ? nil : .spring(response: 0.24, dampingFraction: 0.88)
-  }
-
   private var popoverMarkdown: String? {
     TerminalSidebarTabSummaryView.popoverMarkdown(
       codexHoverMarkdown: agentPresentation.hoverMarkdown,
@@ -1087,7 +1109,7 @@ struct TerminalSidebarTabRow: View {
   }
 
   private func close() {
-    withAnimation(.easeInOut(duration: 0.15)) {
+    TerminalMotion.animate(.easeInOut(duration: 0.15), reduceMotion: accessibilityReduceMotion) {
       _ = store.send(.closeTabRequested(tab.id))
     }
   }
@@ -1125,7 +1147,7 @@ private struct TerminalSidebarAgentActivityView: View {
       .onAppear {
         guard !accessibilityReduceMotion else { return }
         if let animation {
-          withAnimation(animation) {
+          TerminalMotion.animate(animation, reduceMotion: accessibilityReduceMotion) {
             isAnimating = true
           }
         }
@@ -1134,7 +1156,7 @@ private struct TerminalSidebarAgentActivityView: View {
         isAnimating = false
         guard !accessibilityReduceMotion else { return }
         if let animation {
-          withAnimation(animation) {
+          TerminalMotion.animate(animation, reduceMotion: accessibilityReduceMotion) {
             isAnimating = true
           }
         }
@@ -1143,7 +1165,7 @@ private struct TerminalSidebarAgentActivityView: View {
         isAnimating = false
         guard !reduceMotion else { return }
         if let animation {
-          withAnimation(animation) {
+          TerminalMotion.animate(animation, reduceMotion: reduceMotion) {
             isAnimating = true
           }
         }
@@ -1225,7 +1247,7 @@ private struct TerminalSidebarAgentActivityView: View {
           .opacity(runningDotOpacity(for: index, phase: phase))
       }
     }
-    .animation(.smooth(duration: 0.16), value: phase)
+    .terminalAnimation(.smooth(duration: 0.16), value: phase, reduceMotion: accessibilityReduceMotion)
     .accessibilityHidden(true)
   }
 
@@ -1352,6 +1374,7 @@ private struct TerminalSidebarSpaceBar: View {
   let palette: TerminalPalette
   let terminal: TerminalHostState
 
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
   @State private var availableWidth: CGFloat = 0
   @State private var hoveredSpaceID: TerminalSpaceID?
   @State private var showPreview = false
@@ -1404,7 +1427,10 @@ private struct TerminalSidebarSpaceBar: View {
                 .foregroundStyle(palette.primaryText.opacity(0.7))
                 .lineLimit(1)
                 .id(hoveredSpace.id)
-                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                .terminalTransition(
+                  .opacity.combined(with: .scale(scale: 0.96)),
+                  reduceMotion: accessibilityReduceMotion
+                )
                 .offset(y: -20)
             }
           }
@@ -1441,7 +1467,10 @@ private struct TerminalSidebarSpaceBar: View {
                 if !showPreview {
                   DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     if hoveredSpaceID == space.id && isHoveringList {
-                      withAnimation(.easeInOut(duration: 0.2)) {
+                      TerminalMotion.animate(
+                        .easeInOut(duration: 0.2),
+                        reduceMotion: accessibilityReduceMotion
+                      ) {
                         showPreview = true
                       }
                     }
@@ -1452,7 +1481,10 @@ private struct TerminalSidebarSpaceBar: View {
               }
             },
             onSelect: {
-              withAnimation(.easeOut(duration: 0.1)) {
+              TerminalMotion.animate(
+                .easeOut(duration: 0.1),
+                reduceMotion: accessibilityReduceMotion
+              ) {
                 _ = store.send(.selectSpaceButtonTapped(space.id))
               }
             },
@@ -1552,6 +1584,7 @@ private struct TerminalSidebarScrollIndicatorButton: View {
 }
 
 private struct TerminalSidebarRectButtonStyle: ButtonStyle {
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @State private var isHovering = false
@@ -1565,8 +1598,16 @@ private struct TerminalSidebarRectButtonStyle: ButtonStyle {
       .contentShape(.rect)
       .opacity(isEnabled ? 1 : 0.3)
       .scaleEffect(configuration.isPressed && isEnabled ? 0.95 : 1)
-      .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
-      .animation(.easeInOut(duration: 0.15), value: isHovering)
+      .terminalAnimation(
+        .easeInOut(duration: 0.1),
+        value: configuration.isPressed,
+        reduceMotion: accessibilityReduceMotion
+      )
+      .terminalAnimation(
+        .easeInOut(duration: 0.15),
+        value: isHovering,
+        reduceMotion: accessibilityReduceMotion
+      )
       .onHover { isHovering = $0 }
   }
 
@@ -1579,6 +1620,7 @@ private struct TerminalSidebarRectButtonStyle: ButtonStyle {
 }
 
 private struct TerminalSidebarIconButtonStyle: ButtonStyle {
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.controlSize) private var controlSize
@@ -1594,8 +1636,16 @@ private struct TerminalSidebarIconButtonStyle: ButtonStyle {
     .opacity(isEnabled ? 1 : 0.3)
     .contentShape(.rect)
     .scaleEffect(configuration.isPressed && isEnabled ? 0.95 : 1)
-    .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
-    .animation(.easeInOut(duration: 0.15), value: isHovering)
+    .terminalAnimation(
+      .easeInOut(duration: 0.1),
+      value: configuration.isPressed,
+      reduceMotion: accessibilityReduceMotion
+    )
+    .terminalAnimation(
+      .easeInOut(duration: 0.15),
+      value: isHovering,
+      reduceMotion: accessibilityReduceMotion
+    )
     .onHover { isHovering = $0 }
   }
 
@@ -1619,6 +1669,7 @@ private struct TerminalSidebarIconButtonStyle: ButtonStyle {
 }
 
 private struct TerminalSidebarSpaceButtonStyle: ButtonStyle {
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.controlSize) private var controlSize
@@ -1635,8 +1686,16 @@ private struct TerminalSidebarSpaceButtonStyle: ButtonStyle {
     .opacity(isEnabled ? 1 : 0.3)
     .contentShape(.rect)
     .scaleEffect(configuration.isPressed && isEnabled ? 0.95 : 1)
-    .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
-    .animation(.easeInOut(duration: 0.15), value: isHovering)
+    .terminalAnimation(
+      .easeInOut(duration: 0.1),
+      value: configuration.isPressed,
+      reduceMotion: accessibilityReduceMotion
+    )
+    .terminalAnimation(
+      .easeInOut(duration: 0.15),
+      value: isHovering,
+      reduceMotion: accessibilityReduceMotion
+    )
     .onHover { isHovering = $0 }
   }
 

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalChromeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalChromeView.swift
@@ -127,6 +127,7 @@ enum WindowTrafficLightMetrics {
 }
 
 struct WindowTrafficLights: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isHovering = false
 
   var body: some View {
@@ -158,7 +159,7 @@ struct WindowTrafficLights: View {
     .padding(.leading, WindowTrafficLightMetrics.leadingPadding)
     .padding(.top, WindowTrafficLightMetrics.topPadding)
     .onHover { hovering in
-      withAnimation(.easeInOut(duration: 0.1)) {
+      TerminalMotion.animate(.easeInOut(duration: 0.1), reduceMotion: reduceMotion) {
         isHovering = hovering
       }
     }

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
@@ -10,6 +10,8 @@ struct TerminalDetailView: View {
   let terminal: TerminalHostState
   let selectedTabID: TerminalTabID
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
   var body: some View {
     VStack(spacing: 0) {
       TerminalDetailTopBar(
@@ -23,7 +25,10 @@ struct TerminalDetailView: View {
           _ = store.send(.bindingMenuItemSelected(.equalizeSplits))
         },
         toggleSidebar: {
-          withAnimation(.spring(response: 0.2, dampingFraction: 1.0)) {
+          TerminalMotion.animate(
+            .spring(response: 0.2, dampingFraction: 1.0),
+            reduceMotion: reduceMotion
+          ) {
             _ = store.send(.toggleSidebarButtonTapped)
           }
         },

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalMotion.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalMotion.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+enum TerminalMotion {
+  static func allowsMotion(reduceMotion: Bool) -> Bool {
+    !reduceMotion
+  }
+
+  static func animation(_ animation: Animation, reduceMotion: Bool) -> Animation? {
+    allowsMotion(reduceMotion: reduceMotion) ? animation : nil
+  }
+
+  static func transition(_ transition: AnyTransition, reduceMotion: Bool) -> AnyTransition {
+    allowsMotion(reduceMotion: reduceMotion) ? transition : .identity
+  }
+
+  static func contentTransition(
+    _ transition: ContentTransition,
+    reduceMotion: Bool
+  ) -> ContentTransition {
+    allowsMotion(reduceMotion: reduceMotion) ? transition : .identity
+  }
+
+  static func animate(
+    _ animation: Animation,
+    reduceMotion: Bool,
+    _ body: () -> Void
+  ) {
+    guard allowsMotion(reduceMotion: reduceMotion) else {
+      var transaction = Transaction(animation: nil)
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        body()
+      }
+      return
+    }
+    withAnimation(animation) {
+      body()
+    }
+  }
+}
+
+extension View {
+  func terminalAnimation<Value: Equatable>(
+    _ animation: Animation,
+    value: Value,
+    reduceMotion: Bool
+  ) -> some View {
+    self.animation(
+      TerminalMotion.animation(animation, reduceMotion: reduceMotion),
+      value: value
+    )
+  }
+
+  func terminalTransition(
+    _ transition: AnyTransition,
+    reduceMotion: Bool
+  ) -> some View {
+    self.transition(TerminalMotion.transition(transition, reduceMotion: reduceMotion))
+  }
+
+  func terminalContentTransition(
+    _ transition: ContentTransition,
+    reduceMotion: Bool
+  ) -> some View {
+    self.contentTransition(
+      TerminalMotion.contentTransition(transition, reduceMotion: reduceMotion)
+    )
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSidebarViews.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSidebarViews.swift
@@ -121,6 +121,7 @@ struct FloatingSidebarOverlay: View {
   let minFraction: CGFloat
   let maxFraction: CGFloat
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var dragFraction: CGFloat?
 
   var body: some View {
@@ -144,7 +145,7 @@ struct FloatingSidebarOverlay: View {
           width: floatingWidth
         )
         .frame(width: floatingWidth)
-        .transition(.move(edge: .leading))
+        .terminalTransition(.move(edge: .leading), reduceMotion: reduceMotion)
         .zIndex(1)
       }
 

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -535,7 +535,7 @@ struct TerminalSplitTreeView: View {
       for segment in TerminalNotificationPulsePattern.segments {
         DispatchQueue.main.asyncAfter(deadline: .now() + segment.delay) {
           guard notificationPulseAnimationGeneration == generation else { return }
-          withAnimation(.easeInOut(duration: segment.duration)) {
+          TerminalMotion.animate(.easeInOut(duration: segment.duration), reduceMotion: reduceMotion) {
             notificationPulseOpacity = segment.targetOpacity
           }
         }

--- a/apps/mac/supatermTests/TerminalMotionTests.swift
+++ b/apps/mac/supatermTests/TerminalMotionTests.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import Testing
+
+@testable import supaterm
+
+struct TerminalMotionTests {
+  @Test
+  func motionAllowanceFollowsReduceMotionSetting() {
+    #expect(TerminalMotion.allowsMotion(reduceMotion: false))
+    #expect(!TerminalMotion.allowsMotion(reduceMotion: true))
+  }
+
+  @Test
+  func animationIsRemovedWhenReduceMotionIsEnabled() {
+    #expect(TerminalMotion.animation(.easeInOut(duration: 0.2), reduceMotion: false) != nil)
+    #expect(TerminalMotion.animation(.easeInOut(duration: 0.2), reduceMotion: true) == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Gates terminal animations and transitions on the system Reduce Motion setting.
- Replaces decorative progress and activity motion with static presentation when Reduce Motion is enabled.
- Keeps current motion behavior unchanged when Reduce Motion is disabled.

## Rationale

Reduce Motion should remove non-essential UI movement without changing terminal state behavior. Centralizing terminal motion policy keeps the setting derived from SwiftUI environment instead of storing or passing another app-level value.

## Diagram (if applicable)

N/A

## QA

- Enable Reduce Motion in macOS Accessibility settings.
- Open Supaterm and toggle the sidebar, command palette, tabs, spaces, progress indicators, and activity badges; changes should appear immediately without animated transitions.
- Disable Reduce Motion and repeat those interactions; existing motion should return.
