### PR TITLE
[fix] Render Claude agent panel tasks in task ID order

### DIFF
--- a/apps/mac/supaterm/App/ClaudeProgressMonitor.swift
+++ b/apps/mac/supaterm/App/ClaudeProgressMonitor.swift
@@ -22,8 +22,6 @@ private struct ClaudeProgressTask: Equatable {
   var taskID: String
   var title: String
   var status: PaneAgentProgressRow.Status
-  var blockedBy: [String]
-  var modificationDate: Date?
   var metadata: JSONObject
 
   var isInternal: Bool {
@@ -46,112 +44,8 @@ private struct ClaudeProgressTask: Equatable {
   }
 }
 
-private enum ClaudeProgressTaskOrdering {
-  static let recentCompletedInterval: TimeInterval = 30
-
-  static func rows(
-    _ tasks: [ClaudeProgressTask],
-    now: Date = Date()
-  ) -> [PaneAgentProgressRow] {
-    let visibleTasks = tasks.filter { !$0.isInternal }
-    let unresolvedIDs = Set(visibleTasks.filter { $0.status != .completed }.map(\.taskID))
-    return visibleTasks.sorted { lhs, rhs in
-      let lhsBucket = displayBucket(lhs, now: now)
-      let rhsBucket = displayBucket(rhs, now: now)
-      if lhsBucket != rhsBucket {
-        return lhsBucket < rhsBucket
-      }
-      if lhsBucket == 2 {
-        let lhsBlocked = lhs.blockedBy.contains { unresolvedIDs.contains($0) }
-        let rhsBlocked = rhs.blockedBy.contains { unresolvedIDs.contains($0) }
-        if lhsBlocked != rhsBlocked {
-          return !lhsBlocked
-        }
-      }
-      return lhs.precedes(rhs)
-    }.map(\.row)
-  }
-
-  private static func displayBucket(
-    _ task: ClaudeProgressTask,
-    now: Date
-  ) -> Int {
-    switch task.status {
-    case .completed:
-      if let modificationDate = task.modificationDate,
-        now.timeIntervalSince(modificationDate) < recentCompletedInterval
-      {
-        return 0
-      }
-      return 3
-    case .running:
-      return 1
-    case .pending:
-      return 2
-    }
-  }
-}
-
-enum ClaudeTaskProgressReader {
-  static func progressRows(
-    sessionID: String,
-    homeDirectoryURL: URL,
-    now: Date = Date()
-  ) -> [PaneAgentProgressRow] {
-    let taskDirectoryURL =
-      homeDirectoryURL
-      .appendingPathComponent(".claude", isDirectory: true)
-      .appendingPathComponent("tasks", isDirectory: true)
-      .appendingPathComponent(sanitizedTaskListID(sessionID), isDirectory: true)
-    let taskURLs =
-      (try? FileManager.default.contentsOfDirectory(
-        at: taskDirectoryURL,
-        includingPropertiesForKeys: nil
-      )) ?? []
-    let rows =
-      taskURLs
-      .filter { $0.pathExtension == "json" }
-      .compactMap(progressTask)
-
-    return ClaudeProgressTaskOrdering.rows(rows, now: now)
-  }
-
-  static func sanitizedTaskListID(_ value: String) -> String {
-    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
-    return String(
-      value.unicodeScalars.map { scalar in
-        allowed.contains(scalar) ? Character(scalar) : "-"
-      }
-    )
-  }
-
-  private static func progressTask(
-    at url: URL
-  ) -> ClaudeProgressTask? {
-    guard
-      let data = try? Data(contentsOf: url),
-      let object = (try? JSONDecoder().decode(JSONValue.self, from: data))?.objectValue,
-      object["metadata"]?.objectValue?["_internal"] != .bool(true),
-      let id = object["id"]?.stringValue,
-      let title = AgentProgressParsing.normalizedTitle(object["subject"]?.stringValue)
-    else {
-      return nil
-    }
-    return ClaudeProgressTask(
-      taskID: id,
-      title: title,
-      status: AgentProgressParsing.status(object["status"]?.stringValue),
-      blockedBy: object["blockedBy"]?.arrayValue?.compactMap(\.stringValue) ?? [],
-      modificationDate: (try? url.resourceValues(forKeys: [.contentModificationDateKey]))
-        .flatMap(\.contentModificationDate),
-      metadata: object["metadata"]?.objectValue ?? [:]
-    )
-  }
-}
-
 private struct ClaudePendingTask: Equatable {
   var title: String
-  var blockedBy: [String]
   var metadata: JSONObject
 }
 
@@ -161,27 +55,23 @@ private struct ClaudeTranscriptTaskState: Equatable {
   var goalRow: PaneAgentProgressRow?
 
   mutating func apply(_ object: JSONObject) -> [PaneAgentProgressRow]? {
-    let timestamp = Self.timestamp(in: object) ?? Date()
     if let rows = applyGoalStatus(object) {
       return rows
     }
-    if let rows = applyTaskReminder(object, timestamp: timestamp) {
+    if let rows = applyTaskReminder(object) {
       return rows
     }
     switch object["type"]?.stringValue {
     case "assistant":
-      return applyAssistantLine(object, timestamp: timestamp)
+      return applyAssistantLine(object)
     case "user":
-      return applyUserLine(object, timestamp: timestamp)
+      return applyUserLine(object)
     default:
       return nil
     }
   }
 
-  private mutating func applyTaskReminder(
-    _ object: JSONObject,
-    timestamp: Date
-  ) -> [PaneAgentProgressRow]? {
+  private mutating func applyTaskReminder(_ object: JSONObject) -> [PaneAgentProgressRow]? {
     guard
       object["type"]?.stringValue == "attachment",
       let attachment = object["attachment"]?.objectValue,
@@ -192,20 +82,16 @@ private struct ClaudeTranscriptTaskState: Equatable {
     }
     tasks.removeAll()
     for value in content {
-      guard var task = Self.task(from: value.objectValue, timestamp: timestamp) else {
+      guard let task = Self.task(from: value.objectValue) else {
         continue
       }
-      task.modificationDate = timestamp
       tasks[task.taskID] = task
     }
     pendingCreates.removeAll()
     return displayRows(taskRows())
   }
 
-  private mutating func applyAssistantLine(
-    _ object: JSONObject,
-    timestamp: Date
-  ) -> [PaneAgentProgressRow]? {
+  private mutating func applyAssistantLine(_ object: JSONObject) -> [PaneAgentProgressRow]? {
     guard let content = object["message"]?.objectValue?["content"]?.arrayValue else { return nil }
     var didChangeTasks = false
     var latestTodoRows: [PaneAgentProgressRow]?
@@ -217,28 +103,23 @@ private struct ClaudeTranscriptTaskState: Equatable {
       }
       switch toolUse["name"]?.stringValue {
       case "TaskCreate":
-        didChangeTasks = applyTaskCreate(toolUse, timestamp: timestamp) || didChangeTasks
+        didChangeTasks = applyTaskCreate(toolUse) || didChangeTasks
       case "TaskUpdate":
-        didChangeTasks = applyTaskUpdate(toolUse, timestamp: timestamp) || didChangeTasks
+        didChangeTasks = applyTaskUpdate(toolUse) || didChangeTasks
       case "TodoWrite":
         latestTodoRows = Self.todoWriteRows(in: toolUse)
       default:
         continue
       }
     }
-    if let latestTodoRows {
-      if taskRows().isEmpty {
-        return displayRows(latestTodoRows)
-      }
+    if let latestTodoRows, taskRows().isEmpty {
+      return displayRows(latestTodoRows)
     }
     guard didChangeTasks else { return nil }
     return displayRows(taskRows())
   }
 
-  private mutating func applyUserLine(
-    _ object: JSONObject,
-    timestamp: Date
-  ) -> [PaneAgentProgressRow]? {
+  private mutating func applyUserLine(_ object: JSONObject) -> [PaneAgentProgressRow]? {
     guard
       let content = object["message"]?.objectValue?["content"]?.arrayValue,
       let resultObject = object["toolUseResult"]?.objectValue?["task"]?.objectValue,
@@ -264,8 +145,6 @@ private struct ClaudeTranscriptTaskState: Equatable {
         taskID: taskID,
         title: title,
         status: .pending,
-        blockedBy: pending?.blockedBy ?? [],
-        modificationDate: timestamp,
         metadata: pending?.metadata ?? [:]
       )
       didChangeTasks = true
@@ -274,25 +153,19 @@ private struct ClaudeTranscriptTaskState: Equatable {
     return displayRows(taskRows())
   }
 
-  private mutating func applyTaskCreate(
-    _ toolUse: JSONObject,
-    timestamp: Date
-  ) -> Bool {
+  private mutating func applyTaskCreate(_ toolUse: JSONObject) -> Bool {
     guard
       let input = toolUse["input"]?.objectValue,
       let title = AgentProgressParsing.normalizedTitle(input["subject"]?.stringValue)
     else {
       return false
     }
-    let blockedBy = input["blockedBy"]?.arrayValue?.compactMap(\.stringValue) ?? []
     let metadata = input["metadata"]?.objectValue ?? [:]
     if let taskID = input["id"]?.stringValue {
       tasks[taskID] = ClaudeProgressTask(
         taskID: taskID,
         title: title,
         status: .pending,
-        blockedBy: blockedBy,
-        modificationDate: timestamp,
         metadata: metadata
       )
       return true
@@ -300,16 +173,12 @@ private struct ClaudeTranscriptTaskState: Equatable {
     guard let toolUseID = toolUse["id"]?.stringValue else { return false }
     pendingCreates[toolUseID] = ClaudePendingTask(
       title: title,
-      blockedBy: blockedBy,
       metadata: metadata
     )
     return false
   }
 
-  private mutating func applyTaskUpdate(
-    _ toolUse: JSONObject,
-    timestamp: Date
-  ) -> Bool {
+  private mutating func applyTaskUpdate(_ toolUse: JSONObject) -> Bool {
     guard
       let input = toolUse["input"]?.objectValue,
       let taskID = input["taskId"]?.stringValue
@@ -327,8 +196,6 @@ private struct ClaudeTranscriptTaskState: Equatable {
         taskID: taskID,
         title: title,
         status: AgentProgressParsing.status(input["status"]?.stringValue),
-        blockedBy: input["addBlockedBy"]?.arrayValue?.compactMap(\.stringValue) ?? [],
-        modificationDate: timestamp,
         metadata: input["metadata"]?.objectValue ?? [:]
       )
       return true
@@ -339,11 +206,6 @@ private struct ClaudeTranscriptTaskState: Equatable {
     if input["status"]?.stringValue != nil {
       task.status = AgentProgressParsing.status(input["status"]?.stringValue)
     }
-    if let blockedBy = input["addBlockedBy"]?.arrayValue?.compactMap(\.stringValue),
-      !blockedBy.isEmpty
-    {
-      task.blockedBy.append(contentsOf: blockedBy.filter { !task.blockedBy.contains($0) })
-    }
     if let metadata = input["metadata"]?.objectValue {
       for (key, value) in metadata {
         if value == .null {
@@ -353,16 +215,18 @@ private struct ClaudeTranscriptTaskState: Equatable {
         }
       }
     }
-    task.modificationDate = timestamp
     tasks[taskID] = task
     return true
   }
 
   private func taskRows() -> [PaneAgentProgressRow] {
-    ClaudeProgressTaskOrdering.rows(Array(tasks.values))
+    tasks.values
+      .filter { !$0.isInternal }
+      .sorted { $0.precedes($1) }
+      .map(\.row)
   }
 
-  func displayRows(_ rows: [PaneAgentProgressRow]) -> [PaneAgentProgressRow] {
+  private func displayRows(_ rows: [PaneAgentProgressRow]) -> [PaneAgentProgressRow] {
     if let goalRow {
       return [goalRow] + rows
     }
@@ -393,10 +257,7 @@ private struct ClaudeTranscriptTaskState: Equatable {
     )
   }
 
-  private static func task(
-    from object: JSONObject?,
-    timestamp: Date
-  ) -> ClaudeProgressTask? {
+  private static func task(from object: JSONObject?) -> ClaudeProgressTask? {
     guard
       let object,
       let id = object["id"]?.stringValue,
@@ -408,8 +269,6 @@ private struct ClaudeTranscriptTaskState: Equatable {
       taskID: id,
       title: title,
       status: AgentProgressParsing.status(object["status"]?.stringValue),
-      blockedBy: object["blockedBy"]?.arrayValue?.compactMap(\.stringValue) ?? [],
-      modificationDate: timestamp,
       metadata: object["metadata"]?.objectValue ?? [:]
     )
   }
@@ -437,38 +296,16 @@ private struct ClaudeTranscriptTaskState: Equatable {
     }
     return rows
   }
-
-  private static func timestamp(in object: JSONObject) -> Date? {
-    guard let value = object["timestamp"]?.stringValue else { return nil }
-    return fractionalTimestampFormatter.date(from: value)
-      ?? timestampFormatter.date(from: value)
-  }
-
-  private static let fractionalTimestampFormatter: ISO8601DateFormatter = {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter
-  }()
-
-  private static let timestampFormatter = ISO8601DateFormatter()
 }
 
 @MainActor
 final class ClaudePanelMonitor: AgentPanelMonitor {
-  private let sessionID: String
-  private let homeDirectoryURL: URL
   private let transcriptPath: () -> String?
   private var cursor: ClaudeProgressCursor
   private var transcriptRows: [PaneAgentProgressRow]
   private var currentSnapshot: AgentMonitorSnapshot?
 
-  init(
-    sessionID: String,
-    homeDirectoryURL: URL,
-    transcriptPath: @escaping () -> String?
-  ) {
-    self.sessionID = sessionID
-    self.homeDirectoryURL = homeDirectoryURL
+  init(transcriptPath: @escaping () -> String?) {
     self.transcriptPath = transcriptPath
     let initialProgress =
       transcriptPath().map { ClaudeTranscriptProgressMonitor.start(at: $0) }
@@ -478,7 +315,7 @@ final class ClaudePanelMonitor: AgentPanelMonitor {
   }
 
   func start() -> AgentPanelMonitorTick? {
-    let snapshot = panelSnapshot()
+    let snapshot = AgentMonitorSnapshot(progressRows: transcriptRows)
     currentSnapshot = snapshot
     return AgentPanelMonitorTick(snapshot: snapshot, isFinal: false)
   }
@@ -492,22 +329,10 @@ final class ClaudePanelMonitor: AgentPanelMonitor {
         transcriptRows = rows
       }
     }
-    let nextSnapshot = panelSnapshot()
+    let nextSnapshot = AgentMonitorSnapshot(progressRows: transcriptRows)
     guard nextSnapshot != currentSnapshot else { return nil }
     currentSnapshot = nextSnapshot
     return AgentPanelMonitorTick(snapshot: nextSnapshot, isFinal: false)
-  }
-
-  private func panelSnapshot() -> AgentMonitorSnapshot {
-    let taskRows = ClaudeTaskProgressReader.progressRows(
-      sessionID: sessionID,
-      homeDirectoryURL: homeDirectoryURL
-    )
-    let rows =
-      taskRows.isEmpty
-      ? transcriptRows
-      : cursor.transcriptState.displayRows(taskRows)
-    return AgentMonitorSnapshot(progressRows: rows)
   }
 }
 

--- a/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
+++ b/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
@@ -47,7 +47,6 @@ final class TerminalAgentSessionStore {
   var onRunningTimeoutExpired: @MainActor (SupatermAgentKind, String, SupatermCLIContext?) -> Void = { _, _, _ in }
 
   private let agentRunningTimeout: Duration
-  private let claudeTasksHomeDirectoryURL: URL
   private let sleep: (Duration) async throws -> Void
   private let transcriptPollInterval: Duration
   private var foregroundSessionsBySurface: [SurfaceKey: String] = [:]
@@ -58,11 +57,9 @@ final class TerminalAgentSessionStore {
   init(
     agentRunningTimeout: Duration,
     transcriptPollInterval: Duration,
-    claudeTasksHomeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
     sleep: @escaping (Duration) async throws -> Void
   ) {
     self.agentRunningTimeout = agentRunningTimeout
-    self.claudeTasksHomeDirectoryURL = claudeTasksHomeDirectoryURL
     self.transcriptPollInterval = transcriptPollInterval
     self.sleep = sleep
   }
@@ -246,8 +243,6 @@ final class TerminalAgentSessionStore {
     case .claude:
       guard sessions[key] != nil else { return nil }
       return ClaudePanelMonitor(
-        sessionID: key.sessionID,
-        homeDirectoryURL: claudeTasksHomeDirectoryURL,
         transcriptPath: { [weak self] in self?.sessions[key]?.transcriptPath }
       )
     default:

--- a/apps/mac/supaterm/App/TerminalCommandExecutor.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor.swift
@@ -15,7 +15,6 @@ final class TerminalCommandExecutor {
     registry: TerminalWindowRegistry,
     agentRunningTimeout: Duration = .seconds(30),
     transcriptPollInterval: Duration = .seconds(1),
-    claudeTasksHomeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
     clock: C = ContinuousClock()
   ) {
     self.registry = registry
@@ -25,7 +24,6 @@ final class TerminalCommandExecutor {
     agentSessionStore = TerminalAgentSessionStore(
       agentRunningTimeout: agentRunningTimeout,
       transcriptPollInterval: transcriptPollInterval,
-      claudeTasksHomeDirectoryURL: claudeTasksHomeDirectoryURL,
       sleep: sleep
     )
     agentSessionStore.onMonitorSnapshot = { [weak self] snapshot, agent, sessionID, context in

--- a/apps/mac/supatermTests/ClaudeProgressFixtures.swift
+++ b/apps/mac/supatermTests/ClaudeProgressFixtures.swift
@@ -3,15 +3,6 @@ import Foundation
 @testable import supaterm
 
 enum ClaudeProgressFixtures {
-  static func makeHomeDirectory() throws -> URL {
-    let url = FileManager.default.temporaryDirectory.appendingPathComponent(
-      UUID().uuidString,
-      isDirectory: true
-    )
-    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-    return url
-  }
-
   static func makeTranscript() throws -> URL {
     let directoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(
       UUID().uuidString,
@@ -51,10 +42,8 @@ enum ClaudeProgressFixtures {
     subject: String,
     description: String = "",
     activeForm: String = "",
-    blockedBy: [String] = [],
     metadata: [String: Any]? = nil,
     taskID: String? = nil,
-    timestamp: String = "2026-05-26T15:47:17.000Z",
     to transcriptURL: URL
   ) throws {
     var input: [String: Any] = [
@@ -62,9 +51,6 @@ enum ClaudeProgressFixtures {
       "description": description,
       "activeForm": activeForm,
     ]
-    if !blockedBy.isEmpty {
-      input["blockedBy"] = blockedBy
-    }
     if let metadata {
       input["metadata"] = metadata
     }
@@ -74,7 +60,7 @@ enum ClaudeProgressFixtures {
     try appendLine(
       [
         "type": "assistant",
-        "timestamp": timestamp,
+        "timestamp": "2026-05-26T15:47:17.000Z",
         "message": [
           "content": [
             [
@@ -94,13 +80,12 @@ enum ClaudeProgressFixtures {
     toolUseID: String,
     taskID: String,
     subject: String,
-    timestamp: String = "2026-05-26T15:47:17.100Z",
     to transcriptURL: URL
   ) throws {
     try appendLine(
       [
         "type": "user",
-        "timestamp": timestamp,
+        "timestamp": "2026-05-26T15:47:17.100Z",
         "message": [
           "content": [
             [
@@ -125,9 +110,7 @@ enum ClaudeProgressFixtures {
     taskID: String,
     status: String,
     subject: String? = nil,
-    addBlockedBy: [String] = [],
     metadata: [String: Any]? = nil,
-    timestamp: String = "2026-05-26T15:47:18.000Z",
     to transcriptURL: URL
   ) throws {
     var input: [String: Any] = [
@@ -137,16 +120,13 @@ enum ClaudeProgressFixtures {
     if let subject {
       input["subject"] = subject
     }
-    if !addBlockedBy.isEmpty {
-      input["addBlockedBy"] = addBlockedBy
-    }
     if let metadata {
       input["metadata"] = metadata
     }
     try appendLine(
       [
         "type": "assistant",
-        "timestamp": timestamp,
+        "timestamp": "2026-05-26T15:47:18.000Z",
         "message": [
           "content": [
             [
@@ -164,13 +144,12 @@ enum ClaudeProgressFixtures {
 
   static func appendTaskReminder(
     _ tasks: [[String: Any]],
-    timestamp: String = "2026-05-26T15:50:27.000Z",
     to transcriptURL: URL
   ) throws {
     try appendLine(
       [
         "type": "attachment",
-        "timestamp": timestamp,
+        "timestamp": "2026-05-26T15:50:27.000Z",
         "attachment": [
           "type": "task_reminder",
           "content": tasks,
@@ -184,7 +163,6 @@ enum ClaudeProgressFixtures {
   static func appendGoalStatus(
     condition: String,
     met: Bool,
-    timestamp: String = "2026-06-14T14:24:06.660Z",
     to transcriptURL: URL
   ) throws {
     var attachment: [String: Any] = [
@@ -203,44 +181,11 @@ enum ClaudeProgressFixtures {
     try appendLine(
       [
         "type": "attachment",
-        "timestamp": timestamp,
+        "timestamp": "2026-06-14T14:24:06.660Z",
         "attachment": attachment,
       ],
       to: transcriptURL
     )
-  }
-
-  static func writeTask(
-    id: String,
-    subject: String,
-    status: String,
-    sessionID: String,
-    homeDirectoryURL: URL,
-    filename: String? = nil,
-    blockedBy: [String] = [],
-    metadata: [String: Any]? = nil
-  ) throws {
-    let taskDirectoryURL =
-      homeDirectoryURL
-      .appendingPathComponent(".claude", isDirectory: true)
-      .appendingPathComponent("tasks", isDirectory: true)
-      .appendingPathComponent(
-        ClaudeTaskProgressReader.sanitizedTaskListID(sessionID),
-        isDirectory: true
-      )
-    try FileManager.default.createDirectory(at: taskDirectoryURL, withIntermediateDirectories: true)
-    var object: [String: Any] = [
-      "id": id,
-      "subject": subject,
-      "status": status,
-      "blockedBy": blockedBy,
-    ]
-    if let metadata {
-      object["metadata"] = metadata
-    }
-    let url = taskDirectoryURL.appendingPathComponent(filename ?? "\(id).json")
-    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
-    try data.write(to: url)
   }
 
   private static func appendLine(

--- a/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
+++ b/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
@@ -5,140 +5,6 @@ import Testing
 
 struct ClaudeProgressMonitorTests {
   @Test
-  func taskFilesProduceProgressRows() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-2",
-      subject: "Wire panel rows",
-      status: "in_progress",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL,
-      filename: "2.json"
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Read tasks",
-      status: "completed",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL,
-      filename: "1.json"
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-internal",
-      subject: "Internal task",
-      status: "pending",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL,
-      filename: "3.json",
-      metadata: ["_internal": true]
-    )
-
-    #expect(
-      ClaudeTaskProgressReader.progressRows(
-        sessionID: "session:123",
-        homeDirectoryURL: homeDirectoryURL
-      ) == [
-        PaneAgentProgressRow(
-          id: "claude-task:task-1",
-          title: "Read tasks",
-          status: .completed
-        ),
-        PaneAgentProgressRow(
-          id: "claude-task:task-2",
-          title: "Wire panel rows",
-          status: .running
-        ),
-      ]
-    )
-  }
-
-  @Test
-  func taskFilesUseClaudeCodeCompactOrder() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let now = Date(timeIntervalSince1970: 1_700_000_000)
-
-    try ClaudeProgressFixtures.writeTask(
-      id: "1",
-      subject: "Blocked pending",
-      status: "pending",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL,
-      blockedBy: ["2"]
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "2",
-      subject: "Current task",
-      status: "in_progress",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "3",
-      subject: "Recent completion",
-      status: "completed",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "4",
-      subject: "Older completion",
-      status: "completed",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "5",
-      subject: "Available pending",
-      status: "pending",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    try setTaskModificationDate(
-      now.addingTimeInterval(-31),
-      id: "4",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
-    )
-
-    #expect(
-      ClaudeTaskProgressReader.progressRows(
-        sessionID: "session:123",
-        homeDirectoryURL: homeDirectoryURL,
-        now: now
-      ) == [
-        PaneAgentProgressRow(
-          id: "claude-task:3",
-          title: "Recent completion",
-          status: .completed
-        ),
-        PaneAgentProgressRow(
-          id: "claude-task:2",
-          title: "Current task",
-          status: .running
-        ),
-        PaneAgentProgressRow(
-          id: "claude-task:5",
-          title: "Available pending",
-          status: .pending
-        ),
-        PaneAgentProgressRow(
-          id: "claude-task:1",
-          title: "Blocked pending",
-          status: .pending
-        ),
-        PaneAgentProgressRow(
-          id: "claude-task:4",
-          title: "Older completion",
-          status: .completed
-        ),
-      ]
-    )
-  }
-
-  @Test
   func todoWriteTranscriptProducesProgressRows() throws {
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
@@ -244,9 +110,7 @@ struct ClaudeProgressMonitorTests {
 
   @MainActor
   @Test
-  func panelMonitorKeepsGoalRowWhenTaskFilesExist() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
+  func panelMonitorPrependsGoalRowToTaskRows() throws {
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
 
@@ -255,19 +119,19 @@ struct ClaudeProgressMonitorTests {
       met: false,
       to: transcriptURL
     )
-    try ClaudeProgressFixtures.writeTask(
-      id: "1",
-      subject: "Task file row",
-      status: "in_progress",
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL
+    try ClaudeProgressFixtures.appendTaskReminder(
+      [
+        [
+          "id": "1",
+          "subject": "Task row",
+          "status": "in_progress",
+          "blockedBy": [],
+        ]
+      ],
+      to: transcriptURL
     )
 
-    let monitor = ClaudePanelMonitor(
-      sessionID: "session:123",
-      homeDirectoryURL: homeDirectoryURL,
-      transcriptPath: { transcriptURL.path }
-    )
+    let monitor = ClaudePanelMonitor(transcriptPath: { transcriptURL.path })
     let tick = try #require(monitor.start())
 
     #expect(
@@ -280,7 +144,7 @@ struct ClaudeProgressMonitorTests {
         ),
         PaneAgentProgressRow(
           id: "claude-task:1",
-          title: "Task file row",
+          title: "Task row",
           status: .running
         ),
       ]
@@ -318,6 +182,59 @@ struct ClaudeProgressMonitorTests {
           title: "Wire transcript tasks",
           status: .running
         )
+      ]
+    )
+  }
+
+  @Test
+  func transcriptTasksKeepTaskIDOrderAcrossStatusChanges() throws {
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+    try ClaudeProgressFixtures.appendTaskReminder(
+      [
+        ["id": "1", "subject": "Phase A", "status": "completed", "blockedBy": []],
+        ["id": "2", "subject": "Phase B1", "status": "in_progress", "blockedBy": []],
+        ["id": "3", "subject": "Phase B2", "status": "pending", "blockedBy": []],
+        ["id": "10", "subject": "Phase C", "status": "pending", "blockedBy": []],
+      ],
+      to: transcriptURL
+    )
+    try ClaudeProgressFixtures.appendTaskUpdate(
+      taskID: "2",
+      status: "completed",
+      to: transcriptURL
+    )
+    try ClaudeProgressFixtures.appendTaskUpdate(
+      taskID: "3",
+      status: "in_progress",
+      to: transcriptURL
+    )
+
+    let result = ClaudeTranscriptProgressMonitor.start(at: transcriptURL.path)
+
+    #expect(
+      result.rows == [
+        PaneAgentProgressRow(
+          id: "claude-task:1",
+          title: "Phase A",
+          status: .completed
+        ),
+        PaneAgentProgressRow(
+          id: "claude-task:2",
+          title: "Phase B1",
+          status: .completed
+        ),
+        PaneAgentProgressRow(
+          id: "claude-task:3",
+          title: "Phase B2",
+          status: .running
+        ),
+        PaneAgentProgressRow(
+          id: "claude-task:10",
+          title: "Phase C",
+          status: .pending
+        ),
       ]
     )
   }
@@ -377,7 +294,6 @@ struct ClaudeProgressMonitorTests {
     )
     try ClaudeProgressFixtures.appendTaskReminder(
       [],
-      timestamp: "2026-05-26T15:50:28.000Z",
       to: transcriptURL
     )
 
@@ -425,23 +341,5 @@ struct ClaudeProgressMonitorTests {
 
     #expect(result.cursor.transcriptOffset == start.cursor.transcriptOffset)
     #expect(result.rows == nil)
-  }
-
-  private func setTaskModificationDate(
-    _ date: Date,
-    id: String,
-    sessionID: String,
-    homeDirectoryURL: URL
-  ) throws {
-    let taskURL =
-      homeDirectoryURL
-      .appendingPathComponent(".claude", isDirectory: true)
-      .appendingPathComponent("tasks", isDirectory: true)
-      .appendingPathComponent(
-        ClaudeTaskProgressReader.sanitizedTaskListID(sessionID),
-        isDirectory: true
-      )
-      .appendingPathComponent("\(id).json")
-    try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: taskURL.path)
   }
 }

--- a/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
@@ -165,162 +165,13 @@ struct TerminalAgentSessionStoreTests {
   }
 
   @Test
-  func beginClaudePanelTrackingPublishesTaskSnapshot() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let events = SessionStoreEventsSpy()
-    let store = TerminalAgentSessionStore(
-      agentRunningTimeout: .seconds(5),
-      transcriptPollInterval: .seconds(1),
-      claudeTasksHomeDirectoryURL: homeDirectoryURL,
-      sleep: { _ in }
-    )
-    events.bind(to: store)
-    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Read task files",
-      status: "in_progress",
-      sessionID: "session-1",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    store.beginSession(
-      agent: .claude,
-      sessionID: "session-1",
-      context: context,
-      transcriptPath: nil
-    )
-
-    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
-    #expect(
-      events.panelSnapshots == [
-        AgentMonitorSnapshot(
-          progressRows: [
-            PaneAgentProgressRow(
-              id: "claude-task:task-1",
-              title: "Read task files",
-              status: .running
-            )
-          ]
-        )
-      ]
-    )
-  }
-
-  @Test
-  func beginClaudePanelTrackingPollsTaskChanges() async throws {
-    let clock = TestClock()
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let events = SessionStoreEventsSpy()
-    let store = TerminalAgentSessionStore(
-      agentRunningTimeout: .seconds(5),
-      transcriptPollInterval: .seconds(1),
-      claudeTasksHomeDirectoryURL: homeDirectoryURL,
-      sleep: { duration in
-        try await clock.sleep(for: duration)
-      }
-    )
-    events.bind(to: store)
-    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
-    store.beginSession(
-      agent: .claude,
-      sessionID: "session-1",
-      context: context,
-      transcriptPath: nil
-    )
-
-    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
-    #expect(events.panelSnapshots == [AgentMonitorSnapshot()])
-
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Refresh tasks",
-      status: "completed",
-      sessionID: "session-1",
-      homeDirectoryURL: homeDirectoryURL
-    )
-
-    await flushEffects()
-    await clock.advance(by: .seconds(1))
-    await flushEffects()
-
-    #expect(
-      events.panelSnapshots.last
-        == AgentMonitorSnapshot(
-          progressRows: [
-            PaneAgentProgressRow(
-              id: "claude-task:task-1",
-              title: "Refresh tasks",
-              status: .completed
-            )
-          ]
-        )
-    )
-  }
-
-  @Test
-  func beginClaudePanelTrackingUsesTasksBeforeTodoTranscript() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
+  func beginClaudePanelTrackingPublishesTranscriptTaskSnapshot() throws {
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
     let events = SessionStoreEventsSpy()
     let store = TerminalAgentSessionStore(
       agentRunningTimeout: .seconds(5),
       transcriptPollInterval: .seconds(1),
-      claudeTasksHomeDirectoryURL: homeDirectoryURL,
-      sleep: { _ in }
-    )
-    events.bind(to: store)
-    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
-    try ClaudeProgressFixtures.appendTodoWrite(
-      [
-        ["content": "Transcript row", "status": "in_progress"]
-      ],
-      to: transcriptURL
-    )
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Task row",
-      status: "pending",
-      sessionID: "session-1",
-      homeDirectoryURL: homeDirectoryURL
-    )
-    store.beginSession(
-      agent: .claude,
-      sessionID: "session-1",
-      context: context,
-      transcriptPath: transcriptURL.path
-    )
-
-    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
-    #expect(
-      events.panelSnapshots == [
-        AgentMonitorSnapshot(
-          progressRows: [
-            PaneAgentProgressRow(
-              id: "claude-task:task-1",
-              title: "Task row",
-              status: .pending
-            )
-          ]
-        )
-      ]
-    )
-  }
-
-  @Test
-  func beginClaudePanelTrackingUsesTranscriptTasksWhenTaskFilesAreEmpty() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
-    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
-    let events = SessionStoreEventsSpy()
-    let store = TerminalAgentSessionStore(
-      agentRunningTimeout: .seconds(5),
-      transcriptPollInterval: .seconds(1),
-      claudeTasksHomeDirectoryURL: homeDirectoryURL,
       sleep: { _ in }
     )
     events.bind(to: store)
@@ -362,15 +213,12 @@ struct TerminalAgentSessionStoreTests {
   @Test
   func beginClaudePanelTrackingPollsTranscriptTaskChanges() async throws {
     let clock = TestClock()
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
     let events = SessionStoreEventsSpy()
     let store = TerminalAgentSessionStore(
       agentRunningTimeout: .seconds(5),
       transcriptPollInterval: .seconds(1),
-      claudeTasksHomeDirectoryURL: homeDirectoryURL,
       sleep: { duration in
         try await clock.sleep(for: duration)
       }

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -39,26 +39,39 @@ struct TerminalCommandExecutorAgentHookTests {
   }
   @Test
   func claudeSessionStartStoresTaskProgressRows() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Wire progress rows",
-      status: "in_progress",
-      sessionID: ClaudeHookFixtures.sessionID,
-      homeDirectoryURL: homeDirectoryURL
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    try ClaudeProgressFixtures.appendTaskReminder(
+      [
+        [
+          "id": "1",
+          "subject": "Wire progress rows",
+          "status": "in_progress",
+          "blockedBy": [],
+        ]
+      ],
+      to: transcriptURL
     )
-    let harness = try makeClaudeHookHarness(claudeTasksHomeDirectoryURL: homeDirectoryURL)
+    let harness = try makeClaudeHookHarness()
 
     _ = try harness.commandExecutor.handleAgentHook(
-      ClaudeHookFixtures.request(ClaudeHookFixtures.sessionStart, context: harness.context)
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          cwd: ClaudeHookFixtures.cwd,
+          hookEventName: .sessionStart,
+          sessionID: ClaudeHookFixtures.sessionID,
+          transcriptPath: transcriptURL.path
+        )
+      )
     )
 
     #expect(harness.host.agentActivity(for: harness.tabID) == nil)
     #expect(
       harness.host.agentPanelPresentation(for: harness.context.surfaceID)?.progressRows == [
         PaneAgentProgressRow(
-          id: "claude-task:task-1",
+          id: "claude-task:1",
           title: "Wire progress rows",
           status: .running
         )
@@ -368,19 +381,32 @@ struct TerminalCommandExecutorAgentHookTests {
   }
   @Test
   func claudeSessionEndClearsTaskProgressRows() throws {
-    let homeDirectoryURL = try ClaudeProgressFixtures.makeHomeDirectory()
-    defer { try? FileManager.default.removeItem(at: homeDirectoryURL) }
-    try ClaudeProgressFixtures.writeTask(
-      id: "task-1",
-      subject: "Wire progress rows",
-      status: "completed",
-      sessionID: ClaudeHookFixtures.sessionID,
-      homeDirectoryURL: homeDirectoryURL
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    try ClaudeProgressFixtures.appendTaskReminder(
+      [
+        [
+          "id": "1",
+          "subject": "Wire progress rows",
+          "status": "completed",
+          "blockedBy": [],
+        ]
+      ],
+      to: transcriptURL
     )
-    let harness = try makeClaudeHookHarness(claudeTasksHomeDirectoryURL: homeDirectoryURL)
+    let harness = try makeClaudeHookHarness()
 
     _ = try harness.commandExecutor.handleAgentHook(
-      ClaudeHookFixtures.request(ClaudeHookFixtures.sessionStart, context: harness.context)
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          cwd: ClaudeHookFixtures.cwd,
+          hookEventName: .sessionStart,
+          sessionID: ClaudeHookFixtures.sessionID,
+          transcriptPath: transcriptURL.path
+        )
+      )
     )
     #expect(harness.host.agentPanelPresentation(for: harness.context.surfaceID) != nil)
 

--- a/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
@@ -83,7 +83,6 @@ func agentHookRequest(
 func makeClaudeHookHarness<C: Clock<Duration>>(
   agentRunningTimeout: Duration = .seconds(15),
   transcriptPollInterval: Duration = .seconds(1),
-  claudeTasksHomeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
   clock: C = ContinuousClock(),
   windowActivity: WindowActivityState = WindowActivityState(isKeyWindow: true, isVisible: true)
 ) throws -> ClaudeHookHarness {
@@ -94,7 +93,6 @@ func makeClaudeHookHarness<C: Clock<Duration>>(
     registry: registry,
     agentRunningTimeout: agentRunningTimeout,
     transcriptPollInterval: transcriptPollInterval,
-    claudeTasksHomeDirectoryURL: claudeTasksHomeDirectoryURL,
     clock: clock
   )
   let host = TerminalHostState()
@@ -151,14 +149,12 @@ func makeCommandExecutor<C: Clock<Duration>>(
   registry: TerminalWindowRegistry,
   agentRunningTimeout: Duration,
   transcriptPollInterval: Duration,
-  claudeTasksHomeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
   clock: C
 ) -> TerminalCommandExecutor {
   let commandExecutor = TerminalCommandExecutor(
     registry: registry,
     agentRunningTimeout: agentRunningTimeout,
     transcriptPollInterval: transcriptPollInterval,
-    claudeTasksHomeDirectoryURL: claudeTasksHomeDirectoryURL,
     clock: clock
   )
   registry.commandExecutor = commandExecutor

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -111,12 +111,9 @@ The app binds Claude sessions to pane surfaces, tracks the foreground session fo
 - `SessionEnd` clears the tab activity and drops the stored session state.
 - A command-finished signal from the shell clears pane-bound agent sessions and presence.
 
-The panel monitor reads Claude task progress from:
+The panel monitor reads Claude task progress from the hook `transcript_path`.
 
-- `~/.claude/tasks/<sanitized-session-id>/*.json`
-- the hook `transcript_path` when one is present
-
-The monitor understands task reminders, `TaskCreate`, `TaskUpdate`, `TodoWrite`, and goal status records. It filters internal task rows and keeps recently completed rows visible briefly.
+The monitor understands task reminders, `TaskCreate`, `TaskUpdate`, `TodoWrite`, and goal status records. It filters internal task rows and orders tasks by task ID, matching how Claude Code renders its own task list.
 
 ## Codex
 


### PR DESCRIPTION
## Describe your changes

The agent panel showed Claude tasks in a scrambled order. It re-sorted rows into recently-completed / running / pending / stale buckets — an ordering Claude Code only applies when its on-screen list overflows — and evaluated the 30-second "recently completed" window with a clock captured at transcript-parse time, so whatever arrangement existed at the last task event stuck indefinitely.

- Order panel rows by task ID, matching Claude Code's own task list rendering
- Drop the `~/.claude/tasks/<session-id>/*.json` reader; current Claude Code names that directory differently and leaves it empty, so the hook transcript is the only progress source

## Additional details

Manual test: start a Claude session with tasks in Supaterm, complete a middle task — the panel keeps creation order instead of pinning the just-completed task on top.
