### PR TITLE
agent-panel: avoid covering terminal cursor

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttyClipboard.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttyClipboard.swift
@@ -57,6 +57,9 @@ final class GhosttyClipboard {
     ) { allowed in
       guard surfaceReference.isValid else { return }
       complete(allowed ? value : "")
+      if allowed, case .paste = request {
+        view.confirmedPasteDidComplete()
+      }
     }
   }
 

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceState.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceState.swift
@@ -45,6 +45,7 @@ final class GhosttySurfaceState {
   var keyTableTag: ghostty_action_key_table_tag_e?
   var keyTableName: String?
   var keyTableDepth: Int = 0
+  var userInputGeneration = 0
   var secureInput: ghostty_action_secure_input_e?
   var floatWindow: ghostty_action_float_window_e?
   var reloadConfigSoft: Bool?

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -793,8 +793,19 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func recordUserInput() {
-    guard focused else { return }
-    bridge.state.userInputGeneration &+= 1
+    if focused {
+      bridge.state.userInputGeneration &+= 1
+    }
+    guard !passwordInput else { return }
+    SupatermLog.debug(
+      SupatermLog.terminal,
+      "agentPanel.cursorAvoidance.input",
+      fields: [
+        "surfaceID=\(SupatermLog.uuid(id))",
+        "focused=\(focused)",
+        "generation=\(bridge.state.userInputGeneration)",
+      ]
+    )
   }
 
   override func flagsChanged(with event: NSEvent) {

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -748,6 +748,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
       interpretKeyEvents([event])
       return
     }
+    defer { recordUserInput() }
     if focused {
       onDirectInteraction?()
     }
@@ -789,6 +790,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   override func keyUp(with event: NSEvent) {
     sendKey(action: GHOSTTY_ACTION_RELEASE, event: event)
+  }
+
+  private func recordUserInput() {
+    guard focused else { return }
+    bridge.state.userInputGeneration &+= 1
   }
 
   override func flagsChanged(with event: NSEvent) {
@@ -1035,6 +1041,36 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   func currentCellSize() -> CGSize {
     cellSize
+  }
+
+  func terminalCursorRectInScrollWrapper() -> CGRect? {
+    guard let surface, let scrollWrapper else { return nil }
+    if let lastScrollbar {
+      let bottomOffset = lastScrollbar.total - min(lastScrollbar.length, lastScrollbar.total)
+      guard lastScrollbar.offset >= bottomOffset else { return nil }
+    }
+
+    let logicalCellSize = convertFromBacking(cellSize)
+    guard logicalCellSize.width > 0, logicalCellSize.height > 0 else { return nil }
+
+    var x = 0.0
+    var y = 0.0
+    var width = 0.0
+    var height = 0.0
+    ghostty_surface_ime_point(surface, &x, &y, &width, &height)
+    let cursorHeight = max(height, logicalCellSize.height)
+    guard x.isFinite, y.isFinite, cursorHeight.isFinite, cursorHeight > 0 else { return nil }
+
+    let rect = convert(
+      CGRect(
+        x: x - logicalCellSize.width / 2,
+        y: bounds.height - y,
+        width: logicalCellSize.width,
+        height: cursorHeight
+      ),
+      to: scrollWrapper
+    )
+    return scrollWrapper.bounds.intersects(rect) ? rect : nil
   }
 
   func currentFontSizePoints() -> Double? {
@@ -1477,10 +1513,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   @IBAction func paste(_ sender: Any?) {
     performBindingAction("paste_from_clipboard")
+    recordUserInput()
   }
 
   @IBAction func pasteSelection(_ sender: Any?) {
     performBindingAction("paste_from_selection")
+    recordUserInput()
   }
 
   @IBAction override func selectAll(_ sender: Any?) {
@@ -1752,6 +1790,7 @@ extension GhosttySurfaceView: NSTextInputClient {
     }
     if keyTextAccumulator == nil {
       syncPreedit()
+      recordUserInput()
     }
   }
 
@@ -1841,6 +1880,7 @@ extension GhosttySurfaceView: NSTextInputClient {
       keyTextAccumulator = acc
       return
     }
+    defer { recordUserInput() }
     let len = chars.utf8CString.count
     if len == 0 { return }
     chars.withCString { ptr in
@@ -1888,6 +1928,7 @@ extension GhosttySurfaceView: NSServicesMenuRequestor {
     str.withCString { ptr in
       ghostty_surface_text(surface, ptr, UInt(len - 1))
     }
+    recordUserInput()
     return true
   }
 }

--- a/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Ghostty/GhosttySurfaceView.swift
@@ -808,6 +808,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
     )
   }
 
+  func confirmedPasteDidComplete() {
+    recordUserInput()
+  }
+
   override func flagsChanged(with event: NSEvent) {
     let mod: UInt32
     switch event.keyCode {

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -739,14 +739,6 @@ struct TerminalSplitTreeView: View {
     }
   }
 
-  private struct AgentPanelHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-      value = nextValue()
-    }
-  }
-
   private struct AgentPanelSurface: View {
     let isCollapsed: Bool
     let isFocused: Bool
@@ -781,15 +773,15 @@ struct TerminalSplitTreeView: View {
           openURL: openURL
         )
         .fixedSize(horizontal: false, vertical: true)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+          proxy.size.height
+        } action: { height in
+          expandedHeight = max(height, AgentPanelMetrics.collapsedLength)
+        }
         .opacity(isCollapsed ? 0 : 1)
         .scaleEffect(isCollapsed ? 0.96 : 1, anchor: .topTrailing)
         .allowsHitTesting(!isCollapsed)
         .accessibilityHidden(isCollapsed)
-        .background {
-          GeometryReader { proxy in
-            Color.clear.preference(key: AgentPanelHeightPreferenceKey.self, value: proxy.size.height)
-          }
-        }
 
         toggleButton
       }
@@ -822,10 +814,6 @@ struct TerminalSplitTreeView: View {
         value: temporarilyHidesPanel,
         reduceMotion: reduceMotion
       )
-      .onPreferenceChange(AgentPanelHeightPreferenceKey.self) { height in
-        guard height > 0 else { return }
-        expandedHeight = max(height, AgentPanelMetrics.collapsedLength)
-      }
       .task(id: activeInputGeneration) {
         await monitorCursor(activeInputGeneration)
       }

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -653,7 +653,7 @@ struct TerminalSplitTreeView: View {
       focusedSurfaceID == surfaceID ? shortcutHint : nil
     }
 
-    static func shouldTemporarilyHideAgentPanel(
+    static func shouldTemporarilyCollapseAgentPanel(
       cursorRect: CGRect?,
       surfaceSize: CGSize,
       panelHeight: CGFloat?,
@@ -778,10 +778,10 @@ struct TerminalSplitTreeView: View {
         } action: { height in
           expandedHeight = max(height, AgentPanelMetrics.collapsedLength)
         }
-        .opacity(isCollapsed ? 0 : 1)
-        .scaleEffect(isCollapsed ? 0.96 : 1, anchor: .topTrailing)
-        .allowsHitTesting(!isCollapsed)
-        .accessibilityHidden(isCollapsed)
+        .opacity(isEffectivelyCollapsed ? 0 : 1)
+        .scaleEffect(isEffectivelyCollapsed ? 0.96 : 1, anchor: .topTrailing)
+        .allowsHitTesting(!isEffectivelyCollapsed)
+        .accessibilityHidden(isEffectivelyCollapsed)
 
         toggleButton
       }
@@ -802,18 +802,10 @@ struct TerminalSplitTreeView: View {
       .shadow(color: palette.shadow, radius: 18, y: 10)
       .terminalAnimation(
         .spring(response: 0.24, dampingFraction: 0.92),
-        value: isCollapsed,
+        value: isEffectivelyCollapsed,
         reduceMotion: reduceMotion
       )
-      .opacity(temporarilyHidesPanel ? 0 : 1)
-      .allowsHitTesting(!temporarilyHidesPanel)
       .accessibilityElement(children: .contain)
-      .accessibilityHidden(temporarilyHidesPanel)
-      .terminalAnimation(
-        .easeOut(duration: 0.12),
-        value: temporarilyHidesPanel,
-        reduceMotion: reduceMotion
-      )
       .task(id: activeInputGeneration) {
         await monitorCursor(activeInputGeneration)
       }
@@ -825,13 +817,17 @@ struct TerminalSplitTreeView: View {
       return inputGeneration > 0 ? inputGeneration : nil
     }
 
-    private var temporarilyHidesPanel: Bool {
+    private var temporarilyCollapsesPanel: Bool {
       guard activeInputGeneration != nil else { return false }
       return cursorOverlapsAgentPanel(terminalCursorRect)
     }
 
+    private var isEffectivelyCollapsed: Bool {
+      isCollapsed || temporarilyCollapsesPanel
+    }
+
     private func cursorOverlapsAgentPanel(_ cursorRect: CGRect?) -> Bool {
-      return TerminalSplitTreeView.LeafView.shouldTemporarilyHideAgentPanel(
+      return TerminalSplitTreeView.LeafView.shouldTemporarilyCollapseAgentPanel(
         cursorRect: cursorRect,
         surfaceSize: surfaceSize,
         panelHeight: expandedHeight,
@@ -858,10 +854,10 @@ struct TerminalSplitTreeView: View {
             "agentPanel.cursorAvoidance.sample",
             inputGeneration: inputGeneration,
             cursorRect: cursorRect,
-            fields: ["hidden=\(cursorOverlapsAgentPanel(cursorRect))"]
+            fields: ["temporarilyCollapsed=\(cursorOverlapsAgentPanel(cursorRect))"]
           )
         }
-        if clock.now >= deadline, !temporarilyHidesPanel {
+        if clock.now >= deadline, !temporarilyCollapsesPanel {
           terminalCursorRect = nil
           return
         }
@@ -915,15 +911,16 @@ struct TerminalSplitTreeView: View {
     }
 
     private var surfaceWidth: CGFloat {
-      TerminalSplitTreeView.LeafView.agentPanelOverlayWidth(isCollapsed: isCollapsed)
+      TerminalSplitTreeView.LeafView.agentPanelOverlayWidth(isCollapsed: isEffectivelyCollapsed)
     }
 
     private var surfaceHeight: CGFloat? {
-      isCollapsed ? AgentPanelMetrics.collapsedLength : expandedHeight
+      isEffectivelyCollapsed ? AgentPanelMetrics.collapsedLength : expandedHeight
     }
 
     private var cornerRadius: CGFloat {
-      isCollapsed ? AgentPanelMetrics.collapsedCornerRadius : AgentPanelMetrics.expandedCornerRadius
+      isEffectivelyCollapsed
+        ? AgentPanelMetrics.collapsedCornerRadius : AgentPanelMetrics.expandedCornerRadius
     }
   }
 

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -756,6 +756,7 @@ struct TerminalSplitTreeView: View {
     let openURL: (URL) -> Void
 
     @State private var expandedHeight: CGFloat?
+    @State private var cursorMonitoringGeneration: Int?
     @State private var terminalCursorRect: CGRect?
 
     private static let cursorMonitoringInterval = Duration.milliseconds(50)
@@ -806,19 +807,25 @@ struct TerminalSplitTreeView: View {
         reduceMotion: reduceMotion
       )
       .accessibilityElement(children: .contain)
-      .task(id: activeInputGeneration) {
-        await monitorCursor(activeInputGeneration)
+      .onChange(of: surfaceView.bridge.state.userInputGeneration) { _, inputGeneration in
+        guard cursorMonitoringIsAllowed else { return }
+        cursorMonitoringGeneration = inputGeneration
+      }
+      .onChange(of: cursorMonitoringIsAllowed) { _, isAllowed in
+        guard !isAllowed else { return }
+        cursorMonitoringGeneration = nil
+      }
+      .task(id: cursorMonitoringGeneration) {
+        await monitorCursor(cursorMonitoringGeneration)
       }
     }
 
-    private var activeInputGeneration: Int? {
-      guard isFocused, !isCollapsed else { return nil }
-      let inputGeneration = surfaceView.bridge.state.userInputGeneration
-      return inputGeneration > 0 ? inputGeneration : nil
+    private var cursorMonitoringIsAllowed: Bool {
+      isFocused && !isCollapsed
     }
 
     private var temporarilyCollapsesPanel: Bool {
-      guard activeInputGeneration != nil else { return false }
+      guard cursorMonitoringGeneration != nil else { return false }
       return cursorOverlapsAgentPanel(terminalCursorRect)
     }
 
@@ -859,6 +866,9 @@ struct TerminalSplitTreeView: View {
         }
         if clock.now >= deadline, !temporarilyCollapsesPanel {
           terminalCursorRect = nil
+          if cursorMonitoringGeneration == inputGeneration {
+            cursorMonitoringGeneration = nil
+          }
           return
         }
         do {

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -661,19 +661,30 @@ struct TerminalSplitTreeView: View {
     ) -> Bool {
       guard
         let cursorRect,
-        let panelHeight,
-        panelHeight > 0
+        let panelFrame = agentPanelFrame(
+          surfaceSize: surfaceSize,
+          panelHeight: panelHeight,
+          topPadding: topPadding
+        )
       else { return false }
-      let panelFrame = CGRect(
+      return
+        panelFrame
+        .insetBy(dx: -agentPanelCursorClearance, dy: -agentPanelCursorClearance)
+        .intersects(cursorRect)
+    }
+
+    static func agentPanelFrame(
+      surfaceSize: CGSize,
+      panelHeight: CGFloat?,
+      topPadding: CGFloat
+    ) -> CGRect? {
+      guard let panelHeight, panelHeight > 0 else { return nil }
+      return CGRect(
         x: surfaceSize.width - agentPanelEdgePadding - AgentPanelMetrics.expandedWidth,
         y: surfaceSize.height - topPadding - panelHeight,
         width: AgentPanelMetrics.expandedWidth,
         height: panelHeight
       )
-      return
-        panelFrame
-        .insetBy(dx: -agentPanelCursorClearance, dy: -agentPanelCursorClearance)
-        .intersects(cursorRect)
     }
 
     static func shouldTriggerNotificationPulse(
@@ -828,8 +839,12 @@ struct TerminalSplitTreeView: View {
 
     private var temporarilyHidesPanel: Bool {
       guard activeInputGeneration != nil else { return false }
+      return cursorOverlapsAgentPanel(terminalCursorRect)
+    }
+
+    private func cursorOverlapsAgentPanel(_ cursorRect: CGRect?) -> Bool {
       return TerminalSplitTreeView.LeafView.shouldTemporarilyHideAgentPanel(
-        cursorRect: terminalCursorRect,
+        cursorRect: cursorRect,
         surfaceSize: surfaceSize,
         panelHeight: expandedHeight,
         topPadding: topPadding
@@ -837,16 +852,26 @@ struct TerminalSplitTreeView: View {
     }
 
     private func monitorCursor(_ inputGeneration: Int?) async {
-      guard inputGeneration != nil else {
+      guard let inputGeneration else {
         terminalCursorRect = nil
         return
       }
       let clock = ContinuousClock()
       let deadline = clock.now.advanced(by: Self.cursorMonitoringWindow)
+      var hasLoggedSample = false
       while !Task.isCancelled {
         let cursorRect = surfaceView.terminalCursorRectInScrollWrapper()
         if terminalCursorRect != cursorRect {
           terminalCursorRect = cursorRect
+        }
+        if !hasLoggedSample {
+          hasLoggedSample = true
+          logCursorAvoidance(
+            "agentPanel.cursorAvoidance.sample",
+            inputGeneration: inputGeneration,
+            cursorRect: cursorRect,
+            fields: ["hidden=\(cursorOverlapsAgentPanel(cursorRect))"]
+          )
         }
         if clock.now >= deadline, !temporarilyHidesPanel {
           terminalCursorRect = nil
@@ -858,6 +883,38 @@ struct TerminalSplitTreeView: View {
           return
         }
       }
+    }
+
+    private func logCursorAvoidance(
+      _ event: String,
+      inputGeneration: Int?,
+      cursorRect: CGRect?,
+      fields: [String] = []
+    ) {
+      guard !surfaceView.passwordInput else { return }
+      let panelFrame = TerminalSplitTreeView.LeafView.agentPanelFrame(
+        surfaceSize: surfaceSize,
+        panelHeight: expandedHeight,
+        topPadding: topPadding
+      )
+      SupatermLog.debug(
+        SupatermLog.terminal,
+        event,
+        fields: [
+          "surfaceID=\(SupatermLog.uuid(surfaceView.id))",
+          "generation=\(inputGeneration.map { String($0) } ?? "nil")",
+          "focused=\(isFocused)",
+          "collapsed=\(isCollapsed)",
+          "panel=\(Self.format(panelFrame))",
+          "cursor=\(Self.format(cursorRect))",
+        ]
+          + fields
+      )
+    }
+
+    private static func format(_ rect: CGRect?) -> String {
+      guard let rect else { return "nil" }
+      return NSStringFromRect(rect).replacingOccurrences(of: " ", with: "")
     }
 
     private var toggleButton: some View {

--- a/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -341,6 +341,7 @@ struct TerminalSplitTreeView: View {
     @State private var notificationPulseOpacity = 0.0
 
     private static let agentPanelEdgePadding: CGFloat = 12
+    private static let agentPanelCursorClearance: CGFloat = 12
 
     private var unreadGlowShape: UnevenRoundedRectangle {
       UnevenRoundedRectangle(
@@ -439,6 +440,7 @@ struct TerminalSplitTreeView: View {
     @ViewBuilder
     private func agentPanelOverlay(size: CGSize) -> some View {
       let searchIsVisible = surfaceView.bridge.state.searchNeedle != nil
+      let topPadding = Self.agentPanelTopPadding(searchIsVisible: searchIsVisible)
       let overlayState = Self.agentPanelOverlayState(
         presentation: agentPanelPresentation,
         focusedSurfaceID: focusedSurfaceID,
@@ -454,11 +456,15 @@ struct TerminalSplitTreeView: View {
         )
         AgentPanelSurface(
           isCollapsed: overlayState == .collapsedIcon,
+          isFocused: focusedSurfaceID == surfaceView.id,
           presentation: agentPanelPresentation,
           palette: palette,
           forksDown: agentPanelForksDown,
           reduceMotion: reduceMotion,
           shortcutHint: shortcutHint,
+          surfaceSize: size,
+          surfaceView: surfaceView,
+          topPadding: topPadding,
           copyText: { text in
             action(.agentPanelCopyText(text))
           },
@@ -476,7 +482,7 @@ struct TerminalSplitTreeView: View {
             action(.agentPanelURLTapped(url))
           }
         )
-        .padding(.top, Self.agentPanelTopPadding(searchIsVisible: searchIsVisible))
+        .padding(.top, topPadding)
         .padding([.leading, .trailing, .bottom], Self.agentPanelEdgePadding)
       }
     }
@@ -647,6 +653,29 @@ struct TerminalSplitTreeView: View {
       focusedSurfaceID == surfaceID ? shortcutHint : nil
     }
 
+    static func shouldTemporarilyHideAgentPanel(
+      cursorRect: CGRect?,
+      surfaceSize: CGSize,
+      panelHeight: CGFloat?,
+      topPadding: CGFloat
+    ) -> Bool {
+      guard
+        let cursorRect,
+        let panelHeight,
+        panelHeight > 0
+      else { return false }
+      let panelFrame = CGRect(
+        x: surfaceSize.width - agentPanelEdgePadding - AgentPanelMetrics.expandedWidth,
+        y: surfaceSize.height - topPadding - panelHeight,
+        width: AgentPanelMetrics.expandedWidth,
+        height: panelHeight
+      )
+      return
+        panelFrame
+        .insetBy(dx: -agentPanelCursorClearance, dy: -agentPanelCursorClearance)
+        .intersects(cursorRect)
+    }
+
     static func shouldTriggerNotificationPulse(
       from oldValue: Bool,
       to newValue: Bool,
@@ -709,17 +738,25 @@ struct TerminalSplitTreeView: View {
 
   private struct AgentPanelSurface: View {
     let isCollapsed: Bool
+    let isFocused: Bool
     let presentation: PaneAgentPanelPresentation
     let palette: Palette
     let forksDown: Bool
     let reduceMotion: Bool
     let shortcutHint: String?
+    let surfaceSize: CGSize
+    let surfaceView: GhosttySurfaceView
+    let topPadding: CGFloat
     let copyText: (String) -> Void
     let forkSession: (SupatermPaneDirection, PaneAgentPanelSession) -> Void
     let toggle: () -> Void
     let openURL: (URL) -> Void
 
     @State private var expandedHeight: CGFloat?
+    @State private var terminalCursorRect: CGRect?
+
+    private static let cursorMonitoringInterval = Duration.milliseconds(50)
+    private static let cursorMonitoringWindow = Duration.seconds(1)
 
     var body: some View {
       ZStack(alignment: .topTrailing) {
@@ -765,10 +802,61 @@ struct TerminalSplitTreeView: View {
         value: isCollapsed,
         reduceMotion: reduceMotion
       )
+      .opacity(temporarilyHidesPanel ? 0 : 1)
+      .allowsHitTesting(!temporarilyHidesPanel)
       .accessibilityElement(children: .contain)
+      .accessibilityHidden(temporarilyHidesPanel)
+      .terminalAnimation(
+        .easeOut(duration: 0.12),
+        value: temporarilyHidesPanel,
+        reduceMotion: reduceMotion
+      )
       .onPreferenceChange(AgentPanelHeightPreferenceKey.self) { height in
         guard height > 0 else { return }
         expandedHeight = max(height, AgentPanelMetrics.collapsedLength)
+      }
+      .task(id: activeInputGeneration) {
+        await monitorCursor(activeInputGeneration)
+      }
+    }
+
+    private var activeInputGeneration: Int? {
+      guard isFocused, !isCollapsed else { return nil }
+      let inputGeneration = surfaceView.bridge.state.userInputGeneration
+      return inputGeneration > 0 ? inputGeneration : nil
+    }
+
+    private var temporarilyHidesPanel: Bool {
+      guard activeInputGeneration != nil else { return false }
+      return TerminalSplitTreeView.LeafView.shouldTemporarilyHideAgentPanel(
+        cursorRect: terminalCursorRect,
+        surfaceSize: surfaceSize,
+        panelHeight: expandedHeight,
+        topPadding: topPadding
+      )
+    }
+
+    private func monitorCursor(_ inputGeneration: Int?) async {
+      guard inputGeneration != nil else {
+        terminalCursorRect = nil
+        return
+      }
+      let clock = ContinuousClock()
+      let deadline = clock.now.advanced(by: Self.cursorMonitoringWindow)
+      while !Task.isCancelled {
+        let cursorRect = surfaceView.terminalCursorRectInScrollWrapper()
+        if terminalCursorRect != cursorRect {
+          terminalCursorRect = cursorRect
+        }
+        if clock.now >= deadline, !temporarilyHidesPanel {
+          terminalCursorRect = nil
+          return
+        }
+        do {
+          try await clock.sleep(for: Self.cursorMonitoringInterval)
+        } catch {
+          return
+        }
       }
     }
 

--- a/apps/mac/supatermTests/GhosttyClipboardConfirmationTests.swift
+++ b/apps/mac/supatermTests/GhosttyClipboardConfirmationTests.swift
@@ -103,12 +103,15 @@ struct GhosttyClipboardConfirmationTests {
     let pasteboard = NSPasteboard.ghosttySelection
     pasteboard.clearContents()
     pasteboard.setString("\(marker)_A\n\(marker)_B", forType: .string)
+    let inputGeneration = fixture.surface.bridge.state.userInputGeneration
 
     fixture.surface.pasteSelection(nil)
 
     let sheet = try await attachedSheet(of: fixture.window)
+    #expect(fixture.surface.bridge.state.userInputGeneration == inputGeneration + 1)
     try button(titled: "Cancel", in: sheet).performClick(nil)
     try await waitForSheetDismissal(from: fixture.window)
+    #expect(fixture.surface.bridge.state.userInputGeneration == inputGeneration + 1)
     pasteboard.clearContents()
     pasteboard.setString("SUPATERM_SAFE_PROBE", forType: .string)
     fixture.surface.pasteSelection(nil)
@@ -131,12 +134,15 @@ struct GhosttyClipboardConfirmationTests {
     let pasteboard = NSPasteboard.ghosttySelection
     pasteboard.clearContents()
     pasteboard.setString("\(firstLine)\n\(secondLine)\n", forType: .string)
+    let inputGeneration = fixture.surface.bridge.state.userInputGeneration
 
     fixture.surface.pasteSelection(nil)
 
     let sheet = try await attachedSheet(of: fixture.window)
+    #expect(fixture.surface.bridge.state.userInputGeneration == inputGeneration + 1)
     try button(titled: "Paste", in: sheet).performClick(nil)
     try await waitForSheetDismissal(from: fixture.window)
+    #expect(fixture.surface.bridge.state.userInputGeneration == inputGeneration + 2)
     let contents = try await capturedText(from: fixture.surface, containing: secondLine)
     #expect(occurrences(of: firstLine, in: contents) == 1)
     #expect(occurrences(of: secondLine, in: contents) == 1)

--- a/apps/mac/supatermTests/GhosttySurfaceViewTests.swift
+++ b/apps/mac/supatermTests/GhosttySurfaceViewTests.swift
@@ -92,6 +92,39 @@ struct GhosttySurfaceViewTests {
 
   @Test
   @MainActor
+  func focusedKeyInputAdvancesUserInputGeneration() throws {
+    initializeGhosttyForTests()
+
+    let surfaceView = GhosttySurfaceView(
+      runtime: GhosttyRuntime(),
+      tabID: UUID(),
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB
+    )
+    defer { surfaceView.closeSurface() }
+    surfaceView.focusDidChange(true)
+    let event = try #require(
+      NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: [],
+        timestamp: 0,
+        windowNumber: 0,
+        context: nil,
+        characters: "a",
+        charactersIgnoringModifiers: "a",
+        isARepeat: false,
+        keyCode: 0
+      )
+    )
+
+    surfaceView.keyDown(with: event)
+
+    #expect(surfaceView.bridge.state.userInputGeneration == 1)
+  }
+
+  @Test
+  @MainActor
   func surfaceCreationReceivesUnbackedView() {
     initializeGhosttyForTests()
 

--- a/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
+++ b/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
@@ -14,7 +14,7 @@ struct TerminalSplitTreeViewTests {
     panelHeight: CGFloat? = 180,
     topPadding: CGFloat = 12
   ) -> Bool {
-    TerminalSplitTreeView.LeafView.shouldTemporarilyHideAgentPanel(
+    TerminalSplitTreeView.LeafView.shouldTemporarilyCollapseAgentPanel(
       cursorRect: cursorRect,
       surfaceSize: CGSize(width: 800, height: 600),
       panelHeight: panelHeight,
@@ -250,7 +250,7 @@ struct TerminalSplitTreeViewTests {
   }
 
   @Test
-  func caretNearExpandedAgentPanelTemporarilyHidesIt() {
+  func caretNearExpandedAgentPanelTemporarilyCollapsesIt() {
     #expect(agentPanelObscuresCursor(CGRect(x: 470, y: 400, width: 10, height: 20)))
   }
 

--- a/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
+++ b/apps/mac/supatermTests/TerminalSplitTreeViewTests.swift
@@ -9,6 +9,19 @@ struct TerminalSplitTreeViewTests {
     let id = UUID()
   }
 
+  private func agentPanelObscuresCursor(
+    _ cursorRect: CGRect?,
+    panelHeight: CGFloat? = 180,
+    topPadding: CGFloat = 12
+  ) -> Bool {
+    TerminalSplitTreeView.LeafView.shouldTemporarilyHideAgentPanel(
+      cursorRect: cursorRect,
+      surfaceSize: CGSize(width: 800, height: 600),
+      panelHeight: panelHeight,
+      topPadding: topPadding
+    )
+  }
+
   @Test
   func notificationPulsePatternMatchesThreeFixedSizePulses() {
     #expect(TerminalNotificationPulsePattern.initialOpacity == 1)
@@ -234,6 +247,27 @@ struct TerminalSplitTreeViewTests {
   func collapsedAgentPanelKeepsOnlyToggleWidth() {
     #expect(TerminalSplitTreeView.LeafView.agentPanelOverlayWidth(isCollapsed: false) == 306)
     #expect(TerminalSplitTreeView.LeafView.agentPanelOverlayWidth(isCollapsed: true) == 30)
+  }
+
+  @Test
+  func caretNearExpandedAgentPanelTemporarilyHidesIt() {
+    #expect(agentPanelObscuresCursor(CGRect(x: 470, y: 400, width: 10, height: 20)))
+  }
+
+  @Test
+  func agentPanelRemainsVisibleWhenCaretCannotObscureIt() {
+    #expect(!agentPanelObscuresCursor(CGRect(x: 450, y: 400, width: 8, height: 20)))
+    #expect(!agentPanelObscuresCursor(CGRect(x: 500, y: 370, width: 10, height: 8)))
+    #expect(!agentPanelObscuresCursor(nil))
+    #expect(!agentPanelObscuresCursor(CGRect(x: 470, y: 400, width: 10, height: 20), panelHeight: nil))
+  }
+
+  @Test
+  func searchOffsetMovesAgentPanelCursorAvoidanceRegion() {
+    let cursorRect = CGRect(x: 500, y: 570, width: 10, height: 10)
+
+    #expect(agentPanelObscuresCursor(cursorRect))
+    #expect(!agentPanelObscuresCursor(cursorRect, topPadding: GhosttySurfaceSearchOverlay.topReservedHeight))
   }
 
   @Test


### PR DESCRIPTION
## Why

Long prompts can place the terminal caret beneath the expanded agent panel, hiding the insertion point while the user edits. Ghostty already owns the rendered caret position, but the SwiftUI overlay did not account for it.

This reads Ghostty's caret geometry only after focused user input and compares it with the measured panel frame. Reported by Ethan.

## What changed

- Track focused keyboard, paste, service, and input-method activity without reacting to agent output alone.
- Measure the expanded panel directly so cursor avoidance always receives its rendered height.
- Collapse the expanded panel to its info button when the caret enters its 12-point clearance area, then restore it once the caret clears without changing manual visibility.
- Emit bounded verbose OSLog diagnostics for input generation and cursor/panel geometry while suppressing secure-input diagnostics.
- Cover input detection and panel geometry, including the search overlay offset, with regression tests.

## Verification

Focused regressions exercise real Ghostty key input plus the panel overlap boundaries:

```text
Suite GhosttySurfaceViewTests passed
Suite TerminalSplitTreeViewTests passed
Test Succeeded
```

Repository gates:

```text
make mac-check
swift format completed
swiftlint completed

make mac-test
Test Suite 'All tests' passed

make mac-scan-dead-code
Built supaterm and supatermSnapshotCatalog with no findings
```

> [!NOTE]
> Only focused user input arms cursor monitoring; terminal output alone never collapses the panel.
