### PR TITLE
[fix] Persist terminal layout when quit terminates sessions

### DIFF
--- a/apps/mac/supaterm/App/SessionPersistenceState.swift
+++ b/apps/mac/supaterm/App/SessionPersistenceState.swift
@@ -4,24 +4,25 @@ enum SessionPersistenceState: Equatable {
   case active
   case restoring
   case quitting(TerminalSessionCatalog)
-  case quittingAfterSessionTermination
+  case quittingAfterSessionTermination(TerminalSessionCatalog)
 
   var allowsLiveSave: Bool {
     self == .active
   }
 
   var shortCircuitsTerminateReply: Bool {
-    self == .quittingAfterSessionTermination
+    if case .quittingAfterSessionTermination = self {
+      return true
+    }
+    return false
   }
 
   func catalogToPersist(liveCatalog: TerminalSessionCatalog) -> TerminalSessionCatalog {
     switch self {
     case .active, .restoring:
       return liveCatalog
-    case .quitting(let catalog):
+    case .quitting(let catalog), .quittingAfterSessionTermination(let catalog):
       return catalog
-    case .quittingAfterSessionTermination:
-      return .default
     }
   }
 
@@ -31,6 +32,8 @@ enum SessionPersistenceState: Equatable {
     liveCatalog: TerminalSessionCatalog
   ) -> Self {
     guard reply == .terminateNow else { return .active }
-    return terminatesSessions ? .quittingAfterSessionTermination : .quitting(liveCatalog)
+    return terminatesSessions
+      ? .quittingAfterSessionTermination(liveCatalog)
+      : .quitting(liveCatalog)
   }
 }

--- a/apps/mac/supatermTests/SessionPersistenceStateTests.swift
+++ b/apps/mac/supatermTests/SessionPersistenceStateTests.swift
@@ -40,17 +40,17 @@ struct SessionPersistenceStateTests {
   }
 
   @Test
-  func quitTerminatingSessionsPersistsDefaultCatalogAndShortCircuits() {
+  func quitTerminatingSessionsFreezesLiveCatalogAndShortCircuits() {
     let state = SessionPersistenceState.afterTerminationDecision(
       reply: .terminateNow,
       terminatesSessions: true,
       liveCatalog: liveCatalog
     )
 
-    #expect(state == .quittingAfterSessionTermination)
+    #expect(state == .quittingAfterSessionTermination(liveCatalog))
     #expect(!state.allowsLiveSave)
     #expect(state.shortCircuitsTerminateReply)
-    #expect(state.catalogToPersist(liveCatalog: liveCatalog) == .default)
+    #expect(state.catalogToPersist(liveCatalog: TerminalSessionCatalog(windows: [])) == liveCatalog)
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

With zmx sessions disabled, every quit becomes a terminate-sessions quit, which wiped `session.json` to `windows: []` — so Restore Terminal Layout had nothing to restore at launch. `.quittingAfterSessionTermination` now freezes the live catalog exactly like `.quitting`: terminating sessions kills the shells, but the tab/split/cwd layout still restores with fresh ones.

Closes #61

## Additional details

- Manual test: disable zmx sessions, keep Restore Terminal Layout on, open tabs and splits, Cmd+Q, relaunch — the layout comes back.
