### PR TITLE
agent-panel: scope shortcut hints to focused pane

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -447,13 +447,18 @@ struct TerminalSplitTreeView: View {
         isCollapsed: isAgentPanelCollapsed
       )
       if let agentPanelPresentation, overlayState != .hidden {
+        let shortcutHint = Self.visibleShortcutHint(
+          agentPanelShortcutHint,
+          focusedSurfaceID: focusedSurfaceID,
+          surfaceID: surfaceView.id
+        )
         AgentPanelSurface(
           isCollapsed: overlayState == .collapsedIcon,
           presentation: agentPanelPresentation,
           palette: palette,
           forksDown: agentPanelForksDown,
           reduceMotion: reduceMotion,
-          shortcutHint: agentPanelShortcutHint,
+          shortcutHint: shortcutHint,
           copyText: { text in
             action(.agentPanelCopyText(text))
           },
@@ -632,6 +637,14 @@ struct TerminalSplitTreeView: View {
 
     static func agentPanelOverlayWidth(isCollapsed: Bool) -> CGFloat {
       isCollapsed ? AgentPanelMetrics.collapsedLength : AgentPanelMetrics.expandedWidth
+    }
+
+    static func visibleShortcutHint(
+      _ shortcutHint: String?,
+      focusedSurfaceID: UUID?,
+      surfaceID: UUID
+    ) -> String? {
+      focusedSurfaceID == surfaceID ? shortcutHint : nil
     }
 
     static func shouldTriggerNotificationPulse(

--- a/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
+++ b/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
@@ -244,6 +244,28 @@ struct TerminalSplitTreeViewTests {
   }
 
   @Test
+  func agentPanelShortcutHintsOnlyShowInFocusedPane() {
+    let focusedSurfaceID = UUID()
+    let unfocusedSurfaceID = UUID()
+    let hint = AgentPanelShortcut.toggleVisibility.display
+
+    #expect(
+      TerminalSplitTreeView.LeafView.visibleShortcutHint(
+        hint,
+        focusedSurfaceID: focusedSurfaceID,
+        surfaceID: focusedSurfaceID
+      ) == hint
+    )
+    #expect(
+      TerminalSplitTreeView.LeafView.visibleShortcutHint(
+        hint,
+        focusedSurfaceID: focusedSurfaceID,
+        surfaceID: unfocusedSurfaceID
+      ) == nil
+    )
+  }
+
+  @Test
   func agentPanelForkDirectionFollowsOptionState() {
     #expect(AgentPanelView.forkDirection(forksDown: false) == .right)
     #expect(AgentPanelView.forkDirection(forksDown: true) == .down)


### PR DESCRIPTION
## Why

Holding Command publishes one window-scoped shortcut-hint state. Every visible agent panel consumed that state, so all panels in a split showed hotkeys even though agent-panel actions target the focused pane.

## What changed

Filter the shared shortcut hint at each split leaf using the focused surface ID. The focused panel receives the hint while every other panel receives no hint, with regression coverage for both cases.

> [!NOTE]
> This changes hint visibility only. Shortcut routing and agent-panel content remain unchanged.

## Verification

The focused regression exercises one hint against focused and unfocused surface IDs, asserting `⌘I` for the active pane and `nil` for the other pane.

```text
Suite TerminalSplitTreeViewTests passed
Test Succeeded
```

`make mac-check`, the full `make mac-test` suite, and the pre-push dead-code, web, and macOS gates completed successfully.
