### PR TITLE
agent-panel: show subagent response previews

### DIFF
--- a/apps/mac/supaterm/App/TerminalAgentEvent.swift
+++ b/apps/mac/supaterm/App/TerminalAgentEvent.swift
@@ -46,7 +46,7 @@ nonisolated struct TerminalAgentEvent: Equatable, Sendable {
     case sessionEnded
     case sessionResumed(transcriptPath: String?)
     case sessionStarted(transcriptPath: String?)
-    case subagentStarted(nickname: String?, role: String?)
+    case subagentStarted(nickname: String?, role: String?, transcriptPath: String? = nil)
     case subagentStopped
     case turnCompleted(message: String?)
     case turnRunning(detail: String?)

--- a/apps/mac/supaterm/App/TerminalAgentEventTranslator.swift
+++ b/apps/mac/supaterm/App/TerminalAgentEventTranslator.swift
@@ -43,7 +43,11 @@ nonisolated enum TerminalAgentEventTranslator {
   ) -> TerminalAgentEvent.Action {
     let role = normalized(request.event.agentType)
     guard request.agent == .codex else {
-      return .subagentStarted(nickname: nil, role: role)
+      return .subagentStarted(
+        nickname: nil,
+        role: role,
+        transcriptPath: request.event.transcriptPath
+      )
     }
     let nickname = CodexTranscriptMetadataParser.subagentNickname(
       at: request.event.transcriptPath,
@@ -52,7 +56,8 @@ nonisolated enum TerminalAgentEventTranslator {
     )
     return .subagentStarted(
       nickname: nickname,
-      role: role?.lowercased() == "default" ? nil : role
+      role: role?.lowercased() == "default" ? nil : role,
+      transcriptPath: request.event.transcriptPath
     )
   }
 
@@ -138,7 +143,9 @@ nonisolated enum TerminalAgentEventTranslator {
       return [event(request, scope: scope, action: .progressUpdated(rows))]
     }
     if request.event.hookEventName == .postToolUse {
-      return attentionResolutionEvents(for: request, scope: scope) + [
+      let resolutionEvents = attentionResolutionEvents(for: request, scope: scope)
+      guard scope.subagentID == nil else { return resolutionEvents }
+      return resolutionEvents + [
         event(
           request,
           scope: scope,
@@ -154,6 +161,7 @@ nonisolated enum TerminalAgentEventTranslator {
         message: request.event.message
       )
     case .preToolUse:
+      guard scope.subagentID == nil else { return [] }
       action = .turnRunning(detail: request.event.toolName)
     case .sessionEnd:
       action = .sessionEnded

--- a/apps/mac/supaterm/App/TerminalAgentMonitorStore.swift
+++ b/apps/mac/supaterm/App/TerminalAgentMonitorStore.swift
@@ -8,10 +8,24 @@ final class TerminalAgentMonitorStore {
   private struct Key: Hashable {
     let agent: SupatermAgentKind
     let sessionID: String
+    let subagentID: String?
 
     func hash(into hasher: inout Hasher) {
       hasher.combine(agent.rawValue)
       hasher.combine(sessionID)
+      hasher.combine(subagentID)
+    }
+
+    init(_ scope: TerminalAgentEvent.Scope) {
+      agent = scope.agent
+      sessionID = scope.sessionID
+      subagentID = scope.subagentID
+    }
+
+    init(agent: SupatermAgentKind, sessionID: String) {
+      self.agent = agent
+      self.sessionID = sessionID
+      subagentID = nil
     }
   }
 
@@ -19,21 +33,22 @@ final class TerminalAgentMonitorStore {
     let generation: UUID
     let path: String
     let surfaceID: UUID?
+    let turnID: String?
 
     static func == (lhs: Self, rhs: Self) -> Bool {
       lhs.generation == rhs.generation
         && lhs.path == rhs.path
         && lhs.surfaceID == rhs.surfaceID
+        && lhs.turnID == rhs.turnID
     }
   }
 
   var onMonitorSnapshot:
     @MainActor (
       AgentMonitorSnapshot,
-      SupatermAgentKind,
-      String,
+      TerminalAgentEvent.Scope,
       SupatermCLIContext?
-    ) -> Void = { _, _, _, _ in }
+    ) -> Void = { _, _, _ in }
   var onRunningTimeoutExpired:
     @MainActor (
       SupatermAgentKind,
@@ -85,24 +100,26 @@ final class TerminalAgentMonitorStore {
 
   @discardableResult
   func track(
-    agent: SupatermAgentKind,
-    sessionID: String,
+    scope: TerminalAgentEvent.Scope,
     transcriptPath: String,
     context: SupatermCLIContext?
   ) -> Bool {
-    guard let monitor = makeMonitor(agent: agent) else { return false }
-    let key = Key(agent: agent, sessionID: sessionID)
+    guard let monitor = makeMonitor(agent: scope.agent) else { return false }
+    let key = Key(scope)
+    let turnID = scope.subagentID == nil ? nil : scope.turnID
     if entries[key]?.path == transcriptPath,
       entries[key]?.surfaceID == context?.surfaceID,
+      entries[key]?.turnID == turnID,
       monitorTasks[key] != nil
     {
       return true
     }
-    cancelTracking(agent: agent, sessionID: sessionID)
+    cancelTracking(scope: scope)
     let entry = Entry(
       generation: UUID(),
       path: transcriptPath,
-      surfaceID: context?.surfaceID
+      surfaceID: context?.surfaceID,
+      turnID: turnID
     )
     entries[key] = entry
     let updates = updates(transcriptPath)
@@ -121,46 +138,57 @@ final class TerminalAgentMonitorStore {
           try? await sleep(eventDelay)
         }
         guard !Task.isCancelled, let self, self.entries[key] == entry else { return }
-        self.extendRunningTimeoutIfArmed(
-          agent: agent,
-          sessionID: sessionID,
-          context: context
-        )
+        if scope.subagentID == nil {
+          self.extendRunningTimeoutIfArmed(
+            agent: scope.agent,
+            sessionID: scope.sessionID,
+            context: context
+          )
+        }
         if let snapshot = monitor.consume(update) {
-          self.onMonitorSnapshot(snapshot, agent, sessionID, context)
+          self.onMonitorSnapshot(snapshot, scope, context)
         }
       }
     }
     return true
   }
 
-  func cancelTracking(agent: SupatermAgentKind, sessionID: String) {
-    let key = Key(agent: agent, sessionID: sessionID)
+  func cancelTracking(scope: TerminalAgentEvent.Scope) {
+    let key = Key(scope)
     monitorTasks.removeValue(forKey: key)?.cancel()
     entries.removeValue(forKey: key)
   }
 
   func clearSession(agent: SupatermAgentKind, sessionID: String) {
-    cancelTracking(agent: agent, sessionID: sessionID)
+    let keys = entries.keys.filter {
+      $0.agent == agent && $0.sessionID == sessionID
+    }
+    for key in keys {
+      monitorTasks.removeValue(forKey: key)?.cancel()
+      entries.removeValue(forKey: key)
+    }
     cancelRunningTimeout(agent: agent, sessionID: sessionID)
   }
 
   func clearSessions(for surfaceID: UUID) {
-    let keys = Set(
-      entries.compactMap { key, entry in
-        entry.surfaceID == surfaceID ? key : nil
-      }
-        + timeoutSurfaceIDs.compactMap { key, timeoutSurfaceID in
-          timeoutSurfaceID == surfaceID ? key : nil
-        }
-    )
-    for key in keys {
-      clearSession(agent: key.agent, sessionID: key.sessionID)
+    let entryKeys = entries.compactMap { key, entry in
+      entry.surfaceID == surfaceID ? key : nil
+    }
+    for key in entryKeys {
+      monitorTasks.removeValue(forKey: key)?.cancel()
+      entries.removeValue(forKey: key)
+    }
+    let timeoutKeys = timeoutSurfaceIDs.compactMap { key, timeoutSurfaceID in
+      timeoutSurfaceID == surfaceID ? key : nil
+    }
+    for key in timeoutKeys {
+      runningTimeoutTasks.removeValue(forKey: key)?.cancel()
+      timeoutSurfaceIDs.removeValue(forKey: key)
     }
   }
 
-  func isTracking(agent: SupatermAgentKind, sessionID: String) -> Bool {
-    monitorTasks[Key(agent: agent, sessionID: sessionID)] != nil
+  func isTracking(scope: TerminalAgentEvent.Scope) -> Bool {
+    monitorTasks[Key(scope)] != nil
   }
 
   func armRunningTimeout(

--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -25,8 +25,7 @@ extension TerminalCommandExecutor {
   func resumeAgentMonitoring(in terminal: TerminalHostState) {
     for target in terminal.agentTranscriptTargets() {
       _ = agentMonitorStore.track(
-        agent: target.agent,
-        sessionID: target.sessionID,
+        scope: target.scope,
         transcriptPath: target.transcriptPath,
         context: target.context
       )
@@ -83,19 +82,24 @@ extension TerminalCommandExecutor {
 
   func handleMonitorSnapshot(
     _ snapshot: AgentMonitorSnapshot,
-    agent: SupatermAgentKind,
-    sessionID: String,
+    scope: TerminalAgentEvent.Scope,
     context: SupatermCLIContext?
   ) {
-    guard let terminal = agentTerminal(agent: agent, sessionID: sessionID, context: context) else {
-      agentMonitorStore.clearSession(agent: agent, sessionID: sessionID)
+    guard
+      let terminal = agentTerminal(
+        agent: scope.agent,
+        sessionID: scope.sessionID,
+        context: context
+      )
+    else {
+      clearMonitoring(scope)
       return
     }
-    guard terminal.hasAgentSession(agent: agent, sessionID: sessionID) else {
-      agentMonitorStore.clearSession(agent: agent, sessionID: sessionID)
+    guard terminal.hasAgentSession(agent: scope.agent, sessionID: scope.sessionID) else {
+      clearMonitoring(scope)
       return
     }
-    let turnID = snapshot.status?.turnID
+    let turnID = scope.subagentID == nil ? snapshot.status?.turnID : scope.turnID
     var actions: [TerminalAgentEvent.Action] = []
     switch snapshot.status {
     case .started:
@@ -107,15 +111,18 @@ extension TerminalCommandExecutor {
         actions.append(.turnRunning(detail: snapshot.detail))
       }
     }
-    actions.append(.hoverMessagesUpdated(snapshot.hoverMessages))
-    actions.append(.progressUpdated(snapshot.progressRows, source: .transcript))
+    if scope.subagentID == nil {
+      actions.append(.hoverMessagesUpdated(snapshot.hoverMessages))
+      actions.append(.progressUpdated(snapshot.progressRows, source: .transcript))
+    }
     var didChange = false
     for action in actions {
       let event = TerminalAgentEvent(
         scope: TerminalAgentEvent.Scope(
-          agent: agent,
-          sessionID: sessionID,
-          turnID: turnID
+          agent: scope.agent,
+          sessionID: scope.sessionID,
+          turnID: turnID,
+          subagentID: scope.subagentID
         ),
         context: context,
         action: action,
@@ -226,20 +233,25 @@ extension TerminalCommandExecutor {
   ) {
     guard accepted else { return }
     guard let sessionID = request.event.sessionID else { return }
+    guard let scope = events.first?.scope else { return }
     if request.event.hookEventName == .sessionEnd
       || request.event.hookEventName == .sessionShutdown
     {
       agentMonitorStore.clearSession(agent: request.agent, sessionID: sessionID)
       return
     }
-    if let transcriptPath = request.event.transcriptPath {
+    if request.event.hookEventName == .subagentStop
+      || request.event.hookEventName == .stop
+    {
+      agentMonitorStore.cancelTracking(scope: scope)
+    } else if let transcriptPath = request.event.transcriptPath {
       _ = agentMonitorStore.track(
-        agent: request.agent,
-        sessionID: sessionID,
+        scope: scope,
         transcriptPath: transcriptPath,
         context: request.context
       )
     }
+    guard scope.subagentID == nil else { return }
     guard terminal.agentSessionIsForeground(agent: request.agent, sessionID: sessionID) else {
       return
     }
@@ -260,12 +272,19 @@ extension TerminalCommandExecutor {
         context: request.context
       )
     case .stop:
-      agentMonitorStore.cancelTracking(agent: request.agent, sessionID: sessionID)
       agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
     case .sessionEnd, .sessionShutdown:
       agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
     default:
       break
+    }
+  }
+
+  private func clearMonitoring(_ scope: TerminalAgentEvent.Scope) {
+    if scope.subagentID == nil {
+      agentMonitorStore.clearSession(agent: scope.agent, sessionID: scope.sessionID)
+    } else {
+      agentMonitorStore.cancelTracking(scope: scope)
     }
   }
 

--- a/apps/mac/supaterm/App/TerminalCommandExecutor.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor.swift
@@ -27,8 +27,8 @@ final class TerminalCommandExecutor {
       transcriptEventDelay: transcriptEventDelay,
       sleep: sleep
     )
-    agentMonitorStore.onMonitorSnapshot = { [weak self] snapshot, agent, sessionID, context in
-      self?.handleMonitorSnapshot(snapshot, agent: agent, sessionID: sessionID, context: context)
+    agentMonitorStore.onMonitorSnapshot = { [weak self] snapshot, scope, context in
+      self?.handleMonitorSnapshot(snapshot, scope: scope, context: context)
     }
     agentMonitorStore.onRunningTimeoutExpired = { [weak self] agent, sessionID, context in
       self?.handleRunningTimeoutExpired(agent: agent, sessionID: sessionID, context: context)

--- a/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
@@ -23,6 +23,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
   let id: Identity
   let nickname: String?
   let role: String?
+  let transcriptPath: String?
   let phase: AgentActivityPhase
   let detail: String?
   let attentionRequestID: String?
@@ -31,6 +32,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
     id: Identity,
     nickname: String?,
     role: String?,
+    transcriptPath: String? = nil,
     phase: AgentActivityPhase,
     detail: String?,
     attentionRequestID: String? = nil
@@ -38,6 +40,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
     self.id = id
     self.nickname = nickname
     self.role = role
+    self.transcriptPath = transcriptPath
     self.phase = phase
     self.detail = detail
     self.attentionRequestID = attentionRequestID
@@ -306,20 +309,22 @@ nonisolated struct TerminalAgentStateStore {
   ) {
     guard let childKey = Self.childKey(for: event) else { return }
     switch event.action {
-    case .subagentStarted(let nickname, let role):
+    case .subagentStarted(let nickname, let role, let transcriptPath):
       state.activeChildren = state.activeChildren.filter {
         $0.key.subagentID != childKey.subagentID || $0.key == childKey
       }
       if let child = state.activeChildren[childKey] {
         state.activeChildren[childKey] = child.updating(
           nickname: nickname,
-          role: role
+          role: role,
+          transcriptPath: transcriptPath
         )
       } else {
         state.activeChildren[childKey] = TerminalAgentActiveChild(
           id: childKey,
           nickname: nickname,
           role: role,
+          transcriptPath: transcriptPath,
           phase: .running,
           detail: nil
         )
@@ -738,12 +743,14 @@ nonisolated struct TerminalAgentStateStore {
 extension TerminalAgentActiveChild {
   fileprivate nonisolated func updating(
     nickname: String?,
-    role: String?
+    role: String?,
+    transcriptPath: String?
   ) -> Self {
     Self(
       id: id,
       nickname: nickname ?? self.nickname,
       role: role ?? self.role,
+      transcriptPath: transcriptPath ?? self.transcriptPath,
       phase: phase,
       detail: detail,
       attentionRequestID: attentionRequestID
@@ -759,6 +766,7 @@ extension TerminalAgentActiveChild {
       id: id,
       nickname: nickname,
       role: role,
+      transcriptPath: transcriptPath,
       phase: phase,
       detail: detail,
       attentionRequestID: attentionRequestID

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
@@ -2,8 +2,7 @@ import Foundation
 import SupatermCLIShared
 
 struct TerminalAgentTranscriptTarget {
-  let agent: SupatermAgentKind
-  let sessionID: String
+  let scope: TerminalAgentEvent.Scope
   let transcriptPath: String
   let context: SupatermCLIContext
 }
@@ -333,14 +332,36 @@ extension TerminalHostState {
   func agentTranscriptTargets() -> [TerminalAgentTranscriptTarget] {
     liveSurfaceIDs().flatMap { surfaceID -> [TerminalAgentTranscriptTarget] in
       guard let context = agentContext(for: surfaceID) else { return [] }
-      return agentStateStore.snapshots(for: surfaceID).compactMap { snapshot in
-        guard let transcriptPath = snapshot.transcriptPath else { return nil }
-        return TerminalAgentTranscriptTarget(
-          agent: snapshot.agent,
-          sessionID: snapshot.sessionID,
-          transcriptPath: transcriptPath,
-          context: context
+      return agentStateStore.snapshots(for: surfaceID).flatMap { snapshot in
+        var targets: [TerminalAgentTranscriptTarget] = []
+        if let transcriptPath = snapshot.transcriptPath {
+          targets.append(
+            TerminalAgentTranscriptTarget(
+              scope: TerminalAgentEvent.Scope(
+                agent: snapshot.agent,
+                sessionID: snapshot.sessionID
+              ),
+              transcriptPath: transcriptPath,
+              context: context
+            )
+          )
+        }
+        targets.append(
+          contentsOf: snapshot.activeChildren.compactMap { child in
+            guard let transcriptPath = child.transcriptPath else { return nil }
+            return TerminalAgentTranscriptTarget(
+              scope: TerminalAgentEvent.Scope(
+                agent: snapshot.agent,
+                sessionID: child.sessionID,
+                turnID: child.turnID,
+                subagentID: child.subagentID
+              ),
+              transcriptPath: transcriptPath,
+              context: context
+            )
+          }
         )
+        return targets
       }
     }
   }

--- a/apps/mac/supatermTests/TerminalAgentEventTranslatorTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentEventTranslatorTests.swift
@@ -333,7 +333,11 @@ struct TerminalAgentEventTranslatorTests {
 
     #expect(
       TerminalAgentEventTranslator.events(for: request).map(\.action) == [
-        .subagentStarted(nickname: "Mendel", role: nil)
+        .subagentStarted(
+          nickname: "Mendel",
+          role: nil,
+          transcriptPath: transcript.path
+        )
       ]
     )
   }

--- a/apps/mac/supatermTests/TerminalAgentMonitorStoreTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentMonitorStoreTests.swift
@@ -18,8 +18,7 @@ struct TerminalAgentMonitorStoreTests {
 
     #expect(
       !store.track(
-        agent: .pi,
-        sessionID: "session-1",
+        scope: TerminalAgentEvent.Scope(agent: .pi, sessionID: "session-1"),
         transcriptPath: "/tmp/transcript.jsonl",
         context: nil
       )
@@ -42,8 +41,7 @@ struct TerminalAgentMonitorStoreTests {
 
     #expect(
       store.track(
-        agent: .codex,
-        sessionID: "session-1",
+        scope: TerminalAgentEvent.Scope(agent: .codex, sessionID: "session-1"),
         transcriptPath: "/tmp/transcript.jsonl",
         context: nil
       )
@@ -72,8 +70,7 @@ struct TerminalAgentMonitorStoreTests {
 
     #expect(
       store.track(
-        agent: .codex,
-        sessionID: "session-1",
+        scope: TerminalAgentEvent.Scope(agent: .codex, sessionID: "session-1"),
         transcriptPath: "/tmp/transcript.jsonl",
         context: nil
       )
@@ -81,7 +78,11 @@ struct TerminalAgentMonitorStoreTests {
     continuation.finish()
     await flushEffects()
 
-    #expect(!store.isTracking(agent: .codex, sessionID: "session-1"))
+    #expect(
+      !store.isTracking(
+        scope: TerminalAgentEvent.Scope(agent: .codex, sessionID: "session-1")
+      )
+    )
   }
 
   @Test
@@ -121,8 +122,7 @@ struct TerminalAgentMonitorStoreTests {
     let context = SupatermCLIContext(surfaceID: UUID(), tabID: UUID())
     #expect(
       store.track(
-        agent: .codex,
-        sessionID: "session-1",
+        scope: TerminalAgentEvent.Scope(agent: .codex, sessionID: "session-1"),
         transcriptPath: "/tmp/transcript.jsonl",
         context: context
       )
@@ -188,7 +188,7 @@ private final class MonitorStoreEventsSpy {
   var snapshots: [AgentMonitorSnapshot] = []
 
   func bind(to store: TerminalAgentMonitorStore) {
-    store.onMonitorSnapshot = { [weak self] snapshot, _, _, _ in
+    store.onMonitorSnapshot = { [weak self] snapshot, _, _ in
       self?.snapshots.append(snapshot)
     }
     store.onRunningTimeoutExpired = { [weak self] agent, sessionID, _ in

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -179,8 +179,10 @@ struct TerminalCommandExecutorAgentHookTests {
 
     harness.commandExecutor.handleMonitorSnapshot(
       AgentMonitorSnapshot(status: .started("turn-late"), detail: "Late transcript update"),
-      agent: .codex,
-      sessionID: CodexHookFixtures.sessionID,
+      scope: TerminalAgentEvent.Scope(
+        agent: .codex,
+        sessionID: CodexHookFixtures.sessionID
+      ),
       context: harness.context
     )
 
@@ -214,8 +216,10 @@ struct TerminalCommandExecutorAgentHookTests {
           PaneAgentProgressRow(id: "stale", title: "Stale progress", status: .running)
         ]
       ),
-      agent: .codex,
-      sessionID: CodexHookFixtures.sessionID,
+      scope: TerminalAgentEvent.Scope(
+        agent: .codex,
+        sessionID: CodexHookFixtures.sessionID
+      ),
       context: harness.context
     )
 
@@ -319,8 +323,10 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     #expect(
       harness.commandExecutor.agentMonitorStore.isTracking(
-        agent: .codex,
-        sessionID: CodexHookFixtures.sessionID
+        scope: TerminalAgentEvent.Scope(
+          agent: .codex,
+          sessionID: CodexHookFixtures.sessionID
+        )
       )
     )
 
@@ -328,8 +334,10 @@ struct TerminalCommandExecutorAgentHookTests {
 
     #expect(
       !harness.commandExecutor.agentMonitorStore.isTracking(
-        agent: .codex,
-        sessionID: CodexHookFixtures.sessionID
+        scope: TerminalAgentEvent.Scope(
+          agent: .codex,
+          sessionID: CodexHookFixtures.sessionID
+        )
       )
     )
   }
@@ -350,8 +358,10 @@ struct TerminalCommandExecutorAgentHookTests {
 
     #expect(
       !harness.commandExecutor.agentMonitorStore.isTracking(
-        agent: .codex,
-        sessionID: CodexHookFixtures.sessionID
+        scope: TerminalAgentEvent.Scope(
+          agent: .codex,
+          sessionID: CodexHookFixtures.sessionID
+        )
       )
     )
   }
@@ -1040,8 +1050,10 @@ struct TerminalCommandExecutorAgentHookTests {
     #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running, detail: "Bash"))
     #expect(
       harness.commandExecutor.agentMonitorStore.isTracking(
-        agent: .codex,
-        sessionID: CodexHookFixtures.sessionID
+        scope: TerminalAgentEvent.Scope(
+          agent: .codex,
+          sessionID: CodexHookFixtures.sessionID
+        )
       )
     )
   }
@@ -1398,6 +1410,106 @@ struct TerminalCommandExecutorAgentHookTests {
     await advanceClock(clock)
 
     #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
+  }
+  @Test
+  func codexChildTranscriptMessageReplacesToolDetailWithoutReplacingRootMonitor() async throws {
+    let harness = try makeClaudeHookHarness()
+    let rootTranscript = try CodexTranscriptFixtures.makeTranscript()
+    let childTranscript = try CodexTranscriptFixtures.makeTranscript()
+    defer {
+      try? FileManager.default.removeItem(at: rootTranscript.deletingLastPathComponent())
+      try? FileManager.default.removeItem(at: childTranscript.deletingLastPathComponent())
+    }
+    let childScope = TerminalAgentEvent.Scope(
+      agent: .codex,
+      sessionID: CodexHookFixtures.sessionID,
+      turnID: "root-turn",
+      subagentID: "child-1"
+    )
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.sessionStart,
+        transcriptPath: rootTranscript,
+        context: harness.context
+      )
+    )
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .codex,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          hookEventName: .userPromptSubmit,
+          sessionID: CodexHookFixtures.sessionID,
+          transcriptPath: rootTranscript.path,
+          turnID: "root-turn"
+        )
+      )
+    )
+    try CodexTranscriptFixtures.append(
+      .subagentSessionMeta(
+        id: "child-1",
+        sessionID: CodexHookFixtures.sessionID,
+        nickname: "Mendel"
+      ),
+      to: childTranscript
+    )
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "child-turn"), to: childTranscript)
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Tracing native haptic calls"),
+      to: childTranscript
+    )
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .codex,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          agentType: "default",
+          hookEventName: .subagentStart,
+          sessionID: CodexHookFixtures.sessionID,
+          transcriptPath: childTranscript.path,
+          turnID: "root-turn",
+          agentID: "child-1"
+        )
+      )
+    )
+
+    let didLoadChildMessage = await waitUntil {
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?
+        .activeChildren.first?.detail == "Tracing native haptic calls"
+    }
+    #expect(didLoadChildMessage)
+    #expect(harness.commandExecutor.agentMonitorStore.isTracking(scope: childScope))
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .codex,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          hookEventName: .postToolUse,
+          sessionID: CodexHookFixtures.sessionID,
+          toolName: "Bash",
+          transcriptPath: childTranscript.path,
+          turnID: "root-turn",
+          agentID: "child-1"
+        )
+      )
+    )
+    #expect(
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?
+        .activeChildren.first?.detail == "Tracing native haptic calls"
+    )
+
+    try CodexTranscriptFixtures.append(.taskStarted(turnID: "root-turn"), to: rootTranscript)
+    try CodexTranscriptFixtures.append(
+      .assistantMessage("Coordinating child results"),
+      to: rootTranscript
+    )
+    let didKeepRootMonitor = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID)
+        == .codex(.running, detail: "Coordinating child results")
+    }
+    #expect(didKeepRootMonitor)
   }
   @Test
   func codexStopDeliversDesktopNotificationWhenWindowIsInactive() throws {

--- a/apps/mac/supatermTests/TerminalSessionCatalogTests.swift
+++ b/apps/mac/supatermTests/TerminalSessionCatalogTests.swift
@@ -260,6 +260,7 @@ struct TerminalSessionCatalogTests {
           ),
           nickname: "Mendel",
           role: "reviewer",
+          transcriptPath: "/tmp/child.jsonl",
           phase: .running,
           detail: "Reviewing"
         )

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -144,7 +144,7 @@ The app binds Codex sessions to pane surfaces and turns Codex hook events into t
   was missed, and clears structured completion suppression without supplying Codex detail on its own.
 - `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided.
 - `PermissionRequest` and `request_user_input` mark the foreground session as needing input; only completion of the matching tool resolves that attention state.
-- `SubagentStart` and `SubagentStop` maintain scoped child-agent rows. Reused child IDs and late stop events cannot remove a newer child lifetime.
+- `SubagentStart` and `SubagentStop` maintain scoped child-agent rows. Each child rollout is tailed independently, so its latest non-final assistant message supplies the row detail without replacing parent transcript monitoring. Tool completion never replaces that message with a tool name. Reused child IDs and late stop events cannot remove a newer child lifetime.
 - A native `PostToolUse` for `update_plan` reads `tool_input.plan` directly and replaces the native plan rows immediately. Supaterm never reconstructs plans from transcript text.
 - Transcript lifecycle remains authoritative for live Codex detail and corroborates final `idle` transitions.
 - `task_started` and `turn_started` mark the tab as `running`.


### PR DESCRIPTION
## Why

Active subagent rows displayed the latest tool name, such as `Bash`, instead of what the agent was working on. Child hooks share their parent's session ID, so the session-keyed transcript monitor also replaced the parent tail when a child started.

## What changed

Transcript monitors are now scoped by child identity, and each child's rollout path is persisted for restoration. Child rows project their latest non-final assistant message while parent hover and progress state remains parent-owned; tool completion can resolve attention without overwriting the message.

> [!NOTE]
> This changes message sourcing only. Agent panel layout and styling are unchanged.

## Verification

The regression test starts independent parent and child rollouts, confirms the child response survives a `Bash` completion hook, then confirms the parent monitor continues receiving messages. The full macOS suite passed, lint and formatting were clean, the dead-code scan found no unused code, and pre-push validation also passed all 32 web tests.
