### PR TITLE
Fix split panes inheriting focused working directory

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState.swift
@@ -968,10 +968,14 @@ final class TerminalHostState {
 
     switch action {
     case .newSplit(let direction):
+      let inheritedWorkingDirectory = existingWorkingDirectoryURL(
+        for: workingDirectoryPath(for: targetSurface)
+      )
       let newSurface = createSurface(
         tabID: tabID,
         startupCommand: nil,
         inheritingFromSurfaceID: surfaceID,
+        workingDirectory: inheritedWorkingDirectory,
         context: GHOSTTY_SURFACE_CONTEXT_SPLIT
       )
       do {

--- a/apps/mac/supatermTests/TerminalHostStatePaneCreationTests.swift
+++ b/apps/mac/supatermTests/TerminalHostStatePaneCreationTests.swift
@@ -63,6 +63,28 @@ struct TerminalHostStatePaneCreationTests {
     }
   }
 
+  @Test
+  func keyboardSplitInheritsFocusedPaneWorkingDirectory() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      initializeGhosttyForTests()
+
+      let host = restoredHost(rootRatio: 0.5)
+      let focusedSurface = try #require(host.selectedSurfaceView)
+      let focusedPath = "/tmp/focused-pane"
+      focusedSurface.bridge.state.pwd = focusedPath
+
+      #expect(host.performSplitAction(.newSplit(direction: .right), for: focusedSurface.id))
+
+      let snapshot = host.restorationSnapshot()
+      let root = try #require(snapshot.spaces.first?.tabs.first?.root)
+      let paths = root.workingDirectoryPaths.compactMap { $0 }
+      #expect(paths.contains(focusedPath))
+      #expect(paths.filter { $0 == focusedPath }.count == 2)
+    }
+  }
+
   private func restoredHost(rootRatio: Double) -> TerminalHostState {
     let host = TerminalHostState()
     let spaceID = host.spaces[0].id


### PR DESCRIPTION
## Summary
- pass the focused pane working directory when creating a new pane via keyboard split action
- keep split creation behavior consistent with pane duplication and preserved cwd semantics
- add a regression test covering keyboard split cwd inheritance

## Testing
- xcodebuild test -workspace apps/mac/supaterm.xcworkspace -scheme supaterm -destination "platform=macOS" -only-testing:supatermTests/TerminalHostStatePaneCreationTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation *(fails locally: missing apps/mac/.build/ghostty/GhosttyKit.xcframework)*
- pre-push branch checks *(fails locally while building Ghostty/Tuist dependency chain with undefined symbol linker errors)*