### PR TITLE
agent-hooks: keep transcript-driven turns running

### DIFF
--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -263,14 +263,18 @@ extension TerminalCommandExecutor {
       return
     }
     switch request.event.hookEventName {
-    case .postToolUse,
-      .userPromptSubmit,
-      .preToolUse where !request.agent.drivesActivityFromTranscript:
-      agentMonitorStore.armRunningTimeout(
-        agent: request.agent,
-        sessionID: sessionID,
-        context: request.context
-      )
+    case .postToolUse, .userPromptSubmit, .preToolUse:
+      if request.agent.drivesActivityFromTranscript,
+        agentMonitorStore.isTracking(scope: scope)
+      {
+        agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
+      } else {
+        agentMonitorStore.armRunningTimeout(
+          agent: request.agent,
+          sessionID: sessionID,
+          context: request.context
+        )
+      }
     case .stop:
       agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
     case .sessionEnd, .sessionShutdown:

--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -268,13 +268,13 @@ extension TerminalCommandExecutor {
         agentMonitorStore.isTracking(scope: scope)
       {
         agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
-      } else {
-        agentMonitorStore.armRunningTimeout(
-          agent: request.agent,
-          sessionID: sessionID,
-          context: request.context
-        )
+        return
       }
+      agentMonitorStore.armRunningTimeout(
+        agent: request.agent,
+        sessionID: sessionID,
+        context: request.context
+      )
     case .stop:
       agentMonitorStore.cancelRunningTimeout(agent: request.agent, sessionID: sessionID)
     case .sessionEnd, .sessionShutdown:

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -784,6 +784,17 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     #expect(harness.host.agentActivity(for: harness.tabID) == nil)
 
+    _ = try harness.commandExecutor.handleAgentHook(
+      codexHook(
+        CodexHookFixtures.userPromptSubmit,
+        transcriptPath: transcriptPath,
+        context: harness.context
+      )
+    )
+    await advanceClock(clock)
+
+    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
+
     try CodexTranscriptFixtures.append(.taskStarted(turnID: "turn-1"), to: transcriptPath)
     await advanceClock(clock)
 


### PR DESCRIPTION
## Why

A running agent could lose its tab spinner during a quiet transcript interval such as context compaction. The reported session had 91 seconds between transcript events, allowing the 30-second hook fallback to mark the turn completed even though transcript activity later continued; completed turns then correctly rejected that later activity as stale.

## What changed

When a transcript-driven session already has an active monitor, prompt and tool hooks now cancel the hook timeout instead of rearming it. Sessions without an active transcript monitor retain the timeout fallback.

> [!NOTE]
> This does not change spinner rendering or settings. It only prevents fallback lifecycle state from overriding an active transcript monitor.

## Verification

The regression test configures a 10-millisecond fallback, submits a prompt, advances the clock by one second, and verifies that the session remains running before transcript activity continues.

- `TerminalCommandExecutorAgentHookTests`: 58 passed
- Full macOS test suite: passed
- Formatting, lint, and dead-code scan: passed
