### PR TITLE
mac: restore search field paste

### DIFF
--- a/.github/workflows/mac-test-ui.yml
+++ b/.github/workflows/mac-test-ui.yml
@@ -1,0 +1,35 @@
+name: mac-test-ui
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  MISE_HTTP_TIMEOUT: 120
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  mac-test-ui:
+    name: mac-test-ui
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-macos
+      - run: make mac-test-ui UI_RESULT_BUNDLE_PATH="$RUNNER_TEMP/supatermUITests.xcresult"
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-test-ui-xcresult
+          path: ${{ runner.temp }}/supatermUITests.xcresult
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WT_INSTALL_URL := https://raw.githubusercontent.com/khoi/git-wt/main/install.sh
 WORKTREE ?=
 LOGO_OUTPUT ?= /tmp/supaterm-lightning-logo.svg
 .DEFAULT_GOAL := help
-.PHONY: help install-git-hooks bump-and-release worktree-create mac-tuist-install mac-generate mac-tuist-generate mac-generate-sources mac-tuist-generate-release mac-tuist-generate-release-cached mac-build-ghostty mac-build-zmx mac-build mac-build-snapshot-catalog mac-run mac-run-demo mac-run-snapshot-catalog mac-generate-lightning-logo-svg mac-xcode-open mac-install-tip mac-archive mac-archive-xcodebuild mac-export-archive mac-format swiftlint mac-check mac-test mac-test-xcodebuild mac-test-e2e mac-test-snapshots mac-record-snapshots mac-scan-dead-code mac-inspect-dependencies mac-warm-cache web-help web-install web-dev web-worker-dev web-check web-lint web-fmt web-test web-build web-preview web-deploy
+.PHONY: help install-git-hooks bump-and-release worktree-create mac-tuist-install mac-generate mac-tuist-generate mac-generate-sources mac-tuist-generate-release mac-tuist-generate-release-cached mac-build-ghostty mac-build-zmx mac-build mac-build-snapshot-catalog mac-run mac-run-demo mac-run-snapshot-catalog mac-generate-lightning-logo-svg mac-xcode-open mac-install-tip mac-archive mac-archive-xcodebuild mac-export-archive mac-format swiftlint mac-check mac-test mac-test-xcodebuild mac-test-e2e mac-test-ui mac-test-snapshots mac-record-snapshots mac-scan-dead-code mac-inspect-dependencies mac-warm-cache web-help web-install web-dev web-worker-dev web-check web-lint web-fmt web-test web-build web-preview web-deploy
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -122,6 +122,9 @@ mac-test-xcodebuild:
 
 mac-test-e2e:  # Run the macOS end-to-end tests.
 	@$(MAKE) -C "$(MAC_APP_DIR)" test-e2e
+
+mac-test-ui:  # Run the macOS UI tests.
+	@$(MAKE) -C "$(MAC_APP_DIR)" test-ui
 
 mac-test-snapshots:  # Run the macOS snapshot tests.
 	@$(MAKE) -C "$(MAC_APP_DIR)" test-snapshots

--- a/apps/mac/.swiftlint.yml
+++ b/apps/mac/.swiftlint.yml
@@ -7,6 +7,7 @@ included:
   - supatermTests
   - supatermSnapshotTests
   - supatermE2E
+  - supatermUITests
 
 disabled_rules:
   - file_length

--- a/apps/mac/Makefile
+++ b/apps/mac/Makefile
@@ -25,9 +25,11 @@ TUIST_CACHE_CONFIGURATION ?= Debug
 XCODEBUILD_FLAGS ?=
 E2E_RESULT_BUNDLE_PATH ?=
 E2E_RESULT_BUNDLE_FLAGS := $(if $(strip $(E2E_RESULT_BUNDLE_PATH)),-resultBundlePath "$(E2E_RESULT_BUNDLE_PATH)",)
+UI_RESULT_BUNDLE_PATH ?=
+UI_RESULT_BUNDLE_FLAGS := $(if $(strip $(UI_RESULT_BUNDLE_PATH)),-resultBundlePath "$(UI_RESULT_BUNDLE_PATH)",)
 LOGO_OUTPUT ?= /tmp/supaterm-lightning-logo.svg
 .DEFAULT_GOAL := help
-.PHONY: tuist-install tuist-generate tuist-generate-sources tuist-generate-release tuist-generate-release-cached build-ghostty build-zmx build-app build-app-demo build-snapshot-catalog run-app run-app-demo run-snapshot-catalog generate-lightning-logo-svg install-tip archive archive-xcodebuild export-archive format lint check test test-xcodebuild test-e2e test-e2e-xcodebuild test-snapshots record-snapshots scan-dead-code inspect-dependencies warm-cache
+.PHONY: tuist-install tuist-generate tuist-generate-sources tuist-generate-release tuist-generate-release-cached build-ghostty build-zmx build-app build-app-demo build-snapshot-catalog run-app run-app-demo run-snapshot-catalog generate-lightning-logo-svg install-tip archive archive-xcodebuild export-archive format lint check test test-xcodebuild test-e2e test-e2e-xcodebuild test-ui test-ui-xcodebuild test-snapshots record-snapshots scan-dead-code inspect-dependencies warm-cache
 
 ifdef CI
 TUIST_INSTALL_FLAGS := --force-resolved-versions
@@ -179,9 +181,19 @@ test-e2e: tuist-generate build-ghostty build-zmx test-e2e-xcodebuild # Run end-t
 test-e2e-xcodebuild:
 	@if [ -n "$(strip $(E2E_RESULT_BUNDLE_PATH))" ]; then rm -rf "$(E2E_RESULT_BUNDLE_PATH)"; fi
 	@if [ -t 1 ]; then \
-		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) 2>&1 | mise exec -- xcbeautify --disable-logging'; \
+		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" 2>&1 | mise exec -- xcbeautify --disable-logging'; \
 	else \
-		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS); \
+		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""; \
+	fi
+
+test-ui: tuist-generate build-ghostty build-zmx test-ui-xcodebuild
+
+test-ui-xcodebuild:
+	@if [ -n "$(strip $(UI_RESULT_BUNDLE_PATH))" ]; then rm -rf "$(UI_RESULT_BUNDLE_PATH)"; fi
+	@if [ -t 1 ]; then \
+		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermUITests" -destination "platform=macOS" $(UI_RESULT_BUNDLE_FLAGS) 2>&1 | mise exec -- xcbeautify --disable-logging'; \
+	else \
+		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermUITests" -destination "platform=macOS" $(UI_RESULT_BUNDLE_FLAGS); \
 	fi
 
 record-snapshots: tuist-generate build-ghostty # Record snapshot references.

--- a/apps/mac/Makefile
+++ b/apps/mac/Makefile
@@ -179,9 +179,9 @@ test-e2e: tuist-generate build-ghostty build-zmx test-e2e-xcodebuild # Run end-t
 test-e2e-xcodebuild:
 	@if [ -n "$(strip $(E2E_RESULT_BUNDLE_PATH))" ]; then rm -rf "$(E2E_RESULT_BUNDLE_PATH)"; fi
 	@if [ -t 1 ]; then \
-		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" 2>&1 | mise exec -- xcbeautify --disable-logging'; \
+		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) 2>&1 | mise exec -- xcbeautify --disable-logging'; \
 	else \
-		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS) CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""; \
+		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "supatermE2E" -destination "platform=macOS" $(E2E_RESULT_BUNDLE_FLAGS); \
 	fi
 
 record-snapshots: tuist-generate build-ghostty # Record snapshot references.
@@ -191,7 +191,7 @@ scan-dead-code: tuist-generate build-ghostty build-zmx
 	mise exec -- periphery scan
 
 format: # Format code with swift format (local only)
-	swift format -p --in-place --recursive --configuration ./.swift-format.json SupaTheme SupaThemeLogoGenerator SupatermCLIShared SPCLI sp supaterm supatermTests supatermSnapshotTests supatermE2E
+	swift format -p --in-place --recursive --configuration ./.swift-format.json SupaTheme SupaThemeLogoGenerator SupatermCLIShared SPCLI sp supaterm supatermTests supatermSnapshotTests supatermE2E supatermUITests
 
 lint: # Lint code with swiftlint
 	mise exec -- swiftlint lint --quiet --config .swiftlint.yml

--- a/apps/mac/Project.swift
+++ b/apps/mac/Project.swift
@@ -560,6 +560,27 @@ let project = Project(
       )
     ),
     .target(
+      name: "supatermUITests",
+      destinations: .macOS,
+      product: .uiTests,
+      bundleId: "app.supabit.supatermUITests",
+      deploymentTargets: .macOS("26.0"),
+      infoPlist: .default,
+      buildableFolders: [
+        "supatermUITests",
+      ],
+      dependencies: [
+        .target(name: "supaterm"),
+      ],
+      settings: .settings(
+        base: [
+          "SWIFT_DEFAULT_ACTOR_ISOLATION": "nonisolated",
+          "SWIFT_STRICT_CONCURRENCY": "complete",
+        ],
+        defaultSettings: .essential
+      )
+    ),
+    .target(
       name: "supatermSnapshotCatalog",
       destinations: .macOS,
       product: .app,
@@ -710,11 +731,13 @@ let project = Project(
         targets: [
           .target("supaterm"),
           .target("supatermE2E"),
+          .target("supatermUITests"),
         ]
       ),
       testAction: .targets(
         [
           .testableTarget(target: .target("supatermE2E")),
+          .testableTarget(target: .target("supatermUITests")),
         ],
         configuration: .debug,
         expandVariableFromTarget: .target("supaterm")

--- a/apps/mac/Project.swift
+++ b/apps/mac/Project.swift
@@ -731,12 +731,27 @@ let project = Project(
         targets: [
           .target("supaterm"),
           .target("supatermE2E"),
-          .target("supatermUITests"),
         ]
       ),
       testAction: .targets(
         [
           .testableTarget(target: .target("supatermE2E")),
+        ],
+        configuration: .debug,
+        expandVariableFromTarget: .target("supaterm")
+      ),
+      analyzeAction: .analyzeAction(configuration: .debug)
+    ),
+    .scheme(
+      name: "supatermUITests",
+      buildAction: .buildAction(
+        targets: [
+          .target("supaterm"),
+          .target("supatermUITests"),
+        ]
+      ),
+      testAction: .targets(
+        [
           .testableTarget(target: .target("supatermUITests")),
         ],
         configuration: .debug,

--- a/apps/mac/supaterm/App/SupatermMenuController.swift
+++ b/apps/mac/supaterm/App/SupatermMenuController.swift
@@ -87,6 +87,8 @@ final class SupatermMenuController: NSObject {
 
   private let registry: TerminalWindowRegistry
   private var observers: [NSObjectProtocol] = []
+  private var keyWindowObservation: NSKeyValueObservation?
+  private var firstResponderObservation: NSKeyValueObservation?
   private var requestNewWindow: @MainActor () -> Bool = { false }
   private var requestShowSettings: @MainActor (SettingsFeature.Tab) -> Bool = { _ in false }
   private var requestSubmitGitHubIssue: @MainActor () -> Bool = {
@@ -1103,6 +1105,16 @@ final class SupatermMenuController: NSObject {
   }
 
   private func syncShortcut(command: SupatermCommand, item: NSMenuItem?) {
+    guard let item else { return }
+    if !(NSApp.keyWindow?.firstResponder is GhosttySurfaceView) {
+      switch command {
+      case .copyToClipboard, .pasteFromClipboard, .selectAll:
+        SupatermMenuShortcut.apply(command.defaultKeyboardShortcut, to: item)
+        return
+      default:
+        break
+      }
+    }
     syncShortcut(
       action: command.ghosttyBindingAction,
       item: item,
@@ -1141,29 +1153,12 @@ final class SupatermMenuController: NSObject {
 
   private func installObservers() {
     guard observers.isEmpty else { return }
+    keyWindowObservation = NSApp.observe(\.keyWindow, options: [.initial, .new]) { [weak self] app, _ in
+      MainActor.assumeIsolated {
+        self?.observeFirstResponder(in: app.keyWindow)
+      }
+    }
     let center = NotificationCenter.default
-    observers.append(
-      center.addObserver(
-        forName: NSWindow.didBecomeKeyNotification,
-        object: nil,
-        queue: .main
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.refresh()
-        }
-      }
-    )
-    observers.append(
-      center.addObserver(
-        forName: NSWindow.didResignKeyNotification,
-        object: nil,
-        queue: .main
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.refresh()
-        }
-      }
-    )
     observers.append(
       center.addObserver(
         forName: .ghosttyRuntimeConfigDidChange,
@@ -1175,6 +1170,15 @@ final class SupatermMenuController: NSObject {
         }
       }
     )
+  }
+
+  private func observeFirstResponder(in window: NSWindow?) {
+    firstResponderObservation = window?.observe(\.firstResponder) { [weak self] _, _ in
+      MainActor.assumeIsolated {
+        self?.refresh()
+      }
+    }
+    refresh()
   }
 
   private func topLevelMenuItem(title: String, submenu: NSMenu) -> NSMenuItem {

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -983,6 +983,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private func localEventKeyUp(_ event: NSEvent) -> NSEvent? {
     if !event.modifierFlags.contains(.command) { return event }
     guard focused else { return event }
+    guard window?.firstResponder === self else { return event }
     keyUp(with: event)
     return nil
   }
@@ -1239,6 +1240,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     guard event.type == .keyDown else { return false }
     guard let surface else { return false }
     guard focused else { return false }
+    guard window?.firstResponder === self else { return false }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
       if shouldAttemptMenu(for: bindingFlags),

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -118,7 +118,7 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didLoadProgress = await waitUntil {
       harness.host.agentPanelPresentation(for: harness.context.surfaceID)?.progressRows == [
         PaneAgentProgressRow(
           id: "claude-goal:Ship session goal progress",
@@ -127,7 +127,8 @@ struct TerminalCommandExecutorAgentHookTests {
           kind: .goal
         )
       ]
-    )
+    }
+    #expect(didLoadProgress)
   }
   @Test
   func claudePreToolUseMarksTabRunning() throws {
@@ -814,14 +815,13 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didUpdateDetail = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Updating the registry and sidebar")
-    )
-    #expect(
-      harness.host.codexHoverMarkdown(for: harness.tabID)
-        == "Updating the registry and sidebar"
-    )
+        && harness.host.codexHoverMarkdown(for: harness.tabID)
+          == "Updating the registry and sidebar"
+    }
+    #expect(didUpdateDetail)
 
     try CodexTranscriptFixtures.append(
       .assistantMessage(
@@ -832,14 +832,12 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
-      harness.host.agentActivity(for: harness.tabID)
-        == .codex(.running)
-    )
-    #expect(
-      harness.host.codexHoverMarkdown(for: harness.tabID)
-        == "Final answer should stay out of the running subtitle"
-    )
+    let didLoadFinalAnswer = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.running)
+        && harness.host.codexHoverMarkdown(for: harness.tabID)
+          == "Final answer should stay out of the running subtitle"
+    }
+    #expect(didLoadFinalAnswer)
 
     try CodexTranscriptFixtures.append(
       .taskComplete(turnID: "turn-1", lastAgentMessage: "Done."),
@@ -847,7 +845,10 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
+    let didComplete = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.idle)
+    }
+    #expect(didComplete)
   }
   @Test
   func codexSessionStartShowsAlreadyRunningTranscriptSnapshot() async throws {
@@ -1128,11 +1129,12 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didLoadDetail = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Tracking before command finished")
-    )
-    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == "Tracking before command finished")
+        && harness.host.codexHoverMarkdown(for: harness.tabID) == "Tracking before command finished"
+    }
+    #expect(didLoadDetail)
 
     let surface = try #require(harness.host.selectedSurfaceView)
     surface.bridge.onCommandFinished?()
@@ -1206,10 +1208,11 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didKeepAssistantDetail = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Inspecting the transcript path")
-    )
+    }
+    #expect(didKeepAssistantDetail)
   }
   @Test
   func codexTranscriptIgnoresReasoningAfterAssistantMessageAcrossPolls() async throws {
@@ -1236,10 +1239,11 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didLoadAssistantDetail = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Inspecting the transcript path")
-    )
+    }
+    #expect(didLoadAssistantDetail)
 
     try CodexTranscriptFixtures.append(
       .reasoning("Planning the next step"),
@@ -1281,13 +1285,14 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didAccumulateMessages = await waitUntil {
       harness.host.codexHoverMarkdown(for: harness.tabID) == """
         Inspecting the transcript path
 
         Updating the registry and sidebar
         """
-    )
+    }
+    #expect(didAccumulateMessages)
   }
   @Test
   func codexTranscriptKeepsFullHoverMessageWhenRunningDetailIsTruncated() async throws {
@@ -1316,11 +1321,12 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didLoadLongMessage = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: truncatedMessage)
-    )
-    #expect(harness.host.codexHoverMarkdown(for: harness.tabID) == longMessage)
+        && harness.host.codexHoverMarkdown(for: harness.tabID) == longMessage
+    }
+    #expect(didLoadLongMessage)
   }
   @Test
   func codexTranscriptIgnoresExecCommandRunningDetail() async throws {
@@ -1352,7 +1358,10 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
+    let didRemainRunning = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.running)
+    }
+    #expect(didRemainRunning)
   }
   @Test
   func codexTranscriptEventFallbackUpdatesDetailAndAbortedTurnClearsRunning() async throws {
@@ -1373,7 +1382,10 @@ struct TerminalCommandExecutorAgentHookTests {
     try CodexTranscriptFixtures.append(.turnStarted(turnID: "turn-1"), to: transcriptPath)
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
+    let didStart = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.running)
+    }
+    #expect(didStart)
 
     try CodexTranscriptFixtures.append(
       .agentReasoning("Inspecting transcript activity"),
@@ -1389,10 +1401,11 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(
+    let didLoadMessage = await waitUntil {
       harness.host.agentActivity(for: harness.tabID)
         == .codex(.running, detail: "Need approval?")
-    )
+    }
+    #expect(didLoadMessage)
 
     try CodexTranscriptFixtures.append(
       .turnAborted(turnID: "turn-1"),
@@ -1400,7 +1413,10 @@ struct TerminalCommandExecutorAgentHookTests {
     )
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
+    let didAbort = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.idle)
+    }
+    #expect(didAbort)
   }
   @Test
   func codexTurnCompleteMarksTabIdle() async throws {
@@ -1422,12 +1438,18 @@ struct TerminalCommandExecutorAgentHookTests {
     try CodexTranscriptFixtures.append(.turnStarted(turnID: "turn-1"), to: transcriptPath)
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.running))
+    let didStart = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.running)
+    }
+    #expect(didStart)
 
     try CodexTranscriptFixtures.append(.turnComplete(turnID: "turn-1"), to: transcriptPath)
     await advanceClock(clock)
 
-    #expect(harness.host.agentActivity(for: harness.tabID) == .codex(.idle))
+    let didComplete = await waitUntil {
+      harness.host.agentActivity(for: harness.tabID) == .codex(.idle)
+    }
+    #expect(didComplete)
   }
   @Test
   func codexChildTranscriptMessageReplacesToolDetailWithoutReplacingRootMonitor() async throws {
@@ -1792,6 +1814,15 @@ struct TerminalCommandExecutorAgentHookTests {
     try CodexTranscriptFixtures.append(.assistantMessage("Inspecting the transcript path"), to: transcriptPath)
     try CodexTranscriptFixtures.append(.assistantMessage("Updating the registry and sidebar"), to: transcriptPath)
     await advanceClock(clock)
+
+    let didLoadHistory = await waitUntil {
+      harness.host.codexHoverMarkdown(for: harness.tabID) == """
+        Inspecting the transcript path
+
+        Updating the registry and sidebar
+        """
+    }
+    #expect(didLoadHistory)
 
     _ = try harness.commandExecutor.handleAgentHook(
       CodexHookFixtures.request(CodexHookFixtures.stop, context: harness.context)

--- a/apps/mac/supatermUITests/SearchPasteUITests.swift
+++ b/apps/mac/supatermUITests/SearchPasteUITests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import XCTest
+
+final class SearchPasteUITests: XCTestCase {
+  override func setUp() {
+    continueAfterFailure = false
+  }
+
+  @MainActor
+  func testUserCanPasteIntoSearchAfterReactivatingApp() async throws {
+    let token = UUID().uuidString
+    let stateHome = FileManager.default.temporaryDirectory
+      .appendingPathComponent("supaterm-ui-\(token)", isDirectory: true)
+    let home = stateHome.appendingPathComponent("home", isDirectory: true)
+    let zmx = stateHome.appendingPathComponent("zmx", isDirectory: true)
+    let pasteboardItems = pasteboardSnapshot()
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: zmx, withIntermediateDirectories: true)
+
+    let app = XCUIApplication()
+    app.launchArguments = ["-ApplePersistenceIgnoreState", "YES"]
+    app.launchEnvironment = [
+      "HOME": home.path,
+      "SUPATERM_INSTANCE_NAME": "ui-\(token)",
+      "SUPATERM_STATE_HOME": stateHome.path,
+      "ZMX_DIR": zmx.path,
+    ]
+    addTeardownBlock {
+      app.terminate()
+      NSPasteboard.general.clearContents()
+      _ = NSPasteboard.general.writeObjects(pasteboardItems)
+      try? FileManager.default.removeItem(at: stateHome)
+    }
+
+    app.launch()
+    app.activate()
+    XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
+    let terminal = app.textViews.firstMatch
+    XCTAssertTrue(terminal.waitForExistence(timeout: 30))
+    terminal.click()
+
+    let readinessText = "search focus ready"
+    let terminalText = try XCTUnwrap(terminal.value as? String)
+    app.typeKey("f", modifierFlags: .command)
+    try await Task.sleep(for: .milliseconds(200))
+    app.typeText(readinessText)
+    XCTAssertEqual(terminal.value as? String, terminalText)
+    replacePasteboard(with: "readiness sentinel")
+    app.typeKey("a", modifierFlags: .command)
+    app.typeKey("c", modifierFlags: .command)
+    XCTAssertEqual(NSPasteboard.general.string(forType: .string), readinessText)
+    app.typeKey(.delete, modifierFlags: [])
+
+    let pastedText = "search paste regression"
+    replacePasteboard(with: pastedText)
+
+    try await reactivate(app)
+
+    app.typeKey("v", modifierFlags: .command)
+    try await Task.sleep(for: .milliseconds(500))
+    XCTAssertEqual(terminal.value as? String, terminalText)
+
+    replacePasteboard(with: "verification sentinel")
+    app.typeKey("a", modifierFlags: .command)
+    app.typeKey("c", modifierFlags: .command)
+
+    XCTAssertEqual(NSPasteboard.general.string(forType: .string), pastedText)
+
+    app.typeKey(.escape, modifierFlags: [])
+    try await reactivate(app)
+
+    let terminalInput = "terminal focus restored"
+    app.typeText(terminalInput)
+    try await Task.sleep(for: .milliseconds(500))
+    XCTAssertEqual(terminal.value as? String, terminalText + terminalInput)
+  }
+
+  @MainActor
+  private func reactivate(_ app: XCUIApplication) async throws {
+    let finder = XCUIApplication(bundleIdentifier: "com.apple.finder")
+    finder.activate()
+    XCTAssertTrue(finder.wait(for: .runningForeground, timeout: 5))
+    app.activate()
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5))
+    try await Task.sleep(for: .milliseconds(200))
+  }
+
+  @MainActor
+  private func replacePasteboard(with string: String) {
+    NSPasteboard.general.clearContents()
+    XCTAssertTrue(NSPasteboard.general.setString(string, forType: .string))
+  }
+
+  private func pasteboardSnapshot() -> [NSPasteboardItem] {
+    NSPasteboard.general.pasteboardItems?.map { item in
+      let snapshot = NSPasteboardItem()
+      for type in item.types {
+        if let data = item.data(forType: type) {
+          snapshot.setData(data, forType: type)
+        }
+      }
+      return snapshot
+    } ?? []
+  }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,12 +72,13 @@ make mac-record-snapshots       # Regenerate snapshot PNG baselines locally
 End-to-end commands:
 
 ```bash
-make mac-test-e2e       # Run socket-driven E2E and UI tests against the real app
+make mac-test-e2e       # Run socket-driven E2E tests against the real app
+make mac-test-ui        # Run UI tests against the real app
 ```
 
 E2E tests in `apps/mac/supatermE2E` spawn their own `supaterm.app` with a fresh instance name, state home, and `ZMX_DIR`, then control it through the `sp` socket protocol. They never attach to a running development or user instance.
 
-UI tests in `apps/mac/supatermUITests` launch an isolated app through XCTest and exercise user-visible behavior. Both suites run through the `supatermE2E` scheme locally and in the `mac-test-e2e` GitHub workflow.
+UI tests in `apps/mac/supatermUITests` launch an isolated app through XCTest and exercise user-visible behavior. They run through the `supatermUITests` scheme locally and in the `mac-test-ui` GitHub workflow.
 
 Use `$SUPATERM_CLI_PATH` inside Supaterm panes to call the Debug CLI injected by the running app instead of an installed `sp`:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,10 +72,12 @@ make mac-record-snapshots       # Regenerate snapshot PNG baselines locally
 End-to-end commands:
 
 ```bash
-make mac-test-e2e       # Launch the real app in an isolated instance and drive it over the socket
+make mac-test-e2e       # Run socket-driven E2E and UI tests against the real app
 ```
 
 E2E tests in `apps/mac/supatermE2E` spawn their own `supaterm.app` with a fresh instance name, state home, and `ZMX_DIR`, then control it through the `sp` socket protocol. They never attach to a running development or user instance.
+
+UI tests in `apps/mac/supatermUITests` launch an isolated app through XCTest and exercise user-visible behavior. Both suites run through the `supatermE2E` scheme locally and in the `mac-test-e2e` GitHub workflow.
 
 Use `$SUPATERM_CLI_PATH` inside Supaterm panes to call the Debug CLI injected by the running app instead of an installed `sp`:
 


### PR DESCRIPTION
## Why

Ethan reported that paste stopped working in the terminal search field after switching away to copy text and returning. Window activation could mark the selected terminal logically focused while AppKit still routed editing through the search field, and performable terminal bindings could leave the native editing menu without Command-C/V/A equivalents. Together, the terminal could consume Command-V before the field editor.

## What changed

Editing menu shortcuts now follow the key window’s actual first responder, and terminal command-key handling only runs while the terminal is the actual first responder. A signed macOS UI test reproduces the full app-switch flow and proves Escape still returns input ownership to the terminal.

The UI test has its own `supatermUITests` scheme, `make mac-test-ui` target, and `mac-test-ui` workflow. The existing `supatermE2E` scheme, `make mac-test-e2e` target, and `mac-test-e2e` workflow remain limited to socket/process coverage.

> [!NOTE]
> This is limited to native Copy, Paste, and Select All while a non-terminal responder owns focus. Custom terminal bindings remain unchanged when the terminal owns focus.

## Verification

The UI test launches isolated state, opens Find with Command-F, proves the search editor owns input, switches to Finder and back, pastes, and copies the search value back. It then presses Escape, repeats the app switch, and proves ordinary typing reaches the terminal.

`make mac-test-e2e` passed the standalone socket/process suite. `make mac-test-ui` passed the standalone UI regression. `make mac-check` and the full pre-push suite passed. The focused UI regression also passed 10 consecutive iterations and again after rebasing onto `origin/main`.
