### PR TITLE
mac: confirm closing zoomed tabs

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+Close.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+Close.swift
@@ -51,7 +51,19 @@ extension TerminalHostState {
   }
 
   func requestCloseTab(_ tabID: TerminalTabID) {
-    guard let resolvedCloseRequest = resolvedCloseRequest(for: .tab(tabID)) else { return }
+    guard let tree = trees[tabID] else { return }
+    let isZoomed = tree.zoomed != nil
+    guard
+      let resolvedCloseRequest = resolvedCloseRequest(
+        for: .tab(tabID),
+        needsConfirmationOverride: isZoomed ? true : nil
+      )
+    else {
+      return
+    }
+    if isZoomed {
+      trees[tabID] = tree.settingZoomed(nil)
+    }
     emit(resolvedCloseRequest)
   }
 

--- a/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalWindowFeature.swift
@@ -64,11 +64,13 @@ struct TerminalSpaceEditorState: Equatable, Identifiable {
 
 @Reducer
 struct TerminalWindowFeature {
-  static let closeWindowWarningMessage =
-    "Closing this window terminates its terminal sessions. Reopening the window starts new sessions. "
-    + "zmx persistence is for Supaterm restarts."
   static let closeAllWindowsWarningMessage =
     "Closing all windows terminates their terminal sessions. Reopening Supaterm starts new sessions. "
+    + "zmx persistence is for Supaterm restarts."
+  static let closeTabWarningMessage =
+    "Closing this tab closes all its panes and terminates any running processes. Close it anyway?"
+  static let closeWindowWarningMessage =
+    "Closing this window terminates its terminal sessions. Reopening the window starts new sessions. "
     + "zmx persistence is for Supaterm restarts."
 
   @ObservableState
@@ -702,7 +704,7 @@ struct TerminalWindowFeature {
       return PendingCloseRequest(
         target: .tab(tabID),
         title: "Close Tab?",
-        message: "A process is still running in this tab. Close it anyway?"
+        message: Self.closeTabWarningMessage
       )
     case .tabs(let tabIDs):
       return PendingCloseRequest(

--- a/apps/mac/supatermTests/TerminalHostStateCloseTests.swift
+++ b/apps/mac/supatermTests/TerminalHostStateCloseTests.swift
@@ -1,10 +1,71 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import supaterm
 
 @MainActor
 struct TerminalHostStateCloseTests {
+  @Test
+  func closeRequestForZoomedTabUnzoomsAndRequiresConfirmation() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let setup = try makeSplitTabSetup(hasSurvivingTab: true)
+      let stream = setup.host.eventStream()
+      var iterator = stream.makeAsyncIterator()
+
+      #expect(setup.host.performSplitAction(.toggleSplitZoom, for: setup.secondSurfaceID))
+
+      setup.host.requestCloseTab(setup.tabID)
+
+      #expect(setup.host.trees[setup.tabID]?.zoomed == nil)
+      let event = try #require(await iterator.next())
+      #expect(
+        event
+          == .closeRequested(
+            TerminalCloseRequest(target: .tab(setup.tabID), needsConfirmation: true)))
+    }
+  }
+
+  @Test
+  func closeRequestForUnzoomedTabDoesNotForceConfirmation() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let setup = try makeSplitTabSetup(hasSurvivingTab: true)
+      let stream = setup.host.eventStream()
+      var iterator = stream.makeAsyncIterator()
+
+      setup.host.requestCloseTab(setup.tabID)
+
+      let event = try #require(await iterator.next())
+      #expect(
+        event
+          == .closeRequested(
+            TerminalCloseRequest(target: .tab(setup.tabID), needsConfirmation: false)))
+    }
+  }
+
+  @Test
+  func closeRequestForZoomedLastTabUnzoomsBeforeRequestingWindowClose() async throws {
+    try await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let setup = try makeSplitTabSetup(hasSurvivingTab: false)
+      let stream = setup.host.eventStream()
+      var iterator = stream.makeAsyncIterator()
+
+      #expect(setup.host.performSplitAction(.toggleSplitZoom, for: setup.secondSurfaceID))
+
+      setup.host.requestCloseTab(setup.tabID)
+
+      #expect(setup.host.trees[setup.tabID]?.zoomed == nil)
+      let event = try #require(await iterator.next())
+      #expect(event == .windowCloseRequested(needsConfirmation: true))
+    }
+  }
+
   @Test
   func windowCloseScopesConfirmationToItsHost() throws {
     try withDependencies {
@@ -35,4 +96,40 @@ struct TerminalHostStateCloseTests {
       #expect(!emptyHost.windowNeedsCloseConfirmation())
     }
   }
+
+  private func makeSplitTabSetup(hasSurvivingTab: Bool) throws -> CloseTabTestSetup {
+    initializeGhosttyForTests()
+    let runtime = try makeGhosttyRuntime("confirm-close-surface = false")
+    let host = TerminalHostState(
+      runtime: runtime,
+      zmxSessionsEnabled: false
+    )
+    host.handleCommand(.ensureInitialTab(focusing: false, startupCommand: nil))
+    let tabID = try #require(host.selectedTabID)
+    let firstSurfaceID = try #require(host.currentFocusedSurfaceID())
+    let secondPane = try host.createPane(
+      TerminalCreatePaneRequest(
+        startupCommand: nil,
+        direction: .right,
+        focus: true,
+        equalize: false,
+        target: .contextPane(firstSurfaceID)
+      )
+    )
+    if hasSurvivingTab {
+      host.handleCommand(.createTab(inheritingFromSurfaceID: nil))
+      host.handleCommand(.selectTab(tabID))
+    }
+    return CloseTabTestSetup(
+      host: host,
+      secondSurfaceID: secondPane.paneID,
+      tabID: tabID
+    )
+  }
+}
+
+private struct CloseTabTestSetup {
+  let host: TerminalHostState
+  let secondSurfaceID: UUID
+  let tabID: TerminalTabID
 }

--- a/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
+++ b/apps/mac/supatermTests/TerminalWindowFeatureTests.swift
@@ -247,7 +247,7 @@ struct TerminalWindowFeatureTests {
       $0.pendingCloseRequest = TerminalWindowFeature.PendingCloseRequest(
         target: .tab(tabID),
         title: "Close Tab?",
-        message: "A process is still running in this tab. Close it anyway?"
+        message: TerminalWindowFeature.closeTabWarningMessage
       )
     }
   }
@@ -304,7 +304,7 @@ struct TerminalWindowFeatureTests {
     initialState.pendingCloseRequest = TerminalWindowFeature.PendingCloseRequest(
       target: .tab(tabID),
       title: "Close Tab?",
-      message: "A process is still running in this tab. Close it anyway?"
+      message: TerminalWindowFeature.closeTabWarningMessage
     )
 
     let store = TestStore(initialState: initialState) {
@@ -318,6 +318,30 @@ struct TerminalWindowFeatureTests {
     }
 
     #expect(recorder.commands == [.closeTab(tabID)])
+  }
+
+  @Test
+  func closeConfirmationCancelDoesNotClosePendingTab() async {
+    let recorder = TerminalCommandRecorder()
+    let tabID = TerminalTabID()
+    var initialState = TerminalWindowFeature.State()
+    initialState.pendingCloseRequest = TerminalWindowFeature.PendingCloseRequest(
+      target: .tab(tabID),
+      title: "Close Tab?",
+      message: TerminalWindowFeature.closeTabWarningMessage
+    )
+
+    let store = TestStore(initialState: initialState) {
+      TerminalWindowFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { recorder.record($0) }
+    }
+
+    await store.send(.closeConfirmationCancelButtonTapped) {
+      $0.pendingCloseRequest = nil
+    }
+
+    #expect(recorder.commands.isEmpty)
   }
 
   @Test


### PR DESCRIPTION
## Why

When a tab with multiple panes is zoomed, its other panes are hidden. Closing the tab from that state could terminate those hidden panes without first showing the user the full scope of the action.

Interactive tab close now clears the zoom before resolving the close request and forces confirmation even when terminal configuration would otherwise close immediately. Keeping this in the existing host-to-reducer close flow makes the revealed panes and confirmation part of the same destructive action.

## What changed

Zoomed single-tab closes reveal every pane before presenting a tab-specific warning that closing the tab terminates all of its panes and running processes. The same ordering applies when the tab is the window's last tab, while cancelling the confirmation leaves the unzoomed tab open.

> [!NOTE]
> Close Others, Close Tabs Below, and socket or CLI direct-close flows intentionally retain their existing behavior.

## Demo

Automated repro: create a two-pane tab with `confirm-close-surface = false`, zoom one pane, then request tab close. The tab becomes unzoomed and emits a confirmation-required close request instead of closing immediately.

## Verification

`TerminalHostStateCloseTests` covers zoomed, unzoomed, and last-tab requests, including confirmation disabled in terminal configuration. `TerminalWindowFeatureTests` verifies confirm closes the pending tab and cancel sends no close command.

`make mac-check` passed. `make mac-test` passed twice, including the pre-push run. The pre-push dead-code scan found no unused code, and all 32 web tests passed.
