### PR TITLE
SUP-59: Pin toolchain versions

### DIFF
--- a/apps/supaterm.com/package.json
+++ b/apps/supaterm.com/package.json
@@ -40,15 +40,15 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+    "vite-plus": "0.1.13",
     "wrangler": "^4.76.0"
   },
   "packageManager": "pnpm@10.32.1",
   "pnpm": {
     "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13",
       "brace-expansion": "^5.0.5",
       "picomatch": "^4.0.4"
     }

--- a/apps/supaterm.com/pnpm-lock.yaml
+++ b/apps/supaterm.com/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
   brace-expansion: ^5.0.5
   picomatch: ^4.0.4
 
@@ -100,10 +100,10 @@ importers:
         specifier: ^8.57.0
         version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.13
         version: '@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3)'
       vite-plus:
-        specifier: latest
+        specifier: 0.1.13
         version: 0.1.13(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3))(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(typescript@5.9.3)
       wrangler:
         specifier: ^4.76.0

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/mise.toml
+++ b/mise.toml
@@ -3,10 +3,10 @@ hk = "1.45.0"
 pkl = "0.31.1"
 zig = "0.15.2"
 tuist = "4.192.3"
-swiftlint = "latest"
+swiftlint = "0.63.2"
 xcbeautify = "3.2.1"
 pnpm = "10.32.1"
-"npm:create-dmg" = { version = "latest", os = ["macos"] }
+"npm:create-dmg" = { version = "8.1.0", os = ["macos"] }
 
 [env]
 HK_MISE = "1"


### PR DESCRIPTION
Pins the repository toolchain and web package versions so hooks, mise-managed tools, and Vite+ dependencies resolve deterministically instead of floating across environments.