### PR TITLE
test: shared-instance E2E architecture and app.quit seam

### DIFF
--- a/apps/mac/SupatermCLIShared/SupatermSocketProtocol.swift
+++ b/apps/mac/SupatermCLIShared/SupatermSocketProtocol.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum SupatermSocketMethod {
   public static let appOnboarding = "app.onboarding"
   public static let appDebug = "app.debug"
+  public static let appQuit = "app.quit"
   public static let appTree = "app.tree"
   public static let systemIdentity = "system.identity"
   public static let systemPing = "system.ping"
@@ -125,6 +126,10 @@ public struct SupatermSocketRequest: Equatable, Sendable, Codable {
 
   public static func onboarding(id: String = UUID().uuidString) -> Self {
     Self(id: id, method: SupatermSocketMethod.appOnboarding)
+  }
+
+  public static func quit(id: String = UUID().uuidString) -> Self {
+    Self(id: id, method: SupatermSocketMethod.appQuit)
   }
 
   public static func debug(

--- a/apps/mac/supaterm/App/AppDelegate.swift
+++ b/apps/mac/supaterm/App/AppDelegate.swift
@@ -58,6 +58,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
   )
   private var settingsWindowController: SettingsWindowController?
+  private var bypassesConfirmationForNextQuit = false
   private var sessionPersistenceState = SessionPersistenceState.active
   private var terminatesSessionsForNextQuit = false
   private var toggleVisibilityState: ToggleVisibilityState?
@@ -96,6 +97,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       terminalWindowRegistry?.globalKeybindRuntimes() ?? []
     }
     terminalWindowRegistry.commandExecutor = terminalCommandExecutor
+    terminalCommandExecutor.onQuitRequested = { [weak self] in
+      self?.performSocketQuit()
+    }
     terminalWindowRegistry.onChange = { [weak menuController, weak globalKeybindManager] in
       menuController?.refresh()
       globalKeybindManager?.refresh()
@@ -205,13 +209,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
     let terminatesSessionsForNextQuit = self.terminatesSessionsForNextQuit
     self.terminatesSessionsForNextQuit = false
+    let bypassesConfirmationForNextQuit = self.bypassesConfirmationForNextQuit
+    self.bypassesConfirmationForNextQuit = false
     let terminatesSessionsOnQuit = terminatesSessionsForNextQuit || supatermSettings.terminatesSessionsOnQuit
     let terminationPlan = Self.terminationPlan(
       hasVisibleAppWindows: NSApp.windows.contains(where: \.isVisible),
       confirmQuitMode: supatermSettings.confirmQuitMode,
       hasActiveAgentWorkForQuit: terminalWindowRegistry.hasActiveAgentWorkForQuit,
       needsQuitConfirmation: terminalWindowRegistry.needsQuitConfirmation,
-      bypassesQuitConfirmation: terminatesSessionsForNextQuit || terminalWindowRegistry.bypassesQuitConfirmation,
+      bypassesQuitConfirmation: terminatesSessionsForNextQuit
+        || bypassesConfirmationForNextQuit
+        || terminalWindowRegistry.bypassesQuitConfirmation,
       terminatesSessionsOnQuit: terminatesSessionsOnQuit
     ) {
       quitConfirmationPresenter.confirmQuit(terminatesSessions: terminatesSessionsOnQuit)
@@ -236,11 +244,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     return reply
   }
 
+  private func activateForWindowPresentation() {
+    guard !AppBuild.isTestMode else { return }
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  private func performSocketQuit() {
+    bypassesConfirmationForNextQuit = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
+      NSApp.terminate(nil)
+    }
+  }
+
   @discardableResult
   func performNewWindow() -> Bool {
     let controller = createWindow()
     AppPostHog.capture("window_created")
-    NSApp.activate(ignoringOtherApps: true)
+    activateForWindowPresentation()
     controller.window?.makeKeyAndOrderFront(nil)
     return true
   }
@@ -282,7 +302,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     let state = toggleVisibilityState
-    NSApp.activate(ignoringOtherApps: true)
+    activateForWindowPresentation()
     if let state {
       state.restore()
       toggleVisibilityState = nil
@@ -328,7 +348,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     sessionPersistenceState = .active
     saveSession()
     if let window = lastController?.window {
-      NSApp.activate(ignoringOtherApps: true)
+      activateForWindowPresentation()
       window.makeKeyAndOrderFront(nil)
     }
   }
@@ -409,7 +429,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
   private func openServiceTabs(workingDirectoryPaths: [String]) {
     guard let firstPath = workingDirectoryPaths.first else { return }
-    NSApp.activate(ignoringOtherApps: true)
+    activateForWindowPresentation()
 
     guard terminalWindowRegistry.createTabInPreferredWindow(workingDirectoryPath: firstPath) else {
       let controller = createWindow()
@@ -428,7 +448,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
   private func openServiceWindows(workingDirectoryPaths: [String]) {
     guard !workingDirectoryPaths.isEmpty else { return }
-    NSApp.activate(ignoringOtherApps: true)
+    activateForWindowPresentation()
 
     for path in workingDirectoryPaths {
       let controller = createWindow()
@@ -465,7 +485,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       if window.isMiniaturized {
         window.deminiaturize(nil)
       }
-      NSApp.activate(ignoringOtherApps: true)
+      activateForWindowPresentation()
       window.makeKeyAndOrderFront(nil)
       return true
     }

--- a/apps/mac/supaterm/App/TerminalCommandExecutor.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor.swift
@@ -10,6 +10,7 @@ import SupatermTerminalCore
 final class TerminalCommandExecutor {
   let agentSessionStore: TerminalAgentSessionStore
   unowned let registry: TerminalWindowRegistry
+  var onQuitRequested: (() -> Void)?
 
   init<C: Clock<Duration>>(
     registry: TerminalWindowRegistry,
@@ -46,6 +47,9 @@ final class TerminalCommandExecutor {
       return .notify(try notify(notifyRequest))
     case .agentHook(let hookRequest):
       return .agentHook(try handleAgentHook(hookRequest))
+    case .quit:
+      onQuitRequested?()
+      return .quit
     }
   }
 

--- a/apps/mac/supaterm/SocketFeature/SocketControlFeature+App.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketControlFeature+App.swift
@@ -32,6 +32,13 @@ extension SocketControlFeature {
       }
       return try .ok(id: request.id, encodableResult: snapshot)
 
+    case SupatermSocketMethod.appQuit:
+      let result = try await socketRequestExecutor.executeApp(.quit)
+      guard case .quit = result else {
+        throw SocketExecutorError.unexpectedResult
+      }
+      return .ok(id: request.id)
+
     default:
       return nil
     }

--- a/apps/mac/supaterm/SocketFeature/SocketRequestExecutor.swift
+++ b/apps/mac/supaterm/SocketFeature/SocketRequestExecutor.swift
@@ -9,6 +9,7 @@ public struct SocketRequestExecutor: Sendable {
     case treeSnapshot
     case notify(TerminalNotifyRequest)
     case agentHook(SupatermAgentHookRequest)
+    case quit
   }
 
   public enum AppResult: Sendable {
@@ -17,6 +18,7 @@ public struct SocketRequestExecutor: Sendable {
     case treeSnapshot(SupatermTreeSnapshot)
     case notify(SupatermNotifyResult)
     case agentHook(TerminalAgentHookResult)
+    case quit
   }
 
   public enum TerminalCreationRequest: Sendable {
@@ -149,6 +151,8 @@ extension SocketRequestExecutor: DependencyKey {
         throw TerminalCreatePaneError.creationFailed
       case .agentHook:
         return .agentHook(TerminalAgentHookResult(desktopNotification: nil))
+      case .quit:
+        return .quit
       }
     },
     executeTerminalCreation: { request in

--- a/apps/mac/supaterm/Support/AppBuild.swift
+++ b/apps/mac/supaterm/Support/AppBuild.swift
@@ -17,6 +17,10 @@ public enum AppBuild {
     #endif
   }
 
+  public nonisolated static var isTestMode: Bool {
+    ProcessInfo.processInfo.environment["SUPATERM_TEST_MODE"] == "1"
+  }
+
   public nonisolated static var version: String {
     infoString("CFBundleShortVersionString")
   }

--- a/apps/mac/supatermE2E/SupatermE2EApp.swift
+++ b/apps/mac/supatermE2E/SupatermE2EApp.swift
@@ -12,7 +12,7 @@ struct SupatermE2EError: Error, CustomStringConvertible {
   }
 }
 
-final class SupatermE2EApp {
+final class SupatermE2EApp: @unchecked Sendable {
   let stateHome: URL
   private let process: Process
   private let client: SPSocketClient
@@ -53,6 +53,7 @@ final class SupatermE2EApp {
       "LOGNAME": NSUserName(),
       "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
       "SHELL": "/bin/zsh",
+      "SUPATERM_TEST_MODE": "1",
       "USER": NSUserName(),
       "ZMX_DIR": zmxDirectory.path,
       SupatermCLIEnvironment.instanceNameKey: instanceName,
@@ -92,6 +93,10 @@ final class SupatermE2EApp {
       )
     }
     return try response.decodeResult(type)
+  }
+
+  func debugSnapshot() throws -> SupatermAppDebugSnapshot {
+    try send(.debug(SupatermDebugRequest()), as: SupatermAppDebugSnapshot.self)
   }
 
   func capture(_ target: SupatermPaneTargetRequest) throws -> String {

--- a/apps/mac/supatermE2E/SupatermE2ESuite.swift
+++ b/apps/mac/supatermE2E/SupatermE2ESuite.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SupatermCLIShared
+import Testing
+
+@Suite(.serialized) enum SupatermE2ESuite {}
+
+let hermeticShellStartupCommand = "exec /bin/zsh -f"
+
+private nonisolated(unsafe) var sharedAppAtExit: SupatermE2EApp?
+
+enum SharedApp {
+  private static let launchTask = Task<SupatermE2EApp, Error> {
+    let app = try await SupatermE2EApp.launch()
+    sharedAppAtExit = app
+    atexit {
+      sharedAppAtExit?.terminate()
+    }
+    return app
+  }
+
+  static func current() async throws -> SupatermE2EApp {
+    try await launchTask.value
+  }
+}
+
+struct TestSpace {
+  let token: String
+  let directory: URL
+  let spaceID: UUID
+  let tab: SupatermNewTabResult
+
+  var pane: SupatermPaneTargetRequest {
+    SupatermPaneTargetRequest(contextPaneID: tab.paneID)
+  }
+}
+
+func withTestSpace<T>(
+  _ body: (SupatermE2EApp, TestSpace) async throws -> T
+) async throws -> T {
+  let app = try await SharedApp.current()
+  let space = try makeTestSpace(app)
+  defer { try? closeTestSpace(app, spaceID: space.spaceID) }
+  return try await body(app, space)
+}
+
+private func makeTestSpace(_ app: SupatermE2EApp) throws -> TestSpace {
+  let token = String(UUID().uuidString.prefix(8).lowercased())
+  let snapshot = try app.debugSnapshot()
+  guard let window = snapshot.windows.first else {
+    throw SupatermE2EError("No app window is available for a test space.")
+  }
+
+  let directory = app.stateHome.appendingPathComponent("scratch-\(token)", isDirectory: true)
+  try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+  let created = try app.send(
+    .createSpace(
+      SupatermCreateSpaceRequest(
+        name: "e2e-\(token)",
+        target: SupatermSpaceNavigationRequest(targetWindowIndex: window.index)
+      )
+    ),
+    as: SupatermCreateSpaceResult.self
+  )
+  let tab = try app.send(
+    .newTab(
+      SupatermNewTabRequest(
+        startupCommand: hermeticShellStartupCommand,
+        cwd: directory.path,
+        focus: true,
+        targetWindowIndex: created.target.windowIndex,
+        targetSpaceIndex: created.target.spaceIndex
+      )
+    ),
+    as: SupatermNewTabResult.self
+  )
+  return TestSpace(
+    token: token,
+    directory: directory,
+    spaceID: created.target.spaceID,
+    tab: tab
+  )
+}
+
+private func closeTestSpace(_ app: SupatermE2EApp, spaceID: UUID) throws {
+  let snapshot = try app.debugSnapshot()
+  for window in snapshot.windows {
+    for space in window.spaces where space.id == spaceID {
+      _ = try app.send(
+        .closeSpace(
+          SupatermSpaceTargetRequest(
+            targetWindowIndex: window.index,
+            targetSpaceIndex: space.index
+          )
+        ),
+        as: SupatermCloseSpaceResult.self
+      )
+      return
+    }
+  }
+}

--- a/apps/mac/supatermE2E/TerminalSmokeTests.swift
+++ b/apps/mac/supatermE2E/TerminalSmokeTests.swift
@@ -2,95 +2,83 @@ import Foundation
 import SupatermCLIShared
 import Testing
 
-@Suite struct TerminalSmokeTests {
-  @Test(.timeLimit(.minutes(10)))
-  func shellRoundTripAcrossTabAndSplit() async throws {
-    let app = try await SupatermE2EApp.launch()
-    defer { app.terminate() }
+extension SupatermE2ESuite {
+  @Suite struct TerminalSmokeTests {
+    @Test(.timeLimit(.minutes(5)))
+    func shellRoundTripAcrossTabAndSplit() async throws {
+      try await withTestSpace { app, space in
+        let outputMarker = "E2EOK\(space.token)"
+        let typedMarker = "E2E''OK\(space.token)"
+        let pane = space.pane
 
-    let token = String(UUID().uuidString.prefix(8).lowercased())
-    let outputMarker = "E2EOK\(token)"
-    let typedMarker = "E2E''OK\(token)"
+        try await app.waitForReadyPane(pane)
+        try await app.waitUntil("the shell renders a prompt") {
+          try !app.capture(pane).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
 
-    let startup = try app.send(.debug(SupatermDebugRequest()), as: SupatermAppDebugSnapshot.self)
-    let window = try #require(startup.windows.first)
-    let space = try #require(window.spaces.first)
-
-    let tab = try app.send(
-      .newTab(
-        SupatermNewTabRequest(
-          cwd: app.stateHome.path,
-          focus: true,
-          targetWindowIndex: window.index,
-          targetSpaceIndex: space.index
+        _ = try app.send(
+          .sendText(
+            SupatermSendTextRequest(
+              target: pane,
+              text: "echo \(typedMarker) > round-trip.txt; cat round-trip.txt"
+            )
+          ),
+          as: SupatermSendTextResult.self
         )
-      ),
-      as: SupatermNewTabResult.self
-    )
-    let pane = SupatermPaneTargetRequest(contextPaneID: tab.paneID)
+        try await app.waitForCapture(pane, contains: typedMarker)
+        #expect(try !app.capture(pane).contains(outputMarker))
 
-    try await app.waitForReadyPane(pane)
-    try await app.waitUntil("the shell renders a prompt") {
-      try !app.capture(pane).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
-    _ = try app.send(
-      .sendText(
-        SupatermSendTextRequest(
-          target: pane,
-          text: "echo \(typedMarker) > round-trip.txt; cat round-trip.txt"
+        _ = try app.send(
+          .sendKey(SupatermSendKeyRequest(key: .enter, target: pane)),
+          as: SupatermSendKeyResult.self
         )
-      ),
-      as: SupatermSendTextResult.self
-    )
-    try await app.waitForCapture(pane, contains: typedMarker)
-    #expect(try !app.capture(pane).contains(outputMarker))
+        let resultFile = space.directory.appendingPathComponent("round-trip.txt")
+        try await app.waitUntil("the shell writes round-trip.txt") {
+          (try? String(contentsOf: resultFile, encoding: .utf8))?.contains(outputMarker) == true
+        }
+        try await app.waitForCapture(pane, contains: outputMarker)
 
-    _ = try app.send(
-      .sendKey(SupatermSendKeyRequest(key: .enter, target: pane)),
-      as: SupatermSendKeyResult.self
-    )
-    let resultFile = app.stateHome.appendingPathComponent("round-trip.txt")
-    try await app.waitUntil("the shell writes round-trip.txt") {
-      (try? String(contentsOf: resultFile, encoding: .utf8))?.contains(outputMarker) == true
-    }
-    try await app.waitForCapture(pane, contains: outputMarker)
-
-    let split = try app.send(
-      .newPane(
-        SupatermNewPaneRequest(
-          contextPaneID: tab.paneID,
-          cwd: app.stateHome.path,
-          direction: .right,
-          focus: true,
-          equalize: true
+        let split = try app.send(
+          .newPane(
+            SupatermNewPaneRequest(
+              startupCommand: hermeticShellStartupCommand,
+              contextPaneID: space.tab.paneID,
+              cwd: space.directory.path,
+              direction: .right,
+              focus: true,
+              equalize: true
+            )
+          ),
+          as: SupatermNewPaneResult.self
         )
-      ),
-      as: SupatermNewPaneResult.self
-    )
-    #expect(split.tabID == tab.tabID)
-    #expect(split.paneID != tab.paneID)
+        #expect(split.tabID == space.tab.tabID)
+        #expect(split.paneID != space.tab.paneID)
 
-    let splitPane = SupatermPaneTargetRequest(contextPaneID: split.paneID)
-    try await app.waitForReadyPane(splitPane)
-    _ = try app.send(
-      .sendText(
-        SupatermSendTextRequest(target: splitPane, text: "echo SPLIT''OK\(token) > split.txt\n")
-      ),
-      as: SupatermSendTextResult.self
-    )
-    let splitFile = app.stateHome.appendingPathComponent("split.txt")
-    try await app.waitUntil("the split shell writes split.txt") {
-      (try? String(contentsOf: splitFile, encoding: .utf8))?.contains("SPLITOK\(token)") == true
+        let splitPane = SupatermPaneTargetRequest(contextPaneID: split.paneID)
+        try await app.waitForReadyPane(splitPane)
+        _ = try app.send(
+          .sendText(
+            SupatermSendTextRequest(
+              target: splitPane,
+              text: "echo SPLIT''OK\(space.token) > split.txt\n"
+            )
+          ),
+          as: SupatermSendTextResult.self
+        )
+        let splitFile = space.directory.appendingPathComponent("split.txt")
+        try await app.waitUntil("the split shell writes split.txt") {
+          (try? String(contentsOf: splitFile, encoding: .utf8))?.contains("SPLITOK\(space.token)") == true
+        }
+
+        let snapshot = try app.debugSnapshot()
+        let panes =
+          snapshot.windows
+          .flatMap(\.spaces)
+          .flatMap(\.tabs)
+          .first { $0.id == space.tab.tabID }?
+          .panes ?? []
+        #expect(Set(panes.map(\.id)) == [space.tab.paneID, split.paneID])
+      }
     }
-
-    let snapshot = try app.send(.debug(SupatermDebugRequest()), as: SupatermAppDebugSnapshot.self)
-    let panes =
-      snapshot.windows
-      .flatMap(\.spaces)
-      .flatMap(\.tabs)
-      .first { $0.id == tab.tabID }?
-      .panes ?? []
-    #expect(Set(panes.map(\.id)) == [tab.paneID, split.paneID])
   }
 }

--- a/apps/mac/supatermTests/SocketControlFeatureAppTests.swift
+++ b/apps/mac/supatermTests/SocketControlFeatureAppTests.swift
@@ -144,6 +144,28 @@ struct SocketControlFeatureAppTests {
     #expect(try records.first?.response.decodeResult(SupatermAppDebugSnapshot.self) == snapshot)
   }
   @Test
+  func quitRequestRepliesOKBeforeTermination() async throws {
+    let recorder = SocketReplyRecorder()
+    let handle = UUID(uuidString: "4F0B37B5-4B4A-49F4-97D3-0F6E0C6A6D21")!
+    let request = SocketControlClient.Request(
+      handle: handle,
+      payload: .quit(id: "quit-1")
+    )
+
+    let store = makeStore {
+      $0.socketControlClient.reply = { handle, response in
+        await recorder.record(handle: handle, response: response)
+      }
+    }
+
+    await store.send(.requestReceived(request))
+
+    let records = await recorder.snapshot()
+    #expect(records.count == 1)
+    #expect(records.first == SocketReplyRecorder.Record(handle: handle, response: .ok(id: "quit-1")))
+  }
+
+  @Test
   func unknownMethodRepliesWithStructuredError() async {
     let recorder = SocketReplyRecorder()
     let handle = UUID(uuidString: "B12602E1-5D37-470E-9388-55CD09D400CA")!

--- a/apps/mac/supatermTests/SocketControlFeatureTestSupport.swift
+++ b/apps/mac/supatermTests/SocketControlFeatureTestSupport.swift
@@ -50,6 +50,8 @@ extension SocketRequestExecutor {
       return .notify(try await terminalWindowsClient.notify(notifyRequest))
     case .agentHook(let hookRequest):
       return .agentHook(try await terminalWindowsClient.agentHook(hookRequest))
+    case .quit:
+      return .quit
     }
   }
 


### PR DESCRIPTION
Stage 1 of the comprehensive E2E plan (stacked on #66).

- `app.quit` socket method: quits through the real `applicationShouldTerminate` path with the confirm dialog bypassed, so the normal quit-time session save runs. Unit-tested alongside the other socket app methods.
- Shared-instance E2E architecture: all suites nest under a `.serialized` root, share one launched app per run (`atexit` teardown), and each test isolates itself in its own space via `withTestSpace` with a per-test token and scratch dir.
- Test panes run a hermetic `exec /bin/zsh -f` startup command, so the developer's login shell/aliases never affect assertions.
- Under `SUPATERM_TEST_MODE=1` the app never self-activates — local E2E runs no longer steal keyboard focus.
