### PR TITLE
[fix] Keep Claude sidebar spinner alive via transcript heartbeat

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermClaudeHookSettings.swift
+++ b/apps/mac/SupatermCLIShared/SupatermClaudeHookSettings.swift
@@ -30,6 +30,7 @@ public enum SupatermClaudeHookSettings {
   private struct Settings: Encodable {
     let hooks: [String: [HookGroup]] = [
       "Notification": [.init(matcher: "", hooks: [.init(command: command, timeout: 10)])],
+      "PostToolUse": [.init(matcher: "", hooks: [.init(command: command, timeout: 5, isAsync: true)])],
       "PreToolUse": [.init(matcher: "", hooks: [.init(command: command, timeout: 5, isAsync: true)])],
       "SessionEnd": [.init(matcher: "", hooks: [.init(command: command, timeout: 1)])],
       "SessionStart": [.init(matcher: "", hooks: [.init(command: command, timeout: 10)])],

--- a/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
+++ b/apps/mac/supaterm/App/TerminalAgentSessionStore.swift
@@ -218,10 +218,15 @@ final class TerminalAgentSessionStore {
     let interval = transcriptPollInterval
     let sleep = self.sleep
     agentPanelMonitorTasks[key] = Task { [weak self] in
+      var transcriptSize = self?.transcriptFileSize(key: key)
       while !Task.isCancelled {
         try? await sleep(interval)
         guard !Task.isCancelled else { return }
         guard let self, self.sessions[key] != nil else { return }
+        if let size = self.transcriptFileSize(key: key), size != transcriptSize {
+          transcriptSize = size
+          self.extendRunningTimeoutIfArmed(agent: agent, sessionID: sessionID, context: context)
+        }
         guard let tick = monitor.poll() else { continue }
         self.handleMonitorTick(tick, key: key, sessionID: sessionID, context: context)
         if tick.isFinal {
@@ -300,6 +305,21 @@ final class TerminalAgentSessionStore {
     let key = SessionKey(agent: agent, sessionID: sessionID)
     runningTimeoutTasks[key]?.cancel()
     runningTimeoutTasks.removeValue(forKey: key)
+  }
+
+  private func extendRunningTimeoutIfArmed(
+    agent: SupatermAgentKind,
+    sessionID: String,
+    context: SupatermCLIContext?
+  ) {
+    guard runningTimeoutTasks[SessionKey(agent: agent, sessionID: sessionID)] != nil else { return }
+    armRunningTimeout(agent: agent, sessionID: sessionID, context: context)
+  }
+
+  private func transcriptFileSize(key: SessionKey) -> UInt64? {
+    guard let path = sessions[key]?.transcriptPath else { return nil }
+    let values = try? URL(fileURLWithPath: path).resourceValues(forKeys: [.fileSizeKey])
+    return values?.fileSize.map(UInt64.init)
   }
 
   private func handleRunningTimeoutExpiry(

--- a/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
+++ b/apps/mac/supatermTests/ClaudeSettingsInstallerTests.swift
@@ -14,7 +14,10 @@ struct ClaudeSettingsInstallerTests {
     let object = try settingsObject(homeDirectoryURL: homeDirectoryURL)
     let hooks = try #require(object["hooks"] as? [String: Any])
     #expect(
-      Set(hooks.keys) == ["Notification", "PreToolUse", "SessionEnd", "SessionStart", "Stop", "UserPromptSubmit"])
+      Set(hooks.keys) == [
+        "Notification", "PostToolUse", "PreToolUse", "SessionEnd", "SessionStart", "Stop",
+        "UserPromptSubmit",
+      ])
   }
 
   @Test

--- a/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
+++ b/apps/mac/supatermTests/SupatermClaudeHookSettingsTests.swift
@@ -21,8 +21,13 @@ struct SupatermClaudeHookSettingsTests {
     let hooks = try #require(object?["hooks"] as? [String: [[String: Any]]])
 
     #expect(
-      Set(hooks.keys) == ["Notification", "PreToolUse", "SessionEnd", "SessionStart", "Stop", "UserPromptSubmit"])
+      Set(hooks.keys) == [
+        "Notification", "PostToolUse", "PreToolUse", "SessionEnd", "SessionStart", "Stop",
+        "UserPromptSubmit",
+      ])
     #expect(try commandHook(in: hooks, event: "Notification")["timeout"] as? Int == 10)
+    #expect(try commandHook(in: hooks, event: "PostToolUse")["timeout"] as? Int == 5)
+    #expect(try commandHook(in: hooks, event: "PostToolUse")["async"] as? Bool == true)
     #expect(try commandHook(in: hooks, event: "PreToolUse")["timeout"] as? Int == 5)
     #expect(try commandHook(in: hooks, event: "PreToolUse")["async"] as? Bool == true)
     #expect(try commandHook(in: hooks, event: "SessionEnd")["timeout"] as? Int == 1)

--- a/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentSessionStoreTests.swift
@@ -265,6 +265,130 @@ struct TerminalAgentSessionStoreTests {
     )
   }
 
+  @Test
+  func transcriptGrowthExtendsArmedRunningTimeout() async throws {
+    let clock = TestClock()
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    let events = SessionStoreEventsSpy()
+    let store = TerminalAgentSessionStore(
+      agentRunningTimeout: .seconds(3),
+      transcriptPollInterval: .seconds(1),
+      sleep: { duration in
+        try await clock.sleep(for: duration)
+      }
+    )
+    events.bind(to: store)
+    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
+    store.beginSession(
+      agent: .claude,
+      sessionID: "session-1",
+      context: context,
+      transcriptPath: transcriptURL.path
+    )
+    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
+    store.armRunningTimeout(agent: .claude, sessionID: "session-1", context: context)
+    await flushEffects()
+
+    for toolUseID in ["toolu_1", "toolu_2"] {
+      try ClaudeProgressFixtures.appendTaskCreate(
+        toolUseID: toolUseID,
+        subject: "Heartbeat line",
+        to: transcriptURL
+      )
+      await clock.advance(by: .seconds(1))
+      await flushEffects()
+    }
+    await clock.advance(by: .seconds(2))
+    await flushEffects()
+
+    #expect(events.expirations.isEmpty)
+  }
+
+  @Test
+  func transcriptGrowthDoesNotRearmCancelledRunningTimeout() async throws {
+    let clock = TestClock()
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    let events = SessionStoreEventsSpy()
+    let store = TerminalAgentSessionStore(
+      agentRunningTimeout: .seconds(3),
+      transcriptPollInterval: .seconds(1),
+      sleep: { duration in
+        try await clock.sleep(for: duration)
+      }
+    )
+    events.bind(to: store)
+    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
+    store.beginSession(
+      agent: .claude,
+      sessionID: "session-1",
+      context: context,
+      transcriptPath: transcriptURL.path
+    )
+    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
+    store.armRunningTimeout(agent: .claude, sessionID: "session-1", context: context)
+    await flushEffects()
+    store.cancelRunningTimeout(agent: .claude, sessionID: "session-1")
+
+    try ClaudeProgressFixtures.appendTaskCreate(
+      toolUseID: "toolu_1",
+      subject: "Heartbeat line",
+      to: transcriptURL
+    )
+    for _ in 0..<5 {
+      await clock.advance(by: .seconds(1))
+      await flushEffects()
+    }
+
+    #expect(events.expirations.isEmpty)
+  }
+
+  @Test
+  func runningTimeoutExpiresAfterTranscriptGoesQuiet() async throws {
+    let clock = TestClock()
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    let events = SessionStoreEventsSpy()
+    let store = TerminalAgentSessionStore(
+      agentRunningTimeout: .seconds(3),
+      transcriptPollInterval: .seconds(1),
+      sleep: { duration in
+        try await clock.sleep(for: duration)
+      }
+    )
+    events.bind(to: store)
+    let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
+    store.beginSession(
+      agent: .claude,
+      sessionID: "session-1",
+      context: context,
+      transcriptPath: transcriptURL.path
+    )
+    #expect(store.beginAgentPanelTracking(agent: .claude, sessionID: "session-1", context: context))
+    store.armRunningTimeout(agent: .claude, sessionID: "session-1", context: context)
+    await flushEffects()
+
+    try ClaudeProgressFixtures.appendTaskCreate(
+      toolUseID: "toolu_1",
+      subject: "Heartbeat line",
+      to: transcriptURL
+    )
+    await clock.advance(by: .seconds(1))
+    await flushEffects()
+    await clock.advance(by: .seconds(2))
+    await flushEffects()
+
+    #expect(events.expirations.isEmpty)
+
+    await clock.advance(by: .seconds(1))
+    await flushEffects()
+
+    #expect(events.expirations.count == 1)
+    #expect(events.expirations.first?.0 == .claude)
+    #expect(events.expirations.first?.1 == "session-1")
+  }
+
   private func flushEffects() async {
     for _ in 0..<5 {
       await Task.yield()

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -96,18 +96,19 @@ Installed hooks invoke `sp agent receive-agent-hook --agent <agent>`:
 ## Claude
 
 - Settings file: `~/.claude/settings.json`.
-- Installed hook events: `SessionStart`, `PreToolUse`, `Notification`, `UserPromptSubmit`, `Stop`, `SessionEnd`.
+- Installed hook events: `SessionStart`, `PreToolUse`, `PostToolUse`, `Notification`, `UserPromptSubmit`, `Stop`, `SessionEnd`.
 
 ### App Behavior
 
 The app binds Claude sessions to pane surfaces, tracks the foreground session for each pane, and turns Claude hook events into tab activity.
 
 - `SessionStart` binds the session to the current pane surface, registers agent presence, and starts panel monitoring.
-- `PreToolUse` marks the tab as `running`.
+- `PreToolUse` and `PostToolUse` mark the tab as `running`.
 - `Notification` marks the tab as `needs input` and may trigger a notification.
 - `UserPromptSubmit` marks the tab as `running`.
-- `PreToolUse` and `UserPromptSubmit` recover the pane binding when `SessionStart` was missed or announced a different session ID, which is what `claude --fork-session --resume` does: its `SessionStart` reports the parent session ID and every later hook carries the forked one.
+- `PreToolUse`, `PostToolUse`, and `UserPromptSubmit` recover the pane binding when `SessionStart` was missed or announced a different session ID, which is what `claude --fork-session --resume` does: its `SessionStart` reports the parent session ID and every later hook carries the forked one.
 - `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided.
+- While the tab is `running`, transcript growth observed by the panel monitor's poll re-arms the running timeout, so long tool calls and streaming responses do not flip the tab to `idle` between hooks.
 - `SessionEnd` clears the tab activity and drops the stored session state.
 - A command-finished signal from the shell clears pane-bound agent sessions and presence.
 


### PR DESCRIPTION
## Describe your changes

The sidebar spinner for Claude panes died mid-turn: `.running` is set only by hook events, each arming a 30s timeout, so any hook gap longer than 30s (multi-minute Bash calls, long streaming) flipped the tab to `idle` while Claude was still working.

- The panel monitor's poll loop now treats transcript growth as a heartbeat that re-arms the running timeout — only while one is armed, so Stop/Notification/expiry still win and the timeout still fires once the transcript goes quiet
- Install the `PostToolUse` hook (mirrors `PreToolUse`; the app already handled it), restoring `running` the moment a long tool call finishes

## Additional details

Manual test: run a Claude turn with a long Bash call (e.g. `sleep 60`) — the sidebar spinner now stays up through the call instead of vanishing after 30s. Existing installs pick up `PostToolUse` automatically on next app launch.
