### PR TITLE
[build] Skip Ghostty app bundle emission

### DIFF
--- a/apps/mac/scripts/build-ghostty.sh
+++ b/apps/mac/scripts/build-ghostty.sh
@@ -79,7 +79,7 @@ if [ -f "${ghostty_fingerprint_path}" ] &&
 fi
 
 cd "${ghostty_dir}"
-mise exec -- zig build -Doptimize=ReleaseFast -Demit-xcframework=true -Dsentry=false --prefix "${ghostty_build_root}" --cache-dir "${ghostty_local_cache_dir}" --global-cache-dir "${ghostty_global_cache_dir}"
+mise exec -- zig build -Doptimize=ReleaseFast -Demit-xcframework=true -Demit-macos-app=false -Dsentry=false --prefix "${ghostty_build_root}" --cache-dir "${ghostty_local_cache_dir}" --global-cache-dir "${ghostty_global_cache_dir}"
 rsync -a --delete "${ghostty_dir}/macos/GhosttyKit.xcframework/" "${xcframework_path}/"
 prepare_xcframework
 printf '%s\n' "${fingerprint}" > "${ghostty_fingerprint_path}"


### PR DESCRIPTION
## Describe your changes

Stops Supaterm’s Ghostty runtime build from emitting the unused macOS app bundle while still building GhosttyKit and resources.

## Additional details

- Keeps `-Demit-xcframework=true` and adds `-Demit-macos-app=false`.
- Avoids building the unused Dock tile plugin path.
