### PR TITLE
[feature] Add programmable bottom bar

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettings.swift
@@ -42,9 +42,9 @@ public struct SupatermBottomBarSettings: Codable, Equatable, Hashable, Sendable 
 
   public static let `default` = Self(
     enabled: true,
-    left: [.directory, .gitBranch, .gitStatus],
+    left: [.agent],
     center: [],
-    right: [.agent, .exitStatus]
+    right: []
   )
 
   public var modules: [SupatermBottomBarModule] {

--- a/apps/mac/SupatermCLIShared/SupatermSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettings.swift
@@ -1,8 +1,76 @@
 import Foundation
 
+public enum SupatermBottomBarModule: String, Codable, CaseIterable, Equatable, Hashable, Sendable {
+  case directory
+  case gitBranch = "git_branch"
+  case gitStatus = "git_status"
+  case paneTitle = "pane_title"
+  case agent
+  case exitStatus = "exit_status"
+  case commandDuration = "command_duration"
+  case time
+}
+
+public struct SupatermBottomBarSettings: Codable, Equatable, Hashable, Sendable {
+  public var enabled: Bool
+  public var left: [SupatermBottomBarModule]
+  public var center: [SupatermBottomBarModule]
+  public var right: [SupatermBottomBarModule]
+
+  public init(
+    enabled: Bool,
+    left: [SupatermBottomBarModule],
+    center: [SupatermBottomBarModule],
+    right: [SupatermBottomBarModule]
+  ) {
+    self.enabled = enabled
+    self.left = left
+    self.center = center
+    self.right = right
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let defaults = Self.default
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      enabled: try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? defaults.enabled,
+      left: try container.decodeIfPresent([SupatermBottomBarModule].self, forKey: .left) ?? defaults.left,
+      center: try container.decodeIfPresent([SupatermBottomBarModule].self, forKey: .center) ?? defaults.center,
+      right: try container.decodeIfPresent([SupatermBottomBarModule].self, forKey: .right) ?? defaults.right
+    )
+  }
+
+  public static let `default` = Self(
+    enabled: true,
+    left: [.directory, .gitBranch, .gitStatus],
+    center: [],
+    right: [.agent, .exitStatus]
+  )
+
+  public var modules: [SupatermBottomBarModule] {
+    left + center + right
+  }
+
+  public var containsGitModule: Bool {
+    modules.contains(.gitBranch) || modules.contains(.gitStatus)
+  }
+
+  public var containsTimeModule: Bool {
+    modules.contains(.time)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case enabled
+    case left
+    case center
+    case right
+  }
+}
+
 public struct SupatermSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var analyticsEnabled: Bool
+  public var bottomBarSettings: SupatermBottomBarSettings
   public var crashReportsEnabled: Bool
   public var glowingPaneRingEnabled: Bool
   public var newTabPosition: NewTabPosition
@@ -13,6 +81,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public init(
     appearanceMode: AppearanceMode,
     analyticsEnabled: Bool,
+    bottomBarSettings: SupatermBottomBarSettings = .default,
     crashReportsEnabled: Bool,
     glowingPaneRingEnabled: Bool = true,
     newTabPosition: NewTabPosition = .end,
@@ -22,6 +91,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   ) {
     self.appearanceMode = appearanceMode
     self.analyticsEnabled = analyticsEnabled
+    self.bottomBarSettings = bottomBarSettings
     self.crashReportsEnabled = crashReportsEnabled
     self.glowingPaneRingEnabled = glowingPaneRingEnabled
     self.newTabPosition = newTabPosition
@@ -33,6 +103,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public static let `default` = Self(
     appearanceMode: .dark,
     analyticsEnabled: true,
+    bottomBarSettings: .default,
     crashReportsEnabled: true,
     glowingPaneRingEnabled: true,
     newTabPosition: .end,
@@ -55,6 +126,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     let defaults = Self.default
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let appearance = try container.decodeIfPresent(PersistedAppearance.self, forKey: .appearance)
+    let bottomBar = try container.decodeIfPresent(SupatermBottomBarSettings.self, forKey: .bottomBar)
     let privacy = try container.decodeIfPresent(PersistedPrivacy.self, forKey: .privacy)
     let notifications = try container.decodeIfPresent(PersistedNotifications.self, forKey: .notifications)
     let terminal = try container.decodeIfPresent(PersistedTerminal.self, forKey: .terminal)
@@ -63,6 +135,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
     self.init(
       appearanceMode: appearance?.mode ?? defaults.appearanceMode,
       analyticsEnabled: privacy?.analyticsEnabled ?? defaults.analyticsEnabled,
+      bottomBarSettings: bottomBar ?? defaults.bottomBarSettings,
       crashReportsEnabled: privacy?.crashReportsEnabled ?? defaults.crashReportsEnabled,
       glowingPaneRingEnabled: notifications?.glowingPaneRing ?? defaults.glowingPaneRingEnabled,
       newTabPosition: terminal?.newTabPosition ?? defaults.newTabPosition,
@@ -75,6 +148,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(PersistedAppearance(mode: appearanceMode), forKey: .appearance)
+    try container.encode(bottomBarSettings, forKey: .bottomBar)
     try container.encode(
       PersistedPrivacy(
         analyticsEnabled: analyticsEnabled,
@@ -103,6 +177,7 @@ public struct SupatermSettings: Codable, Equatable, Sendable {
 extension SupatermSettings {
   enum CodingKeys: String, CodingKey {
     case appearance
+    case bottomBar = "bottom_bar"
     case privacy
     case notifications
     case terminal
@@ -148,8 +223,8 @@ extension SupatermSettings {
   }
 }
 
-private extension SupatermSettings {
-  static func configDirectoryURL(homeDirectoryPath: String) -> URL {
+extension SupatermSettings {
+  fileprivate static func configDirectoryURL(homeDirectoryPath: String) -> URL {
     URL(fileURLWithPath: homeDirectoryPath, isDirectory: true)
       .appendingPathComponent(".config", isDirectory: true)
       .appendingPathComponent("supaterm", isDirectory: true)

--- a/apps/mac/SupatermCLIShared/SupatermSettingsFile.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSettingsFile.swift
@@ -172,12 +172,19 @@ private struct SupatermSettingsUnknownKeyAudit: Decodable {
     warnings.append(
       contentsOf: Self.unknownKeys(
         in: container,
-        allowedKeys: ["appearance", "notifications", "privacy", "terminal", "updates"],
+        allowedKeys: ["appearance", "bottom_bar", "notifications", "privacy", "terminal", "updates"],
         prefix: nil
       )
     )
 
     warnings.append(contentsOf: try Self.unknownNestedKeys(in: container, section: "appearance", allowedKeys: ["mode"]))
+    warnings.append(
+      contentsOf: try Self.unknownNestedKeys(
+        in: container,
+        section: "bottom_bar",
+        allowedKeys: ["center", "enabled", "left", "right"]
+      )
+    )
     warnings.append(
       contentsOf: try Self.unknownNestedKeys(
         in: container,

--- a/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
+++ b/apps/mac/supaterm/Features/Settings/SettingsFeature.swift
@@ -60,6 +60,7 @@ public struct SettingsFeature {
   public struct State: Equatable {
     var appearanceMode = SupatermSettings.default.appearanceMode
     var analyticsEnabled = SupatermSettings.default.analyticsEnabled
+    var bottomBarSettings = SupatermSettings.default.bottomBarSettings
     @Presents var alert: AlertState<Alert>?
     var claudeIntegration = SettingsAgentIntegrationState(
       settingsPath: SupatermAgentKind.claude.settingsPathDescription
@@ -269,6 +270,7 @@ public struct SettingsFeature {
   ) {
     state.appearanceMode = supatermSettings.appearanceMode
     state.analyticsEnabled = supatermSettings.analyticsEnabled
+    state.bottomBarSettings = supatermSettings.bottomBarSettings
     state.crashReportsEnabled = supatermSettings.crashReportsEnabled
     state.glowingPaneRingEnabled = supatermSettings.glowingPaneRingEnabled
     state.newTabPosition = supatermSettings.newTabPosition
@@ -287,6 +289,7 @@ public struct SettingsFeature {
     let supatermSettings = SupatermSettings(
       appearanceMode: state.appearanceMode,
       analyticsEnabled: state.analyticsEnabled,
+      bottomBarSettings: state.bottomBarSettings,
       crashReportsEnabled: state.crashReportsEnabled,
       glowingPaneRingEnabled: state.glowingPaneRingEnabled,
       newTabPosition: state.newTabPosition,

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarContext.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarContext.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+nonisolated enum TerminalBarAgentPhase: String, Equatable, Sendable {
+  case needsInput
+  case running
+  case idle
+}
+
+nonisolated enum TerminalBarAgentTone: String, Equatable, Sendable {
+  case attention
+  case active
+  case muted
+}
+
+nonisolated struct TerminalBarAgentContext: Equatable, Sendable {
+  let kindTitle: String
+  let phase: TerminalBarAgentPhase
+  let detail: String?
+  let tone: TerminalBarAgentTone
+
+  init(activity: TerminalHostState.AgentActivity) {
+    kindTitle = activity.kind.notificationTitle
+    phase =
+      switch activity.phase {
+      case .needsInput:
+        .needsInput
+      case .running:
+        .running
+      case .idle:
+        .idle
+      }
+    detail = activity.detail
+    tone =
+      switch phase {
+      case .needsInput:
+        .attention
+      case .running:
+        .active
+      case .idle:
+        .muted
+      }
+  }
+
+  var refreshID: String {
+    "\(kindTitle):\(phase):\(detail ?? ""):\(tone)"
+  }
+}
+
+nonisolated struct TerminalBarContextRefreshID: Equatable, Sendable {
+  let selectedSpaceID: String?
+  let selectedTabID: String
+  let focusedPaneID: String
+  let paneTitle: String
+  let workingDirectoryPath: String?
+  let agentID: String?
+  let commandExitCode: Int?
+  let commandDuration: UInt64?
+}
+
+nonisolated struct TerminalBarContext: Equatable, Sendable {
+  let selectedSpaceID: String?
+  let selectedTabID: String
+  let focusedPaneID: String
+  let paneTitle: String
+  let workingDirectoryPath: String?
+  let agentActivity: TerminalBarAgentContext?
+  let commandExitCode: Int?
+  let commandDuration: UInt64?
+
+  var refreshID: TerminalBarContextRefreshID {
+    TerminalBarContextRefreshID(
+      selectedSpaceID: selectedSpaceID,
+      selectedTabID: selectedTabID,
+      focusedPaneID: focusedPaneID,
+      paneTitle: paneTitle,
+      workingDirectoryPath: workingDirectoryPath,
+      agentID: agentActivity?.refreshID,
+      commandExitCode: commandExitCode,
+      commandDuration: commandDuration
+    )
+  }
+}
+
+extension TerminalHostState {
+  var selectedBarContext: TerminalBarContext? {
+    guard
+      let selectedTabID,
+      let focusedSurfaceID = currentFocusedSurfaceID()
+    else {
+      return nil
+    }
+
+    let focusedPaneID = focusedSurfaceID.uuidString
+    let state = selectedSurfaceState
+    let agentActivity = tabAgentPresentation(for: selectedTabID).detailActivity
+
+    return TerminalBarContext(
+      selectedSpaceID: selectedSpaceID?.rawValue.uuidString,
+      selectedTabID: selectedTabID.rawValue.uuidString,
+      focusedPaneID: focusedPaneID,
+      paneTitle: selectedPaneDisplayTitle,
+      workingDirectoryPath: state?.pwd,
+      agentActivity: agentActivity.map(TerminalBarAgentContext.init),
+      commandExitCode: state?.commandExitCode,
+      commandDuration: state?.commandDuration
+    )
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarGitState.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarGitState.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+nonisolated struct TerminalBarGitState: Equatable, Sendable {
+  let branch: String
+  let stagedCount: Int
+  let unstagedCount: Int
+  let untrackedCount: Int
+  let conflictCount: Int
+  let aheadCount: Int
+  let behindCount: Int
+
+  var hasStatus: Bool {
+    stagedCount > 0
+      || unstagedCount > 0
+      || untrackedCount > 0
+      || conflictCount > 0
+      || aheadCount > 0
+      || behindCount > 0
+  }
+}
+
+nonisolated enum TerminalBarGitStatusParser {
+  static func parse(_ output: String) -> TerminalBarGitState? {
+    let lines =
+      output
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .map(String.init)
+
+    guard let branchLine = lines.first, branchLine.hasPrefix("## ") else {
+      return nil
+    }
+
+    guard let branch = parseBranch(from: branchLine) else {
+      return nil
+    }
+
+    let counts = lines.dropFirst().reduce(into: TerminalBarGitCounts()) { counts, line in
+      counts.record(line)
+    }
+
+    return TerminalBarGitState(
+      branch: branch,
+      stagedCount: counts.stagedCount,
+      unstagedCount: counts.unstagedCount,
+      untrackedCount: counts.untrackedCount,
+      conflictCount: counts.conflictCount,
+      aheadCount: aheadCount(from: branchLine),
+      behindCount: behindCount(from: branchLine)
+    )
+  }
+
+  private static func parseBranch(from line: String) -> String? {
+    var value = String(line.dropFirst(3))
+    if value.hasPrefix("No commits yet on ") {
+      value.removeFirst("No commits yet on ".count)
+    }
+    if let range = value.range(of: "...") {
+      value = String(value[..<range.lowerBound])
+    }
+    if let range = value.range(of: " [") {
+      value = String(value[..<range.lowerBound])
+    }
+    if value == "HEAD (no branch)" || value == "(no branch)" {
+      return "HEAD"
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private static func aheadCount(from line: String) -> Int {
+    count(named: "ahead", in: line)
+  }
+
+  private static func behindCount(from line: String) -> Int {
+    count(named: "behind", in: line)
+  }
+
+  private static func count(named name: String, in line: String) -> Int {
+    let pattern = "\(name) "
+    guard let range = line.range(of: pattern) else { return 0 }
+    let suffix = line[range.upperBound...]
+    let digits = suffix.prefix { $0.isNumber }
+    return Int(digits) ?? 0
+  }
+}
+
+private nonisolated struct TerminalBarGitCounts {
+  var stagedCount = 0
+  var unstagedCount = 0
+  var untrackedCount = 0
+  var conflictCount = 0
+
+  mutating func record(_ line: String) {
+    guard line.count >= 2 else { return }
+    let status = String(line.prefix(2))
+    if status == "!!" {
+      return
+    }
+    if status == "??" {
+      untrackedCount += 1
+      return
+    }
+    if Self.conflictStatuses.contains(status) {
+      conflictCount += 1
+      return
+    }
+    let x = line[line.startIndex]
+    let y = line[line.index(after: line.startIndex)]
+    if x != " " {
+      stagedCount += 1
+    }
+    if y != " " {
+      unstagedCount += 1
+    }
+  }
+
+  private static let conflictStatuses: Set<String> = ["DD", "AU", "UD", "UA", "DU", "AA", "UU"]
+}
+
+nonisolated struct TerminalBarGitClient: Sendable {
+  private let run: @Sendable (String) async throws -> String
+  private let sleep: @Sendable (Duration) async throws -> Void
+  private let timeout: Duration
+
+  init(
+    timeout: Duration = .seconds(1),
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+      try await ContinuousClock().sleep(for: duration)
+    },
+    run: @escaping @Sendable (String) async throws -> String
+  ) {
+    self.run = run
+    self.sleep = sleep
+    self.timeout = timeout
+  }
+
+  static let live = Self { cwd in
+    try await TerminalBarGitProcess.output(cwd: cwd)
+  }
+
+  func status(cwd: String) async -> TerminalBarGitState? {
+    do {
+      return try await withThrowingTaskGroup(of: TerminalBarGitState?.self) { group in
+        group.addTask {
+          TerminalBarGitStatusParser.parse(try await run(cwd))
+        }
+        group.addTask {
+          try await sleep(timeout)
+          throw TerminalBarGitClientError.timeout
+        }
+        let state = try await group.next() ?? nil
+        group.cancelAll()
+        return state
+      }
+    } catch {
+      return nil
+    }
+  }
+}
+
+private nonisolated enum TerminalBarGitClientError: Error {
+  case timeout
+  case missingOutput
+  case failed(Int32)
+}
+
+private nonisolated enum TerminalBarGitProcess {
+  static func output(cwd: String) async throws -> String {
+    let box = TerminalBarGitProcessBox()
+    return try await withTaskCancellationHandler {
+      try await Task.detached(priority: .utility) {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", cwd, "status", "--porcelain=v1", "--branch"]
+        process.standardOutput = output
+        process.standardError = Pipe()
+        box.set(process)
+        defer { box.clear(process) }
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+          throw TerminalBarGitClientError.failed(process.terminationStatus)
+        }
+        guard let string = String(data: data, encoding: .utf8) else {
+          throw TerminalBarGitClientError.missingOutput
+        }
+        return string
+      }
+      .value
+    } onCancel: {
+      box.terminate()
+    }
+  }
+}
+
+private nonisolated final class TerminalBarGitProcessBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var process: Process?
+
+  func set(_ process: Process) {
+    lock.lock()
+    self.process = process
+    lock.unlock()
+  }
+
+  func clear(_ process: Process) {
+    lock.lock()
+    if self.process === process {
+      self.process = nil
+    }
+    lock.unlock()
+  }
+
+  func terminate() {
+    lock.lock()
+    let process = process
+    lock.unlock()
+    process?.terminate()
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarPresentation.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarPresentation.swift
@@ -1,0 +1,185 @@
+import Foundation
+import SupatermCLIShared
+
+nonisolated enum TerminalBarPresenter {
+  static func presentation(
+    settings: SupatermBottomBarSettings,
+    context: TerminalBarContext?,
+    gitState: TerminalBarGitState?,
+    now: Date
+  ) -> TerminalBarPresentation {
+    guard settings.enabled, let context else {
+      return .empty
+    }
+    return TerminalBarPresentation(
+      left: segments(for: settings.left, context: context, gitState: gitState, now: now),
+      center: segments(for: settings.center, context: context, gitState: gitState, now: now),
+      right: segments(for: settings.right, context: context, gitState: gitState, now: now)
+    )
+  }
+
+  private static func segments(
+    for modules: [SupatermBottomBarModule],
+    context: TerminalBarContext,
+    gitState: TerminalBarGitState?,
+    now: Date
+  ) -> [TerminalBarSegment] {
+    modules.compactMap { module in
+      segment(for: module, context: context, gitState: gitState, now: now)
+    }
+  }
+
+  private static func segment(
+    for module: SupatermBottomBarModule,
+    context: TerminalBarContext,
+    gitState: TerminalBarGitState?,
+    now: Date
+  ) -> TerminalBarSegment? {
+    switch module {
+    case .directory:
+      return directorySegment(context)
+    case .gitBranch:
+      return gitBranchSegment(gitState)
+    case .gitStatus:
+      return gitStatusSegment(gitState)
+    case .paneTitle:
+      return paneTitleSegment(context)
+    case .agent:
+      return agentSegment(context)
+    case .exitStatus:
+      return exitStatusSegment(context)
+    case .commandDuration:
+      return commandDurationSegment(context)
+    case .time:
+      return timeSegment(now)
+    }
+  }
+
+  private static func directorySegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
+    guard let path = normalized(context.workingDirectoryPath) else {
+      return nil
+    }
+    let url = URL(fileURLWithPath: path, isDirectory: true)
+    let name = normalized(url.lastPathComponent) ?? path
+    return TerminalBarSegment(
+      id: "directory",
+      text: name,
+      tooltip: path,
+      tone: .normal
+    )
+  }
+
+  private static func gitBranchSegment(_ state: TerminalBarGitState?) -> TerminalBarSegment? {
+    guard let state else { return nil }
+    return TerminalBarSegment(
+      id: "git_branch",
+      text: state.branch,
+      tone: .accent
+    )
+  }
+
+  private static func gitStatusSegment(_ state: TerminalBarGitState?) -> TerminalBarSegment? {
+    guard let state, state.hasStatus else { return nil }
+    var parts: [String] = []
+    if state.conflictCount > 0 {
+      parts.append("!\(state.conflictCount)")
+    }
+    if state.stagedCount > 0 {
+      parts.append("+\(state.stagedCount)")
+    }
+    if state.unstagedCount > 0 {
+      parts.append("~\(state.unstagedCount)")
+    }
+    if state.untrackedCount > 0 {
+      parts.append("?\(state.untrackedCount)")
+    }
+    if state.aheadCount > 0 {
+      parts.append("ahead \(state.aheadCount)")
+    }
+    if state.behindCount > 0 {
+      parts.append("behind \(state.behindCount)")
+    }
+    return TerminalBarSegment(
+      id: "git_status",
+      text: parts.joined(separator: " "),
+      tone: state.conflictCount > 0 ? .error : .warning
+    )
+  }
+
+  private static func paneTitleSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
+    guard let title = normalized(context.paneTitle) else { return nil }
+    return TerminalBarSegment(id: "pane_title", text: title, tone: .muted)
+  }
+
+  private static func agentSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
+    guard let activity = context.agentActivity else { return nil }
+    let phase =
+      switch activity.phase {
+      case .needsInput:
+        "needs input"
+      case .running:
+        "running"
+      case .idle:
+        "idle"
+      }
+    var text = "\(activity.kindTitle) \(phase)"
+    if let detail = normalized(activity.detail) {
+      text += ": \(detail)"
+    }
+    let tone: TerminalBarSegmentTone =
+      switch activity.tone {
+      case .attention:
+        .warning
+      case .active:
+        .accent
+      case .muted:
+        .muted
+      }
+    return TerminalBarSegment(id: "agent", text: text, tone: tone)
+  }
+
+  private static func exitStatusSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
+    guard let code = context.commandExitCode, code != 0 else { return nil }
+    return TerminalBarSegment(
+      id: "exit_status",
+      text: "exit \(code)",
+      tone: .error
+    )
+  }
+
+  private static func commandDurationSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
+    guard let duration = context.commandDuration else { return nil }
+    return TerminalBarSegment(
+      id: "command_duration",
+      text: formattedDuration(duration),
+      tone: .muted
+    )
+  }
+
+  private static func timeSegment(_ now: Date) -> TerminalBarSegment {
+    let components = Calendar.current.dateComponents([.hour, .minute], from: now)
+    let hour = components.hour ?? 0
+    let minute = components.minute ?? 0
+    return TerminalBarSegment(
+      id: "time",
+      text: String(format: "%02d:%02d", hour, minute),
+      tone: .muted
+    )
+  }
+
+  private static func formattedDuration(_ milliseconds: UInt64) -> String {
+    if milliseconds < 1_000 {
+      return "\(milliseconds)ms"
+    }
+    let seconds = Double(milliseconds) / 1_000
+    if seconds < 10 {
+      return String(format: "%.1fs", seconds)
+    }
+    return "\(Int(seconds.rounded()))s"
+  }
+
+  private static func normalized(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarPresentation.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarPresentation.swift
@@ -113,7 +113,7 @@ nonisolated enum TerminalBarPresenter {
 
   private static func agentSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {
     guard let activity = context.agentActivity else { return nil }
-    let phase =
+    let status =
       switch activity.phase {
       case .needsInput:
         "needs input"
@@ -122,10 +122,11 @@ nonisolated enum TerminalBarPresenter {
       case .idle:
         "idle"
       }
-    var text = "\(activity.kindTitle) \(phase)"
+    var text = status
     if let detail = normalized(activity.detail) {
       text += ": \(detail)"
     }
+    let tooltip = "\(activity.kindTitle) \(text)"
     let tone: TerminalBarSegmentTone =
       switch activity.tone {
       case .attention:
@@ -135,7 +136,7 @@ nonisolated enum TerminalBarPresenter {
       case .muted:
         .muted
       }
-    return TerminalBarSegment(id: "agent", text: text, tone: tone)
+    return TerminalBarSegment(id: "agent", symbol: "hammer", text: text, tooltip: tooltip, tone: tone)
   }
 
   private static func exitStatusSegment(_ context: TerminalBarContext) -> TerminalBarSegment? {

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarRuntime.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarRuntime.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Observation
+import SupatermCLIShared
+
+nonisolated enum TerminalBarRefreshReason: Equatable, Sendable {
+  case focus
+  case workingDirectory
+  case title
+  case commandFinished
+  case agent
+  case settings
+  case time
+}
+
+@MainActor
+@Observable
+final class TerminalBarRuntime {
+  private(set) var presentation = TerminalBarPresentation.empty
+
+  @ObservationIgnored private let gitClient: TerminalBarGitClient
+  @ObservationIgnored private let sleep: @Sendable (Duration) async throws -> Void
+  @ObservationIgnored private let debounceDuration: Duration
+  @ObservationIgnored private let successFreshness: TimeInterval
+  @ObservationIgnored private let missFreshness: TimeInterval
+  @ObservationIgnored private let cacheLimit: Int
+  @ObservationIgnored private var cache: [String: GitCacheEntry] = [:]
+  @ObservationIgnored private var cacheOrder: [String] = []
+  @ObservationIgnored private var gitTask: Task<Void, Never>?
+  @ObservationIgnored private var activeGitRequestID: UUID?
+
+  init(
+    gitClient: TerminalBarGitClient = .live,
+    debounceDuration: Duration = .milliseconds(200),
+    successFreshness: TimeInterval = 2,
+    missFreshness: TimeInterval = 5,
+    cacheLimit: Int = 32,
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+      try await ContinuousClock().sleep(for: duration)
+    }
+  ) {
+    self.gitClient = gitClient
+    self.debounceDuration = debounceDuration
+    self.successFreshness = successFreshness
+    self.missFreshness = missFreshness
+    self.cacheLimit = cacheLimit
+    self.sleep = sleep
+  }
+
+  deinit {
+    gitTask?.cancel()
+  }
+
+  func refresh(
+    settings: SupatermBottomBarSettings,
+    context: TerminalBarContext?,
+    now: Date = Date(),
+    reason: TerminalBarRefreshReason = .settings
+  ) {
+    guard settings.enabled, let context else {
+      cancelGitProbe()
+      presentation = .empty
+      return
+    }
+
+    guard settings.containsGitModule, let cwd = context.workingDirectoryPath else {
+      cancelGitProbe()
+      presentation = TerminalBarPresenter.presentation(settings: settings, context: context, gitState: nil, now: now)
+      return
+    }
+
+    let cacheKey = normalizedPath(cwd)
+    let cachedEntry = cache[cacheKey]
+    let freshEntry = freshCacheEntry(cachedEntry, now: now)
+
+    if reason != .commandFinished, let freshEntry {
+      touch(cacheKey)
+      presentation = TerminalBarPresenter.presentation(
+        settings: settings,
+        context: context,
+        gitState: freshEntry.state,
+        now: now
+      )
+      return
+    }
+
+    presentation = TerminalBarPresenter.presentation(
+      settings: settings,
+      context: context,
+      gitState: cachedEntry?.state,
+      now: now
+    )
+
+    guard reason != .time else {
+      return
+    }
+
+    scheduleGitProbe(
+      cacheKey: cacheKey,
+      cwd: cwd,
+      settings: settings,
+      context: context,
+      now: now
+    )
+  }
+
+  private func scheduleGitProbe(
+    cacheKey: String,
+    cwd: String,
+    settings: SupatermBottomBarSettings,
+    context: TerminalBarContext,
+    now: Date
+  ) {
+    gitTask?.cancel()
+    let requestID = UUID()
+    activeGitRequestID = requestID
+    let request = GitProbeRequest(
+      cacheKey: cacheKey,
+      requestID: requestID,
+      settings: settings,
+      context: context,
+      now: now
+    )
+    let gitClient = gitClient
+    let sleep = sleep
+    let debounceDuration = debounceDuration
+    gitTask = Task { [weak self] in
+      do {
+        try await sleep(debounceDuration)
+        let state = await gitClient.status(cwd: cwd)
+        guard !Task.isCancelled else { return }
+        await self?.publishGitState(state, request: request)
+      } catch {}
+    }
+  }
+
+  private func publishGitState(
+    _ state: TerminalBarGitState?,
+    request: GitProbeRequest
+  ) {
+    guard activeGitRequestID == request.requestID else { return }
+    store(state, for: request.cacheKey, at: Date())
+    presentation = TerminalBarPresenter.presentation(
+      settings: request.settings,
+      context: request.context,
+      gitState: state,
+      now: request.now
+    )
+  }
+
+  private func cancelGitProbe() {
+    activeGitRequestID = nil
+    gitTask?.cancel()
+    gitTask = nil
+  }
+
+  private func freshCacheEntry(_ entry: GitCacheEntry?, now: Date) -> GitCacheEntry? {
+    guard let entry else { return nil }
+    let freshness = entry.state == nil ? missFreshness : successFreshness
+    guard now.timeIntervalSince(entry.date) <= freshness else {
+      return nil
+    }
+    return entry
+  }
+
+  private func store(_ state: TerminalBarGitState?, for key: String, at date: Date) {
+    cache[key] = GitCacheEntry(state: state, date: date)
+    touch(key)
+    while cacheOrder.count > cacheLimit {
+      let evicted = cacheOrder.removeFirst()
+      cache.removeValue(forKey: evicted)
+    }
+  }
+
+  private func touch(_ key: String) {
+    cacheOrder.removeAll { $0 == key }
+    cacheOrder.append(key)
+  }
+
+  private func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+  }
+}
+
+private nonisolated struct GitCacheEntry {
+  let state: TerminalBarGitState?
+  let date: Date
+}
+
+private nonisolated struct GitProbeRequest: Sendable {
+  let cacheKey: String
+  let requestID: UUID
+  let settings: SupatermBottomBarSettings
+  let context: TerminalBarContext
+  let now: Date
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarSegment.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarSegment.swift
@@ -11,17 +11,20 @@ nonisolated enum TerminalBarSegmentTone: Equatable, Sendable {
 
 nonisolated struct TerminalBarSegment: Equatable, Identifiable, Sendable {
   let id: String
+  let symbol: String?
   let text: String
   let tooltip: String?
   let tone: TerminalBarSegmentTone
 
   init(
     id: String,
+    symbol: String? = nil,
     text: String,
     tooltip: String? = nil,
     tone: TerminalBarSegmentTone = .normal
   ) {
     self.id = id
+    self.symbol = symbol
     self.text = text
     self.tooltip = tooltip
     self.tone = tone
@@ -34,4 +37,8 @@ nonisolated struct TerminalBarPresentation: Equatable, Sendable {
   var right: [TerminalBarSegment]
 
   static let empty = Self(left: [], center: [], right: [])
+
+  var isEmpty: Bool {
+    left.isEmpty && center.isEmpty && right.isEmpty
+  }
 }

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarSegment.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarSegment.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+nonisolated enum TerminalBarSegmentTone: Equatable, Sendable {
+  case normal
+  case muted
+  case success
+  case warning
+  case error
+  case accent
+}
+
+nonisolated struct TerminalBarSegment: Equatable, Identifiable, Sendable {
+  let id: String
+  let text: String
+  let tooltip: String?
+  let tone: TerminalBarSegmentTone
+
+  init(
+    id: String,
+    text: String,
+    tooltip: String? = nil,
+    tone: TerminalBarSegmentTone = .normal
+  ) {
+    self.id = id
+    self.text = text
+    self.tooltip = tooltip
+    self.tone = tone
+  }
+}
+
+nonisolated struct TerminalBarPresentation: Equatable, Sendable {
+  var left: [TerminalBarSegment]
+  var center: [TerminalBarSegment]
+  var right: [TerminalBarSegment]
+
+  static let empty = Self(left: [], center: [], right: [])
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarView.swift
@@ -1,0 +1,132 @@
+import Sharing
+import SupatermCLIShared
+import SwiftUI
+
+struct TerminalBarView: View {
+  @Shared(.supatermSettings) private var supatermSettings = .default
+  let palette: TerminalPalette
+  let terminal: TerminalHostState
+
+  @State private var previousRefreshKey: TerminalBarRefreshKey?
+  @State private var timeTick = 0
+
+  private var settings: SupatermBottomBarSettings {
+    supatermSettings.bottomBarSettings
+  }
+
+  private var refreshKey: TerminalBarRefreshKey {
+    TerminalBarRefreshKey(
+      settings: settings,
+      contextID: terminal.selectedBarContext?.refreshID,
+      timeTick: timeTick
+    )
+  }
+
+  var body: some View {
+    HStack(spacing: 8) {
+      segmentGroup(terminal.terminalBarRuntime.presentation.left)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      segmentGroup(terminal.terminalBarRuntime.presentation.center)
+        .frame(maxWidth: .infinity, alignment: .center)
+      segmentGroup(terminal.terminalBarRuntime.presentation.right)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+    .padding(.horizontal, 10)
+    .frame(maxWidth: .infinity, minHeight: 28, maxHeight: 28)
+    .background(terminal.terminalBackgroundColor)
+    .overlay(alignment: .top) {
+      Rectangle()
+        .fill(palette.detailStroke)
+        .frame(height: 1)
+    }
+    .task(id: refreshKey) {
+      let reason = refreshKey.reason(comparedTo: previousRefreshKey)
+      previousRefreshKey = refreshKey
+      terminal.terminalBarRuntime.refresh(
+        settings: settings,
+        context: terminal.selectedBarContext,
+        reason: reason
+      )
+    }
+    .task(id: settings.containsTimeModule) {
+      guard settings.containsTimeModule else { return }
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(60))
+        guard !Task.isCancelled else { return }
+        timeTick += 1
+      }
+    }
+  }
+
+  private func segmentGroup(_ segments: [TerminalBarSegment]) -> some View {
+    HStack(spacing: 10) {
+      ForEach(segments) { segment in
+        segmentView(segment)
+      }
+    }
+    .lineLimit(1)
+  }
+
+  private func segmentView(_ segment: TerminalBarSegment) -> some View {
+    Text(segment.text)
+      .font(.system(size: 12, weight: .medium))
+      .foregroundStyle(color(for: segment.tone))
+      .lineLimit(1)
+      .truncationMode(.middle)
+      .help(segment.tooltip ?? segment.text)
+  }
+
+  private func color(for tone: TerminalBarSegmentTone) -> Color {
+    switch tone {
+    case .normal:
+      palette.primaryText
+    case .muted:
+      palette.secondaryText
+    case .success:
+      palette.mint
+    case .warning:
+      palette.amber
+    case .error:
+      palette.coral
+    case .accent:
+      palette.sky
+    }
+  }
+}
+
+private struct TerminalBarRefreshKey: Equatable {
+  let settings: SupatermBottomBarSettings
+  let contextID: TerminalBarContextRefreshID?
+  let timeTick: Int
+
+  func reason(comparedTo previous: Self?) -> TerminalBarRefreshReason {
+    guard let previous else { return .settings }
+    if settings != previous.settings {
+      return .settings
+    }
+    guard let contextID, let previousContextID = previous.contextID else {
+      return .focus
+    }
+    if contextID.focusedPaneID != previousContextID.focusedPaneID {
+      return .focus
+    }
+    if contextID.workingDirectoryPath != previousContextID.workingDirectoryPath {
+      return .workingDirectory
+    }
+    if contextID.commandExitCode != previousContextID.commandExitCode
+      || contextID.commandDuration != previousContextID.commandDuration
+    {
+      return .commandFinished
+    }
+    if contextID.agentID != previousContextID.agentID {
+      return .agent
+    }
+    if contextID.paneTitle != previousContextID.paneTitle {
+      return .title
+    }
+    if timeTick != previous.timeTick {
+      return .time
+    }
+    return .settings
+  }
+}

--- a/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Bar/TerminalBarView.swift
@@ -22,23 +22,31 @@ struct TerminalBarView: View {
     )
   }
 
+  private var presentation: TerminalBarPresentation {
+    terminal.terminalBarRuntime.presentation
+  }
+
   var body: some View {
     HStack(spacing: 8) {
-      segmentGroup(terminal.terminalBarRuntime.presentation.left)
+      segmentGroup(presentation.left)
         .frame(maxWidth: .infinity, alignment: .leading)
-      segmentGroup(terminal.terminalBarRuntime.presentation.center)
+      segmentGroup(presentation.center)
         .frame(maxWidth: .infinity, alignment: .center)
-      segmentGroup(terminal.terminalBarRuntime.presentation.right)
+      segmentGroup(presentation.right)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
     .padding(.horizontal, 10)
-    .frame(maxWidth: .infinity, minHeight: 28, maxHeight: 28)
+    .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
     .background(terminal.terminalBackgroundColor)
     .overlay(alignment: .top) {
-      Rectangle()
-        .fill(palette.detailStroke)
-        .frame(height: 1)
+      if !presentation.isEmpty {
+        Rectangle()
+          .fill(palette.detailStroke)
+          .frame(height: 1)
+      }
     }
+    .clipped()
+    .opacity(presentation.isEmpty ? 0 : 1)
     .task(id: refreshKey) {
       let reason = refreshKey.reason(comparedTo: previousRefreshKey)
       previousRefreshKey = refreshKey
@@ -58,6 +66,10 @@ struct TerminalBarView: View {
     }
   }
 
+  private var height: CGFloat {
+    presentation.isEmpty ? 0 : 28
+  }
+
   private func segmentGroup(_ segments: [TerminalBarSegment]) -> some View {
     HStack(spacing: 10) {
       ForEach(segments) { segment in
@@ -68,12 +80,20 @@ struct TerminalBarView: View {
   }
 
   private func segmentView(_ segment: TerminalBarSegment) -> some View {
-    Text(segment.text)
-      .font(.system(size: 12, weight: .medium))
-      .foregroundStyle(color(for: segment.tone))
-      .lineLimit(1)
-      .truncationMode(.middle)
-      .help(segment.tooltip ?? segment.text)
+    HStack(spacing: 4) {
+      if let symbol = segment.symbol {
+        Image(systemName: symbol)
+          .font(.system(size: 11, weight: .semibold))
+          .accessibilityHidden(true)
+        Text("-")
+      }
+      Text(segment.text)
+        .truncationMode(.middle)
+    }
+    .font(.system(size: 12, weight: .medium))
+    .foregroundStyle(color(for: segment.tone))
+    .lineLimit(1)
+    .help(segment.tooltip ?? segment.text)
   }
 
   private func color(for tone: TerminalBarSegmentTone) -> Color {

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -227,6 +227,8 @@ final class TerminalHostState {
   var lastAppliedPinnedTabCatalog = TerminalPinnedTabCatalog.default
   @ObservationIgnored
   var onSessionChange: @MainActor () -> Void = {}
+  @ObservationIgnored
+  let terminalBarRuntime = TerminalBarRuntime()
   let spaceManager = TerminalSpaceManager()
 
   var pendingEvents: [TerminalClient.Event] = []
@@ -1172,6 +1174,17 @@ final class TerminalHostState {
     view.bridge.onProgressReport = { [weak self] _ in
       guard let self else { return }
       self.updateRunningState(for: tabID)
+    }
+    view.bridge.onCommandFinished = { [weak self] in
+      guard let self else { return }
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.terminalBarRuntime.refresh(
+          settings: self.supatermSettings.bottomBarSettings,
+          context: self.selectedBarContext,
+          reason: .commandFinished
+        )
+      }
     }
     configureBridgeCloseCallbacks(for: view)
     view.bridge.onDesktopNotification = { [weak self, weak view] title, body in

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalDetailView.swift
@@ -45,6 +45,12 @@ struct TerminalDetailView: View {
         terminal: terminal,
         selectedTabID: selectedTabID
       )
+      if supatermSettings.bottomBarSettings.enabled {
+        TerminalBarView(
+          palette: palette,
+          terminal: terminal
+        )
+      }
     }
     .compositingGroup()
     .terminalPaneChrome(palette: palette)

--- a/apps/mac/supatermTests/SettingsFeatureGeneralTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureGeneralTests.swift
@@ -68,6 +68,45 @@ struct SettingsFeatureGeneralTests {
   }
 
   @Test
+  func generalSettingsPreserveBottomBarPrefs() async throws {
+    let bottomBarSettings = SupatermBottomBarSettings(
+      enabled: true,
+      left: [.paneTitle],
+      center: [.time],
+      right: [.gitBranch, .gitStatus]
+    )
+
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      @Shared(.supatermSettings) var supatermSettings = .default
+      $supatermSettings.withLock {
+        $0 = SupatermSettings(
+          appearanceMode: .dark,
+          analyticsEnabled: true,
+          bottomBarSettings: bottomBarSettings,
+          crashReportsEnabled: true,
+          updateChannel: .stable
+        )
+      }
+
+      let store = TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+
+      await store.send(.settingsLoaded(supatermSettings)) {
+        $0.bottomBarSettings = bottomBarSettings
+      }
+
+      await store.send(.restoreTerminalLayoutEnabledChanged(false)) {
+        $0.restoreTerminalLayoutEnabled = false
+      }
+
+      #expect(supatermSettings.bottomBarSettings == bottomBarSettings)
+    }
+  }
+
+  @Test
   func newTabPositionSettingPersistsPrefs() async throws {
     await withDependencies {
       $0.defaultFileStorage = .inMemory

--- a/apps/mac/supatermTests/SettingsFeatureTests.swift
+++ b/apps/mac/supatermTests/SettingsFeatureTests.swift
@@ -35,6 +35,12 @@ struct SettingsFeatureTests {
         $0 = SupatermSettings(
           appearanceMode: .dark,
           analyticsEnabled: false,
+          bottomBarSettings: SupatermBottomBarSettings(
+            enabled: true,
+            left: [.paneTitle],
+            center: [.time],
+            right: [.gitBranch, .gitStatus]
+          ),
           crashReportsEnabled: true,
           glowingPaneRingEnabled: false,
           newTabPosition: .current,
@@ -57,6 +63,12 @@ struct SettingsFeatureTests {
       await store.receive(.settingsLoaded(supatermSettings), timeout: 0) {
         $0.appearanceMode = .dark
         $0.analyticsEnabled = false
+        $0.bottomBarSettings = SupatermBottomBarSettings(
+          enabled: true,
+          left: [.paneTitle],
+          center: [.time],
+          right: [.gitBranch, .gitStatus]
+        )
         $0.crashReportsEnabled = true
         $0.glowingPaneRingEnabled = false
         $0.about.updateChannel = .tip

--- a/apps/mac/supatermTests/SupatermSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsTests.swift
@@ -77,8 +77,8 @@ struct SupatermSettingsTests {
         [bottom_bar]
         center = []
         enabled = true
-        left = ["directory", "git_branch", "git_status"]
-        right = ["agent", "exit_status"]
+        left = ["agent"]
+        right = []
 
         [notifications]
         glowing_pane_ring = true

--- a/apps/mac/supatermTests/SupatermSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsTests.swift
@@ -29,6 +29,7 @@ struct SupatermSettingsTests {
 
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
+    #expect(prefs.bottomBarSettings == .default)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
@@ -53,6 +54,7 @@ struct SupatermSettingsTests {
 
     #expect(prefs.appearanceMode == .dark)
     #expect(prefs.analyticsEnabled)
+    #expect(prefs.bottomBarSettings == .default)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
@@ -71,6 +73,12 @@ struct SupatermSettingsTests {
         == """
         [appearance]
         mode = "dark"
+
+        [bottom_bar]
+        center = []
+        enabled = true
+        left = ["directory", "git_branch", "git_status"]
+        right = ["agent", "exit_status"]
 
         [notifications]
         glowing_pane_ring = true
@@ -96,6 +104,12 @@ struct SupatermSettingsTests {
       SupatermSettings(
         appearanceMode: .dark,
         analyticsEnabled: false,
+        bottomBarSettings: SupatermBottomBarSettings(
+          enabled: true,
+          left: [.paneTitle],
+          center: [.time],
+          right: [.gitBranch, .gitStatus, .commandDuration]
+        ),
         crashReportsEnabled: false,
         glowingPaneRingEnabled: false,
         newTabPosition: .current,
@@ -111,6 +125,12 @@ struct SupatermSettingsTests {
         == SupatermSettings(
           appearanceMode: .dark,
           analyticsEnabled: false,
+          bottomBarSettings: SupatermBottomBarSettings(
+            enabled: true,
+            left: [.paneTitle],
+            center: [.time],
+            right: [.gitBranch, .gitStatus, .commandDuration]
+          ),
           crashReportsEnabled: false,
           glowingPaneRingEnabled: false,
           newTabPosition: .current,
@@ -134,12 +154,48 @@ struct SupatermSettingsTests {
 
     #expect(prefs.appearanceMode == .light)
     #expect(prefs.analyticsEnabled)
+    #expect(prefs.bottomBarSettings == .default)
     #expect(prefs.crashReportsEnabled)
     #expect(prefs.glowingPaneRingEnabled)
     #expect(prefs.newTabPosition == .end)
     #expect(prefs.restoreTerminalLayoutEnabled)
     #expect(!prefs.systemNotificationsEnabled)
     #expect(prefs.updateChannel == .stable)
+  }
+
+  @Test
+  func prefsDecodeUsesDefaultsForMissingBottomBarKeys() throws {
+    let data = Data(
+      #"""
+      [bottom_bar]
+      enabled = false
+      right = ["time"]
+      """#.utf8
+    )
+
+    let prefs = try SupatermSettingsCodec.decode(data)
+
+    #expect(!prefs.bottomBarSettings.enabled)
+    #expect(prefs.bottomBarSettings.left == SupatermBottomBarSettings.default.left)
+    #expect(prefs.bottomBarSettings.center == SupatermBottomBarSettings.default.center)
+    #expect(prefs.bottomBarSettings.right == [.time])
+  }
+
+  @Test
+  func unknownBottomBarModuleFailsDecoding() throws {
+    let data = Data(
+      #"""
+      [bottom_bar]
+      enabled = true
+      left = ["directory", "nope"]
+      center = []
+      right = []
+      """#.utf8
+    )
+
+    #expect(throws: Error.self) {
+      _ = try SupatermSettingsCodec.decode(data)
+    }
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermSettingsValidationTests.swift
+++ b/apps/mac/supatermTests/SupatermSettingsValidationTests.swift
@@ -45,6 +45,13 @@ struct SupatermSettingsValidationTests {
       mode = "dark"
       extra = "ignored"
 
+      [bottom_bar]
+      enabled = true
+      left = ["directory"]
+      center = []
+      right = []
+      extra = "ignored"
+
       [privacy]
       analytics_enabled = true
       crash_reports_enabled = true
@@ -55,8 +62,38 @@ struct SupatermSettingsValidationTests {
     let result = SupatermSettingsValidator(homeDirectoryURL: homeDirectoryURL).validate()
 
     #expect(result.status == .valid)
-    #expect(result.warnings == ["Unknown config key `appearance.extra`."])
+    #expect(
+      result.warnings == [
+        "Unknown config key `appearance.extra`.",
+        "Unknown config key `bottom_bar.extra`.",
+      ]
+    )
     #expect(result.errors.isEmpty)
+  }
+
+  @Test
+  func unknownBottomBarModuleReturnsFailure() throws {
+    let homeDirectoryURL = try temporarySettingsValidationHomeDirectory()
+    let settingsURL = SupatermSettings.defaultURL(homeDirectoryPath: homeDirectoryURL.path)
+    try FileManager.default.createDirectory(
+      at: settingsURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try Data(
+      #"""
+      [bottom_bar]
+      enabled = true
+      left = ["directory", "missing"]
+      center = []
+      right = []
+      """#.utf8
+    )
+    .write(to: settingsURL)
+
+    let result = SupatermSettingsValidator(homeDirectoryURL: homeDirectoryURL).validate()
+
+    #expect(result.status == .invalid)
+    #expect(result.errors.count == 1)
   }
 
   @Test

--- a/apps/mac/supatermTests/TerminalBarGitStateTests.swift
+++ b/apps/mac/supatermTests/TerminalBarGitStateTests.swift
@@ -1,0 +1,48 @@
+import Testing
+
+@testable import supaterm
+
+struct TerminalBarGitStateTests {
+  @Test
+  func parsesBranchAndStatusCounts() throws {
+    let state = try #require(
+      TerminalBarGitStatusParser.parse(
+        """
+        ## main...origin/main [ahead 2, behind 1]
+        M  staged.swift
+         M unstaged.swift
+        ?? untracked.swift
+        UU conflicted.swift
+        """
+      )
+    )
+
+    #expect(state.branch == "main")
+    #expect(state.stagedCount == 1)
+    #expect(state.unstagedCount == 1)
+    #expect(state.untrackedCount == 1)
+    #expect(state.conflictCount == 1)
+    #expect(state.aheadCount == 2)
+    #expect(state.behindCount == 1)
+  }
+
+  @Test
+  func parsesInitialBranch() throws {
+    let state = try #require(
+      TerminalBarGitStatusParser.parse(
+        """
+        ## No commits yet on trunk
+        A  first.swift
+        """
+      )
+    )
+
+    #expect(state.branch == "trunk")
+    #expect(state.stagedCount == 1)
+  }
+
+  @Test
+  func ignoresNonRepositoryOutput() {
+    #expect(TerminalBarGitStatusParser.parse("fatal: not a git repository") == nil)
+  }
+}

--- a/apps/mac/supatermTests/TerminalBarPresentationTests.swift
+++ b/apps/mac/supatermTests/TerminalBarPresentationTests.swift
@@ -7,25 +7,28 @@ import Testing
 @MainActor
 struct TerminalBarPresentationTests {
   @Test
-  func defaultLayoutRendersWorkContext() {
+  func defaultLayoutRendersAgentStatus() {
     let presentation = TerminalBarPresenter.presentation(
       settings: .default,
       context: context(
         workingDirectoryPath: "/Users/khoi/code/supaterm",
         commandExitCode: 1,
-        agentActivity: .codex(.running)
+        agentActivity: .init(kind: .pi, phase: .needsInput, detail: "Approve command")
       ),
       gitState: gitState(stagedCount: 1, unstagedCount: 2),
       now: Date()
     )
 
-    #expect(presentation.left.map(\.id) == ["directory", "git_branch", "git_status"])
-    #expect(presentation.left.map(\.text) == ["supaterm", "main", "+1 ~2"])
-    #expect(presentation.right.map(\.id) == ["agent", "exit_status"])
+    #expect(presentation.left.map(\.id) == ["agent"])
+    #expect(presentation.left.map(\.symbol) == ["hammer"])
+    #expect(presentation.left.map(\.text) == ["needs input: Approve command"])
+    #expect(presentation.left.map(\.tooltip) == ["Pi needs input: Approve command"])
+    #expect(presentation.center.isEmpty)
+    #expect(presentation.right.isEmpty)
   }
 
   @Test
-  func missingCwdHidesDirectoryAndGitModules() {
+  func defaultLayoutHidesWhenAgentIsAbsent() {
     let presentation = TerminalBarPresenter.presentation(
       settings: .default,
       context: context(workingDirectoryPath: nil),
@@ -33,7 +36,29 @@ struct TerminalBarPresentationTests {
       now: Date()
     )
 
-    #expect(presentation.left.isEmpty)
+    #expect(presentation.isEmpty)
+  }
+
+  @Test
+  func configuredWorkModulesRender() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: SupatermBottomBarSettings(
+        enabled: true,
+        left: [.directory, .gitBranch, .gitStatus],
+        center: [],
+        right: [.exitStatus]
+      ),
+      context: context(
+        workingDirectoryPath: "/Users/khoi/code/supaterm",
+        commandExitCode: 1
+      ),
+      gitState: gitState(stagedCount: 1, unstagedCount: 2),
+      now: Date()
+    )
+
+    #expect(presentation.left.map(\.id) == ["directory", "git_branch", "git_status"])
+    #expect(presentation.left.map(\.text) == ["supaterm", "main", "+1 ~2"])
+    #expect(presentation.right.map(\.id) == ["exit_status"])
   }
 
   @Test

--- a/apps/mac/supatermTests/TerminalBarPresentationTests.swift
+++ b/apps/mac/supatermTests/TerminalBarPresentationTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import SupatermCLIShared
+import Testing
+
+@testable import supaterm
+
+@MainActor
+struct TerminalBarPresentationTests {
+  @Test
+  func defaultLayoutRendersWorkContext() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: .default,
+      context: context(
+        workingDirectoryPath: "/Users/khoi/code/supaterm",
+        commandExitCode: 1,
+        agentActivity: .codex(.running)
+      ),
+      gitState: gitState(stagedCount: 1, unstagedCount: 2),
+      now: Date()
+    )
+
+    #expect(presentation.left.map(\.id) == ["directory", "git_branch", "git_status"])
+    #expect(presentation.left.map(\.text) == ["supaterm", "main", "+1 ~2"])
+    #expect(presentation.right.map(\.id) == ["agent", "exit_status"])
+  }
+
+  @Test
+  func missingCwdHidesDirectoryAndGitModules() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: .default,
+      context: context(workingDirectoryPath: nil),
+      gitState: nil,
+      now: Date()
+    )
+
+    #expect(presentation.left.isEmpty)
+  }
+
+  @Test
+  func successfulExitStatusHides() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: SupatermBottomBarSettings(
+        enabled: true,
+        left: [],
+        center: [],
+        right: [.exitStatus]
+      ),
+      context: context(commandExitCode: 0),
+      gitState: nil,
+      now: Date()
+    )
+
+    #expect(presentation.right.isEmpty)
+  }
+
+  @Test
+  func failedExitStatusRenders() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: SupatermBottomBarSettings(
+        enabled: true,
+        left: [],
+        center: [],
+        right: [.exitStatus]
+      ),
+      context: context(commandExitCode: 127),
+      gitState: nil,
+      now: Date()
+    )
+
+    #expect(presentation.right.map(\.text) == ["exit 127"])
+  }
+
+  @Test
+  func configuredTimeAndCommandDurationRender() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: SupatermBottomBarSettings(
+        enabled: true,
+        left: [.commandDuration],
+        center: [.time],
+        right: []
+      ),
+      context: context(commandDuration: 1_550),
+      gitState: nil,
+      now: Date(timeIntervalSince1970: 1_800)
+    )
+
+    #expect(presentation.left.map(\.text) == ["1.6s"])
+    #expect(presentation.center.map(\.id) == ["time"])
+  }
+
+  @Test
+  func commandDurationIsAbsentFromDefault() {
+    let presentation = TerminalBarPresenter.presentation(
+      settings: .default,
+      context: context(commandDuration: 1_550),
+      gitState: gitState(),
+      now: Date()
+    )
+
+    #expect(!presentation.left.map(\.id).contains("command_duration"))
+    #expect(!presentation.right.map(\.id).contains("command_duration"))
+  }
+
+  private func context(
+    workingDirectoryPath: String? = "/Users/khoi/code/supaterm",
+    commandExitCode: Int? = nil,
+    commandDuration: UInt64? = nil,
+    agentActivity: TerminalHostState.AgentActivity? = nil
+  ) -> TerminalBarContext {
+    TerminalBarContext(
+      selectedSpaceID: UUID().uuidString,
+      selectedTabID: UUID().uuidString,
+      focusedPaneID: UUID().uuidString,
+      paneTitle: "zsh",
+      workingDirectoryPath: workingDirectoryPath,
+      agentActivity: agentActivity.map(TerminalBarAgentContext.init),
+      commandExitCode: commandExitCode,
+      commandDuration: commandDuration
+    )
+  }
+
+  private func gitState(
+    stagedCount: Int = 0,
+    unstagedCount: Int = 0,
+    untrackedCount: Int = 0,
+    conflictCount: Int = 0,
+    aheadCount: Int = 0,
+    behindCount: Int = 0
+  ) -> TerminalBarGitState {
+    TerminalBarGitState(
+      branch: "main",
+      stagedCount: stagedCount,
+      unstagedCount: unstagedCount,
+      untrackedCount: untrackedCount,
+      conflictCount: conflictCount,
+      aheadCount: aheadCount,
+      behindCount: behindCount
+    )
+  }
+}

--- a/apps/mac/supatermTests/TerminalBarRuntimeTests.swift
+++ b/apps/mac/supatermTests/TerminalBarRuntimeTests.swift
@@ -1,0 +1,171 @@
+import Clocks
+import Foundation
+import SupatermCLIShared
+import Testing
+
+@testable import supaterm
+
+@MainActor
+struct TerminalBarRuntimeTests {
+  @Test
+  func debounceCoalescesGitProbes() async {
+    let clock = TestClock()
+    let recorder = TerminalBarGitRecorder(outputs: ["## main\n"])
+    let runtime = makeRuntime(clock: clock, recorder: recorder)
+
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/one"), reason: .focus)
+    await clock.advance(by: .milliseconds(100))
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/two"), reason: .focus)
+    await clock.advance(by: .milliseconds(199))
+    await flushEffects()
+    #expect(await recorder.calls() == [])
+
+    await clock.advance(by: .milliseconds(1))
+    await flushEffects()
+
+    #expect(await recorder.calls() == ["/tmp/two"])
+  }
+
+  @Test
+  func freshCacheAvoidsGitProbe() async {
+    let clock = TestClock()
+    let recorder = TerminalBarGitRecorder(outputs: ["## main\n"])
+    let runtime = makeRuntime(clock: clock, recorder: recorder)
+    let now = Date()
+
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    await clock.advance(by: .milliseconds(200))
+    await flushEffects()
+
+    runtime.refresh(
+      settings: .default,
+      context: context(cwd: "/tmp/repo"),
+      now: now.addingTimeInterval(1),
+      reason: .focus
+    )
+
+    #expect(await recorder.calls() == ["/tmp/repo"])
+  }
+
+  @Test
+  func expiredCacheRefreshesGitProbe() async {
+    let clock = TestClock()
+    let recorder = TerminalBarGitRecorder(outputs: ["## main\n", "## trunk\n"])
+    let runtime = makeRuntime(clock: clock, recorder: recorder)
+    let now = Date()
+
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    await clock.advance(by: .milliseconds(200))
+    await flushEffects()
+
+    runtime.refresh(
+      settings: .default,
+      context: context(cwd: "/tmp/repo"),
+      now: now.addingTimeInterval(3),
+      reason: .focus
+    )
+    await clock.advance(by: .milliseconds(200))
+    await flushEffects()
+
+    #expect(await recorder.calls() == ["/tmp/repo", "/tmp/repo"])
+    #expect(runtime.presentation.left.map(\.text).contains("trunk"))
+  }
+
+  @Test
+  func commandFinishedBypassesFreshCache() async {
+    let clock = TestClock()
+    let recorder = TerminalBarGitRecorder(outputs: ["## main\n", "## trunk\n"])
+    let runtime = makeRuntime(clock: clock, recorder: recorder)
+    let now = Date()
+
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    await clock.advance(by: .milliseconds(200))
+    await flushEffects()
+
+    runtime.refresh(
+      settings: .default,
+      context: context(cwd: "/tmp/repo"),
+      now: now.addingTimeInterval(1),
+      reason: .commandFinished
+    )
+    await clock.advance(by: .milliseconds(200))
+    await flushEffects()
+
+    #expect(await recorder.calls() == ["/tmp/repo", "/tmp/repo"])
+    #expect(runtime.presentation.left.map(\.text).contains("trunk"))
+  }
+
+  @Test
+  func timeoutHidesGitModules() async {
+    let clock = TestClock()
+    let client = TerminalBarGitClient(
+      timeout: .seconds(1),
+      sleep: { duration in try await clock.sleep(for: duration) },
+      run: { _ in
+        try await clock.sleep(for: .seconds(10))
+        return "## main\n"
+      }
+    )
+    let runtime = TerminalBarRuntime(
+      gitClient: client,
+      debounceDuration: .milliseconds(200),
+      sleep: { duration in try await clock.sleep(for: duration) }
+    )
+
+    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), reason: .focus)
+    await clock.advance(by: .milliseconds(200))
+    await clock.advance(by: .seconds(1))
+    await flushEffects()
+
+    #expect(!runtime.presentation.left.map(\.id).contains("git_branch"))
+  }
+
+  private func makeRuntime(
+    clock: TestClock<Duration>,
+    recorder: TerminalBarGitRecorder
+  ) -> TerminalBarRuntime {
+    let client = TerminalBarGitClient(
+      sleep: { duration in try await clock.sleep(for: duration) },
+      run: { cwd in try await recorder.run(cwd) }
+    )
+    return TerminalBarRuntime(
+      gitClient: client,
+      debounceDuration: .milliseconds(200),
+      sleep: { duration in try await clock.sleep(for: duration) }
+    )
+  }
+
+  private func context(cwd: String) -> TerminalBarContext {
+    TerminalBarContext(
+      selectedSpaceID: UUID().uuidString,
+      selectedTabID: UUID().uuidString,
+      focusedPaneID: UUID().uuidString,
+      paneTitle: "zsh",
+      workingDirectoryPath: cwd,
+      agentActivity: nil,
+      commandExitCode: nil,
+      commandDuration: nil
+    )
+  }
+}
+
+private actor TerminalBarGitRecorder {
+  private var recordedCalls: [String] = []
+  private var outputs: [String]
+
+  init(outputs: [String]) {
+    self.outputs = outputs
+  }
+
+  func run(_ cwd: String) throws -> String {
+    recordedCalls.append(cwd)
+    guard !outputs.isEmpty else {
+      return "## main\n"
+    }
+    return outputs.removeFirst()
+  }
+
+  func calls() -> [String] {
+    recordedCalls
+  }
+}

--- a/apps/mac/supatermTests/TerminalBarRuntimeTests.swift
+++ b/apps/mac/supatermTests/TerminalBarRuntimeTests.swift
@@ -13,9 +13,9 @@ struct TerminalBarRuntimeTests {
     let recorder = TerminalBarGitRecorder(outputs: ["## main\n"])
     let runtime = makeRuntime(clock: clock, recorder: recorder)
 
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/one"), reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/one"), reason: .focus)
     await clock.advance(by: .milliseconds(100))
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/two"), reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/two"), reason: .focus)
     await clock.advance(by: .milliseconds(199))
     await flushEffects()
     #expect(await recorder.calls() == [])
@@ -33,12 +33,12 @@ struct TerminalBarRuntimeTests {
     let runtime = makeRuntime(clock: clock, recorder: recorder)
     let now = Date()
 
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
     await clock.advance(by: .milliseconds(200))
     await flushEffects()
 
     runtime.refresh(
-      settings: .default,
+      settings: gitSettings,
       context: context(cwd: "/tmp/repo"),
       now: now.addingTimeInterval(1),
       reason: .focus
@@ -54,12 +54,12 @@ struct TerminalBarRuntimeTests {
     let runtime = makeRuntime(clock: clock, recorder: recorder)
     let now = Date()
 
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
     await clock.advance(by: .milliseconds(200))
     await flushEffects()
 
     runtime.refresh(
-      settings: .default,
+      settings: gitSettings,
       context: context(cwd: "/tmp/repo"),
       now: now.addingTimeInterval(3),
       reason: .focus
@@ -78,12 +78,12 @@ struct TerminalBarRuntimeTests {
     let runtime = makeRuntime(clock: clock, recorder: recorder)
     let now = Date()
 
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/repo"), now: now, reason: .focus)
     await clock.advance(by: .milliseconds(200))
     await flushEffects()
 
     runtime.refresh(
-      settings: .default,
+      settings: gitSettings,
       context: context(cwd: "/tmp/repo"),
       now: now.addingTimeInterval(1),
       reason: .commandFinished
@@ -112,7 +112,7 @@ struct TerminalBarRuntimeTests {
       sleep: { duration in try await clock.sleep(for: duration) }
     )
 
-    runtime.refresh(settings: .default, context: context(cwd: "/tmp/repo"), reason: .focus)
+    runtime.refresh(settings: gitSettings, context: context(cwd: "/tmp/repo"), reason: .focus)
     await clock.advance(by: .milliseconds(200))
     await clock.advance(by: .seconds(1))
     await flushEffects()
@@ -132,6 +132,15 @@ struct TerminalBarRuntimeTests {
       gitClient: client,
       debounceDuration: .milliseconds(200),
       sleep: { duration in try await clock.sleep(for: duration) }
+    )
+  }
+
+  private var gitSettings: SupatermBottomBarSettings {
+    SupatermBottomBarSettings(
+      enabled: true,
+      left: [.directory, .gitBranch, .gitStatus],
+      center: [],
+      right: []
     )
   }
 

--- a/docs/bottom-bar.md
+++ b/docs/bottom-bar.md
@@ -1,0 +1,32 @@
+# Bottom Bar
+
+Supaterm reads the terminal bottom bar from `~/.config/supaterm/settings.toml`.
+
+The default layout is:
+
+```toml
+[bottom_bar]
+enabled = true
+left = ["directory", "git_branch", "git_status"]
+center = []
+right = ["agent", "exit_status"]
+```
+
+Available modules:
+
+```text
+directory
+git_branch
+git_status
+pane_title
+agent
+exit_status
+command_duration
+time
+```
+
+The bar is global for the selected tab. In a split tab, Supaterm shows one bottom bar and refreshes it from the focused pane.
+
+Refresh behavior is event-driven. Focus, working directory, title, command completion, agent state, and valid settings changes refresh immediately. Git probes are debounced by about 200 ms and cached briefly. The `time` module ticks once per minute only when configured.
+
+Run `sp config validate` after editing `settings.toml`. Unknown keys warn; unknown module names make the config invalid.

--- a/docs/bottom-bar.md
+++ b/docs/bottom-bar.md
@@ -7,9 +7,9 @@ The default layout is:
 ```toml
 [bottom_bar]
 enabled = true
-left = ["directory", "git_branch", "git_status"]
+left = ["agent"]
 center = []
-right = ["agent", "exit_status"]
+right = []
 ```
 
 Available modules:


### PR DESCRIPTION

- Adds `[bottom_bar]` settings with configurable left, center, and right module groups.
- Renders one bottom bar below the terminal detail area, shared by split panes and driven by the focused pane.
- Adds built-in modules for directory, source control, pane metadata, agent state, exit status, command duration, and time.
- Debounces bar refresh work and caches source-control probes so focus changes and command completion stay cheap.
