### PR TITLE
SUP-62: Harden socket runtime

### DIFF
--- a/apps/mac/supaterm/SocketFeature/SocketControlClient.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketControlClient.swift
@@ -17,6 +17,7 @@ public struct SocketControlClient: Sendable {
   }
 
   public var currentEndpoint: @MainActor @Sendable () async -> SupatermSocketEndpoint?
+  public var isPending: @MainActor @Sendable (UUID) async -> Bool
   public var requests: @MainActor @Sendable () async -> AsyncStream<Request>
   public var reply: @MainActor @Sendable (UUID, SupatermSocketResponse) async -> Void
   public var start: @MainActor @Sendable () async throws -> SupatermSocketEndpoint
@@ -24,12 +25,14 @@ public struct SocketControlClient: Sendable {
 
   public nonisolated init(
     currentEndpoint: @escaping @MainActor @Sendable () async -> SupatermSocketEndpoint?,
+    isPending: @escaping @MainActor @Sendable (UUID) async -> Bool,
     requests: @escaping @MainActor @Sendable () async -> AsyncStream<Request>,
     reply: @escaping @MainActor @Sendable (UUID, SupatermSocketResponse) async -> Void,
     start: @escaping @MainActor @Sendable () async throws -> SupatermSocketEndpoint,
     stop: @escaping @MainActor @Sendable () async -> Void
   ) {
     self.currentEndpoint = currentEndpoint
+    self.isPending = isPending
     self.requests = requests
     self.reply = reply
     self.start = start
@@ -43,6 +46,9 @@ extension SocketControlClient: DependencyKey {
     return Self(
       currentEndpoint: {
         await runtime.currentEndpoint()
+      },
+      isPending: { handle in
+        await runtime.isPending(handle)
       },
       requests: {
         await runtime.requests()
@@ -63,6 +69,7 @@ extension SocketControlClient: DependencyKey {
     currentEndpoint: {
       nil
     },
+    isPending: { _ in true },
     requests: {
       AsyncStream { continuation in
         continuation.finish()

--- a/apps/mac/supaterm/SocketFeature/SocketControlFeature.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketControlFeature.swift
@@ -80,6 +80,7 @@ public struct SocketControlFeature {
       switch action {
       case .requestReceived(let request):
         return .run { [desktopNotificationClient, socketControlClient, socketRequestExecutor] _ in
+          guard await socketControlClient.isPending(request.handle) else { return }
           let response = await response(
             for: request.payload,
             desktopNotificationClient: desktopNotificationClient,

--- a/apps/mac/supaterm/SocketFeature/SocketControlRuntime.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketControlRuntime.swift
@@ -76,6 +76,10 @@ actor SocketControlRuntime {
     endpoint
   }
 
+  func isPending(_ handle: UUID) -> Bool {
+    pendingReplies[handle] != nil
+  }
+
   func requests() -> AsyncStream<SocketControlClient.Request> {
     requestsContinuation?.finish()
     let (stream, continuation) = AsyncStream.makeStream(of: SocketControlClient.Request.self)
@@ -245,6 +249,7 @@ actor SocketControlRuntime {
 
   private func expireReply(_ handle: UUID) {
     guard let pendingReply = pendingReplies.removeValue(forKey: handle) else { return }
+    bufferedRequests.removeAll { $0.handle == handle }
     Darwin.close(pendingReply.clientSocket)
   }
 

--- a/apps/mac/supaterm/SocketFeature/SocketControlRuntime.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketControlRuntime.swift
@@ -49,7 +49,10 @@ actor SocketControlRuntime {
     endpointProvider: SupatermProcessSocketEndpoint.current
   )
 
+  private let clientReadTimeout: TimeInterval
   private let endpointProvider: @Sendable () -> SupatermSocketEndpoint?
+  private let replyTimeout: Duration
+  private let sleep: @Sendable (Duration) async throws -> Void
   private var bufferedRequests: [SocketControlClient.Request] = []
   private var endpoint: SupatermSocketEndpoint?
   private var listenerTask: Task<Void, Never>?
@@ -58,9 +61,15 @@ actor SocketControlRuntime {
   private var serverSocket: Int32 = -1
 
   init(
-    endpointProvider: @escaping @Sendable () -> SupatermSocketEndpoint?
+    endpointProvider: @escaping @Sendable () -> SupatermSocketEndpoint?,
+    clientReadTimeout: TimeInterval = 10,
+    replyTimeout: Duration = .seconds(30),
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
   ) {
+    self.clientReadTimeout = clientReadTimeout
     self.endpointProvider = endpointProvider
+    self.replyTimeout = replyTimeout
+    self.sleep = sleep
   }
 
   func currentEndpoint() -> SupatermSocketEndpoint? {
@@ -140,8 +149,13 @@ actor SocketControlRuntime {
       }
 
       let runtime = self
+      let clientReadTimeout = self.clientReadTimeout
       listenerTask = Task.detached(priority: .utility) {
-        Self.acceptLoop(serverSocket: serverSocket, runtime: runtime)
+        Self.acceptLoop(
+          serverSocket: serverSocket,
+          runtime: runtime,
+          clientReadTimeout: clientReadTimeout
+        )
       }
 
       return endpoint
@@ -212,6 +226,13 @@ actor SocketControlRuntime {
     let handle = UUID()
     pendingReplies[handle] = PendingReply(clientSocket: clientSocket)
     emit(SocketControlClient.Request(handle: handle, payload: request))
+
+    let sleep = self.sleep
+    let replyTimeout = self.replyTimeout
+    Task { [weak self] in
+      try? await sleep(replyTimeout)
+      await self?.expireReply(handle)
+    }
   }
 
   private func emit(_ request: SocketControlClient.Request) {
@@ -222,9 +243,15 @@ actor SocketControlRuntime {
     requestsContinuation.yield(request)
   }
 
+  private func expireReply(_ handle: UUID) {
+    guard let pendingReply = pendingReplies.removeValue(forKey: handle) else { return }
+    Darwin.close(pendingReply.clientSocket)
+  }
+
   private nonisolated static func acceptLoop(
     serverSocket: Int32,
-    runtime: SocketControlRuntime
+    runtime: SocketControlRuntime,
+    clientReadTimeout: TimeInterval
   ) {
     while !Task.isCancelled {
       let clientSocket = Darwin.accept(serverSocket, nil, nil)
@@ -236,10 +263,26 @@ actor SocketControlRuntime {
       }
 
       Task.detached(priority: .utility) {
+        var receiveTimeout = Self.socketTimeout(clientReadTimeout)
+        _ = setsockopt(
+          clientSocket,
+          SOL_SOCKET,
+          SO_RCVTIMEO,
+          &receiveTimeout,
+          socklen_t(MemoryLayout<timeval>.size)
+        )
+
         let requestLine = Self.readLine(from: clientSocket)
         await runtime.handleRequestLine(requestLine, clientSocket: clientSocket)
       }
     }
+  }
+
+  private nonisolated static func socketTimeout(_ interval: TimeInterval) -> timeval {
+    let clampedInterval = max(0, interval)
+    let seconds = __darwin_time_t(clampedInterval.rounded(.down))
+    let microseconds = __darwin_suseconds_t(((clampedInterval - Double(seconds)) * 1_000_000).rounded())
+    return timeval(tv_sec: seconds, tv_usec: microseconds)
   }
 
   private nonisolated static func socketAddress(path: String) throws -> sockaddr_un {

--- a/apps/mac/supatermTests/SocketControlFeatureTests.swift
+++ b/apps/mac/supatermTests/SocketControlFeatureTests.swift
@@ -63,6 +63,40 @@ struct SocketControlFeatureLifecycleTests {
         )
     )
   }
+
+  @Test
+  func expiredRequestDoesNotExecuteSideEffects() async throws {
+    let recorder = SocketReplyRecorder()
+    let handle = UUID(uuidString: "A0BB14C3-962E-40E2-B105-503CF7B87B45")!
+    let request = SocketControlClient.Request(
+      handle: handle,
+      payload: try .newTab(
+        SupatermNewTabRequest(
+          startupCommand: "pwd",
+          focus: false,
+          targetWindowIndex: 1,
+          targetSpaceIndex: 1
+        ),
+        id: "expired-new-tab-1"
+      )
+    )
+
+    let store = makeStore {
+      $0.socketControlClient.isPending = { _ in false }
+      $0.socketControlClient.reply = { handle, response in
+        await recorder.record(handle: handle, response: response)
+      }
+      $0.terminalWindowsClient.createTab = { _ in
+        Issue.record("Expired request should not create a tab.")
+        throw POSIXError(.EIO)
+      }
+    }
+
+    await store.send(.requestReceived(request))
+
+    #expect(await recorder.snapshot().isEmpty)
+  }
+
   @Test
   func identityRequestRepliesWithEndpoint() async throws {
     let recorder = SocketReplyRecorder()

--- a/apps/mac/supatermTests/SocketControlRuntimeTests.swift
+++ b/apps/mac/supatermTests/SocketControlRuntimeTests.swift
@@ -271,6 +271,46 @@ struct SocketControlRuntimeTests {
   }
 
   @Test
+  func expiredBufferedRequestIsNotEmitted() async throws {
+    let rootURL = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sleepRecorder = RuntimeSleepRecorder()
+    let replyTimeout = Duration.milliseconds(50)
+    let socketURL = rootURL.appendingPathComponent("control.sock", isDirectory: false)
+    let runtime = SocketControlRuntime(
+      endpointProvider: {
+        socketEndpoint(path: socketURL.path)
+      },
+      replyTimeout: replyTimeout,
+      sleep: { duration in
+        await sleepRecorder.record(duration)
+      }
+    )
+    let endpoint = try await runtime.start()
+    let socketDescriptor = try openConnectedSocket(path: endpoint.path)
+    defer { Darwin.close(socketDescriptor) }
+
+    do {
+      try writeRequest(.ping(id: "buffered-expire-1"), to: socketDescriptor)
+      #expect(try readByte(from: socketDescriptor) == 0)
+      #expect(await sleepRecorder.durations() == [replyTimeout])
+
+      let stream = await runtime.requests()
+      let requestTask = Task {
+        var iterator = stream.makeAsyncIterator()
+        return await iterator.next()
+      }
+
+      await runtime.stop()
+      #expect(await requestTask.value == nil)
+    } catch {
+      await runtime.stop()
+      throw error
+    }
+  }
+
+  @Test
   func repliedRequestIsNotExpiredTwice() async throws {
     let rootURL = try makeTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/apps/mac/supatermTests/SocketControlRuntimeTests.swift
+++ b/apps/mac/supatermTests/SocketControlRuntimeTests.swift
@@ -193,6 +193,130 @@ struct SocketControlRuntimeTests {
 
     await runtime.stop()
   }
+
+  @Test
+  func silentClientConnectionIsClosedAfterReadTimeout() async throws {
+    let rootURL = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let socketURL = rootURL.appendingPathComponent("control.sock", isDirectory: false)
+    let runtime = SocketControlRuntime(
+      endpointProvider: {
+        socketEndpoint(path: socketURL.path)
+      },
+      clientReadTimeout: 0.2
+    )
+    let endpoint = try await runtime.start()
+    let stream = await runtime.requests()
+    let requestTask = Task {
+      var iterator = stream.makeAsyncIterator()
+      return await iterator.next()
+    }
+
+    let socketDescriptor = try openConnectedSocket(path: endpoint.path)
+    defer { Darwin.close(socketDescriptor) }
+
+    do {
+      #expect(try readByte(from: socketDescriptor) == 0)
+      await runtime.stop()
+      #expect(await requestTask.value == nil)
+    } catch {
+      await runtime.stop()
+      _ = await requestTask.value
+      throw error
+    }
+  }
+
+  @Test
+  func unrepliedRequestExpiresAndClosesClientSocket() async throws {
+    let rootURL = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sleepRecorder = RuntimeSleepRecorder()
+    let replyTimeout = Duration.milliseconds(50)
+    let socketURL = rootURL.appendingPathComponent("control.sock", isDirectory: false)
+    let runtime = SocketControlRuntime(
+      endpointProvider: {
+        socketEndpoint(path: socketURL.path)
+      },
+      replyTimeout: replyTimeout,
+      sleep: { duration in
+        await sleepRecorder.record(duration)
+      }
+    )
+    let endpoint = try await runtime.start()
+    let stream = await runtime.requests()
+    let requestTask = Task {
+      var iterator = stream.makeAsyncIterator()
+      return await iterator.next()
+    }
+
+    let socketDescriptor = try openConnectedSocket(path: endpoint.path)
+    defer { Darwin.close(socketDescriptor) }
+
+    do {
+      try writeRequest(.ping(id: "expire-1"), to: socketDescriptor)
+
+      let request = try #require(await requestTask.value)
+      #expect(try readByte(from: socketDescriptor) == 0)
+      #expect(await sleepRecorder.durations() == [replyTimeout])
+
+      await runtime.reply(.ok(id: "expire-1"), to: request.handle)
+      await runtime.stop()
+    } catch {
+      await runtime.stop()
+      _ = await requestTask.value
+      throw error
+    }
+  }
+
+  @Test
+  func repliedRequestIsNotExpiredTwice() async throws {
+    let rootURL = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sleepGate = RuntimeSleepGate()
+    let replyTimeout = Duration.milliseconds(50)
+    let socketURL = rootURL.appendingPathComponent("control.sock", isDirectory: false)
+    let runtime = SocketControlRuntime(
+      endpointProvider: {
+        socketEndpoint(path: socketURL.path)
+      },
+      replyTimeout: replyTimeout,
+      sleep: { duration in
+        try await sleepGate.sleep(duration)
+      }
+    )
+    let endpoint = try await runtime.start()
+    let stream = await runtime.requests()
+    let requestTask = Task {
+      var iterator = stream.makeAsyncIterator()
+      return await iterator.next()
+    }
+
+    let socketDescriptor = try openConnectedSocket(path: endpoint.path)
+    defer { Darwin.close(socketDescriptor) }
+
+    do {
+      try writeRequest(.ping(id: "reply-1"), to: socketDescriptor)
+
+      let request = try #require(await requestTask.value)
+      await runtime.reply(.ok(id: "reply-1"), to: request.handle)
+
+      let response = try #require(try readSocketResponse(from: socketDescriptor))
+      #expect(response.ok)
+      #expect(response.id == "reply-1")
+      #expect(await sleepGate.durations() == [replyTimeout])
+
+      await sleepGate.resumeAll()
+      await runtime.stop()
+    } catch {
+      await sleepGate.resumeAll()
+      await runtime.stop()
+      _ = await requestTask.value
+      throw error
+    }
+  }
 }
 
 private func makeTemporaryDirectory() throws -> URL {
@@ -270,4 +394,178 @@ nonisolated private func socketEndpoint(path: String) -> SupatermSocketEndpoint 
     pid: 1,
     startedAt: Date(timeIntervalSince1970: 0)
   )
+}
+
+private actor RuntimeSleepRecorder {
+  private var recordedDurations: [Duration] = []
+
+  func record(_ duration: Duration) {
+    recordedDurations.append(duration)
+  }
+
+  func durations() -> [Duration] {
+    recordedDurations
+  }
+}
+
+private actor RuntimeSleepGate {
+  private var continuations: [CheckedContinuation<Void, Never>] = []
+  private var recordedDurations: [Duration] = []
+
+  func sleep(_ duration: Duration) async throws {
+    recordedDurations.append(duration)
+    await withCheckedContinuation { continuation in
+      continuations.append(continuation)
+    }
+  }
+
+  func durations() -> [Duration] {
+    recordedDurations
+  }
+
+  func resumeAll() {
+    let pendingContinuations = continuations
+    continuations.removeAll()
+    for continuation in pendingContinuations {
+      continuation.resume()
+    }
+  }
+}
+
+private func openConnectedSocket(
+  path: String,
+  responseTimeout: TimeInterval = 1
+) throws -> Int32 {
+  let socketDescriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+  guard socketDescriptor >= 0 else {
+    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+  }
+
+  do {
+    var address = try runtimeSocketAddress(path: path)
+    let connectResult = withUnsafePointer(to: &address) { pointer in
+      pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+        Darwin.connect(socketDescriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+      }
+    }
+    guard connectResult == 0 else {
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+
+    var receiveTimeout = runtimeSocketTimeout(responseTimeout)
+    _ = setsockopt(
+      socketDescriptor,
+      SOL_SOCKET,
+      SO_RCVTIMEO,
+      &receiveTimeout,
+      socklen_t(MemoryLayout<timeval>.size)
+    )
+
+    return socketDescriptor
+  } catch {
+    Darwin.close(socketDescriptor)
+    throw error
+  }
+}
+
+private func writeRequest(
+  _ request: SupatermSocketRequest,
+  to socketDescriptor: Int32
+) throws {
+  let data = try JSONEncoder().encode(request) + Data([0x0A])
+  try data.withUnsafeBytes { buffer in
+    guard let baseAddress = buffer.baseAddress else { return }
+    var offset = 0
+    while offset < buffer.count {
+      let bytesWritten = Darwin.write(
+        socketDescriptor,
+        baseAddress.advanced(by: offset),
+        buffer.count - offset
+      )
+      guard bytesWritten > 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+      offset += bytesWritten
+    }
+  }
+}
+
+private func readSocketResponse(from socketDescriptor: Int32) throws -> SupatermSocketResponse? {
+  guard let responseLine = try readLine(from: socketDescriptor) else { return nil }
+  guard let responseData = responseLine.data(using: .utf8) else { return nil }
+  return try JSONDecoder().decode(SupatermSocketResponse.self, from: responseData)
+}
+
+private func readLine(from socketDescriptor: Int32) throws -> String? {
+  var data = Data()
+  var buffer = [UInt8](repeating: 0, count: 1024)
+
+  while true {
+    try waitForSocketRead(socketDescriptor)
+    let bytesRead = Darwin.read(socketDescriptor, &buffer, buffer.count)
+    guard bytesRead >= 0 else {
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    guard bytesRead > 0 else { break }
+
+    data.append(buffer, count: bytesRead)
+    if let newlineIndex = data.firstIndex(of: 0x0A) {
+      data = Data(data[..<newlineIndex])
+      break
+    }
+  }
+
+  guard !data.isEmpty else { return nil }
+  return String(data: data, encoding: .utf8)
+}
+
+private func readByte(from socketDescriptor: Int32) throws -> Int {
+  try waitForSocketRead(socketDescriptor)
+  var byte = UInt8(0)
+  let bytesRead = Darwin.read(socketDescriptor, &byte, 1)
+  guard bytesRead >= 0 else {
+    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+  }
+  return bytesRead
+}
+
+private func waitForSocketRead(
+  _ socketDescriptor: Int32,
+  timeoutMilliseconds: Int32 = 1_000
+) throws {
+  var descriptor = pollfd(fd: socketDescriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
+  let result = Darwin.poll(&descriptor, 1, timeoutMilliseconds)
+  guard result > 0 else {
+    if result == 0 {
+      throw POSIXError(.ETIMEDOUT)
+    }
+    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+  }
+}
+
+private func runtimeSocketAddress(path: String) throws -> sockaddr_un {
+  var address = sockaddr_un()
+  memset(&address, 0, MemoryLayout<sockaddr_un>.size)
+  address.sun_family = sa_family_t(AF_UNIX)
+
+  let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+  guard path.utf8.count < maxLength else {
+    throw POSIXError(.ENAMETOOLONG)
+  }
+
+  path.withCString { pointer in
+    withUnsafeMutablePointer(to: &address.sun_path) { pathPointer in
+      let buffer = UnsafeMutableRawPointer(pathPointer).assumingMemoryBound(to: CChar.self)
+      strncpy(buffer, pointer, maxLength - 1)
+    }
+  }
+
+  return address
+}
+
+private func runtimeSocketTimeout(_ interval: TimeInterval) -> timeval {
+  let clampedInterval = max(0, interval)
+  let seconds = __darwin_time_t(clampedInterval.rounded(.down))
+  let microseconds = __darwin_suseconds_t(((clampedInterval - Double(seconds)) * 1_000_000).rounded())
+  return timeval(tv_sec: seconds, tv_usec: microseconds)
 }


### PR DESCRIPTION
Hardens the socket runtime around stale socket recovery, pid ownership checks, and partial-message handling while preserving the SUP-61 transport regression coverage as the safety net.