### PR TITLE
SUP-60: Truth up onboarding docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,18 @@
 
 ### Commands
 
+Canonical macOS gates:
+
+```bash
+make mac-check          # format + lint
+make mac-test           # full test suite
+```
+
+Useful macOS development commands:
+
 ```bash
 make mac-build          # Debug build
 make mac-run            # Debug run with isolated ephemeral state
-make mac-test           # full test suite
 ```
 
 Run a single test class or method:
@@ -29,12 +37,19 @@ xcodebuild test -workspace apps/mac/supaterm.xcworkspace -scheme supaterm -desti
 
 ### Website (`apps/supaterm.com`)
 
+Canonical website gates:
+
 ```bash
-make web-install        # install dependencies (vp install)
 make web-check          # format + lint + type check
-make web-dev            # dev server
 make web-test           # test suite
 make web-build          # production build
+```
+
+Useful website development commands:
+
+```bash
+make web-install        # install dependencies (vp install)
+make web-dev            # dev server
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A terminal for ur coding agents.
 
 ## Development
 
-Read [./docs](./docs)
+- [Development](./docs/development.md)
+- [Coding agents integration](./docs/coding-agents-integration.md)
+- [Socket control](./docs/how-socket-works.md)
 
 ## Thank you
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,7 @@ git submodule update --init --recursive
 Install pinned tools:
 
 ```bash
+mise trust mise.toml
 mise install
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,32 @@
 # Development
 
+## Bootstrap
+
+Initialize submodules from the repo root:
+
+```bash
+git submodule update --init --recursive
+```
+
+Install pinned tools:
+
+```bash
+mise install
+```
+
+Authenticate Tuist before using cache-backed generation:
+
+```bash
+mise exec -- tuist auth login
+mise exec -- tuist auth whoami
+```
+
+Warm the macOS Tuist cache:
+
+```bash
+make mac-warm-cache
+```
+
 Use `$SUPATERM_CLI_PATH` in development shells to call the Debug CLI instead of the installed app CLI:
 
 ```bash
@@ -21,18 +48,6 @@ SUPATERM_RUN_INSTANCE_NAME=supaterm-dev SUPATERM_RUN_STATE_HOME=/tmp/supaterm-de
 ```
 
 Panes inherit `SUPATERM_STATE_HOME`, so `sp` commands launched inside the app use the same root.
-
-## Warm Cache
-
-Warm the macOS Tuist cache from the repo root with:
-
-```bash
-mise exec -- tuist auth login
-mise exec -- tuist auth whoami
-make mac-warm-cache
-```
-
-This warms external dependencies for Debug.
 
 ## Testing
 

--- a/docs/how-socket-works.md
+++ b/docs/how-socket-works.md
@@ -39,9 +39,9 @@ This document captures the stable rules of Supaterm's socket IPC. The source rem
 
 ## Code Index
 
-- `apps/mac/supaterm/Features/Socket/` is the app-side socket boundary.
-- `apps/mac/supaterm/Features/Socket/SocketControlFeature.swift` owns request semantics.
-- `apps/mac/supaterm/Features/Socket/SocketControlRuntime.swift` owns socket lifecycle and transport.
+- `apps/mac/supaterm/SocketFeature/` is the app-side socket boundary.
+- `apps/mac/supaterm/SocketFeature/SocketControlFeature.swift` owns request semantics.
+- `apps/mac/supaterm/SocketFeature/SocketControlRuntime.swift` owns socket lifecycle and transport.
 - `apps/mac/SupatermCLIShared/` holds the shared IPC contract.
 - `apps/mac/SupatermCLIShared/SupatermSocketProtocol.swift` defines request and response types.
 - `apps/mac/SupatermCLIShared/SupatermSocketPath.swift` defines endpoint resolution and discovery.


### PR DESCRIPTION
Updates onboarding and socket documentation to match the current repository layout, first-run setup flow, and canonical verification gates.