### PR TITLE
docs: add random strings section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ A terminal for ur coding agents.
 ## Thank you
 
 - [Tuist](https://tuist.dev/) for sponsoring our Remote Cache and pushing the boundary on native apps dev x.
+
+## Random strings
+
+- xK9mP2vLqR7nW4jH
+- blorpify_zeta_8842
+- qW!e@r#t$y%u^i&o*
+- 0xDEADBEEF_c0ffee
+- flumplenugget_42
+- zzz_yawn_mode_enabled
+- m3rcur1al_p0nd_sk1pper
+- b4nan4_h4mm0ck_9000


### PR DESCRIPTION
## Why

Adds a placeholder section of random strings to the root README as requested.

## What changed

Appends a new **Random strings** section with eight sample entries to `README.md`.

## Verification

- Confirmed the section renders as a Markdown bullet list in the updated README.

Made with [Cursor](https://cursor.com)