### PR TITLE
agent-panel: preserve foreground during internal sessions

### DIFF
--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -35,7 +35,10 @@ extension TerminalCommandExecutor {
   func handleAgentHook(_ request: SupatermAgentHookRequest) throws -> TerminalAgentHookResult {
     pruneDeadAgentProcesses()
     let events = TerminalAgentEventTranslator.events(for: request)
-    guard !events.isEmpty, let terminal = agentTerminal(for: request) else {
+    guard !events.isEmpty,
+      let terminal = agentTerminal(for: request),
+      shouldHandleAgentHook(request, in: terminal)
+    else {
       return TerminalAgentHookResult(desktopNotification: nil)
     }
 
@@ -315,6 +318,19 @@ extension TerminalCommandExecutor {
       sessionID: request.event.sessionID,
       context: request.context
     )
+  }
+
+  private func shouldHandleAgentHook(
+    _ request: SupatermAgentHookRequest,
+    in terminal: TerminalHostState
+  ) -> Bool {
+    guard request.agent == .codex,
+      request.event.transcriptPath == nil,
+      let sessionID = request.event.sessionID
+    else {
+      return true
+    }
+    return terminal.hasAgentSession(agent: .codex, sessionID: sessionID)
   }
 
   private func agentTerminal(

--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -326,11 +326,18 @@ extension TerminalCommandExecutor {
   ) -> Bool {
     guard request.agent == .codex,
       request.event.transcriptPath == nil,
-      let sessionID = request.event.sessionID
+      let sessionID = request.event.sessionID,
+      !terminal.hasAgentSession(agent: .codex, sessionID: sessionID),
+      let surfaceID = request.context?.surfaceID,
+      let processID = request.processID
     else {
       return true
     }
-    return terminal.hasAgentSession(agent: .codex, sessionID: sessionID)
+    return !terminal.hasForegroundAgentSession(
+      agent: .codex,
+      processID: processID,
+      for: surfaceID
+    )
   }
 
   private func agentTerminal(

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
@@ -340,6 +340,16 @@ extension TerminalHostState {
     agentStateStore.hasSession(agent: agent, sessionID: sessionID)
   }
 
+  func hasForegroundAgentSession(
+    agent: SupatermAgentKind,
+    processID: Int32,
+    for surfaceID: UUID
+  ) -> Bool {
+    agentStateStore.snapshots(for: surfaceID).contains {
+      $0.agent == agent && $0.isForeground && $0.processIDs.contains(processID)
+    }
+  }
+
   func agentSessionIsForeground(agent: SupatermAgentKind, sessionID: String) -> Bool {
     agentStateStore.isForeground(agent: agent, sessionID: sessionID)
   }

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -1048,6 +1048,34 @@ struct TerminalCommandExecutorAgentHookTests {
     )
   }
   @Test
+  func codexTranscriptlessPostToolUseRecoversMissingSession() throws {
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .codex,
+        context: harness.context,
+        event: CodexHookFixtures.planUpdate([
+          ("Recovered session", "in_progress")
+        ]),
+        processID: getpid()
+      )
+    )
+
+    #expect(
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?.progressRows == [
+        PaneAgentProgressRow(
+          id: "0:Recovered session",
+          title: "Recovered session",
+          status: .running
+        )
+      ]
+    )
+    #expect(
+      harness.host.hasAgentSession(agent: .codex, sessionID: CodexHookFixtures.sessionID)
+    )
+  }
+  @Test
   func codexPreToolUseRecoversMissingSessionAndStartsPanelTracking() throws {
     let harness = try makeClaudeHookHarness()
     let transcriptPath = try CodexTranscriptFixtures.makeTranscript()
@@ -1606,6 +1634,7 @@ struct TerminalCommandExecutorAgentHookTests {
   @Test
   func codexTranscriptlessSessionCannotReplaceForegroundSession() throws {
     let harness = try makeClaudeHookHarness()
+    let processID = getpid()
 
     for hookEventName in [
       SupatermAgentHookEventName.sessionStart,
@@ -1616,7 +1645,8 @@ struct TerminalCommandExecutorAgentHookTests {
           agent: .codex,
           sessionID: "foreground-session",
           hookEventName: hookEventName,
-          context: harness.context
+          context: harness.context,
+          processID: processID
         )
       )
     }
@@ -1650,7 +1680,8 @@ struct TerminalCommandExecutorAgentHookTests {
         SupatermAgentHookRequest(
           agent: .codex,
           context: harness.context,
-          event: event
+          event: event,
+          processID: processID
         )
       )
       #expect(result.desktopNotification == nil)

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -1604,6 +1604,74 @@ struct TerminalCommandExecutorAgentHookTests {
     #expect(session.forkStartupCommand.contains("codex fork child-session"))
   }
   @Test
+  func codexTranscriptlessSessionCannotReplaceForegroundSession() throws {
+    let harness = try makeClaudeHookHarness()
+
+    for hookEventName in [
+      SupatermAgentHookEventName.sessionStart,
+      .userPromptSubmit,
+    ] {
+      _ = try harness.commandExecutor.handleAgentHook(
+        agentHookRequest(
+          agent: .codex,
+          sessionID: "foreground-session",
+          hookEventName: hookEventName,
+          context: harness.context
+        )
+      )
+    }
+
+    let memorySessionID = "memory-session"
+    let memoryWorkingDirectory = "/tmp/codex/memories"
+    let memoryEvents = [
+      SupatermAgentHookEvent(
+        cwd: memoryWorkingDirectory,
+        hookEventName: .sessionStart,
+        sessionID: memorySessionID
+      ),
+      SupatermAgentHookEvent(
+        cwd: memoryWorkingDirectory,
+        hookEventName: .postToolUse,
+        sessionID: memorySessionID,
+        toolInput: .object([
+          "plan": .array([
+            .object([
+              "status": .string("in_progress"),
+              "step": .string("Refresh memory_summary.md"),
+            ])
+          ])
+        ]),
+        toolName: "update_plan",
+        turnID: "memory-turn"
+      ),
+    ]
+    for event in memoryEvents {
+      let result = try harness.commandExecutor.handleAgentHook(
+        SupatermAgentHookRequest(
+          agent: .codex,
+          context: harness.context,
+          event: event
+        )
+      )
+      #expect(result.desktopNotification == nil)
+    }
+
+    let presentation = try #require(
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)
+    )
+    #expect(
+      presentation.session
+        == PaneAgentPanelSession.supported(
+          agent: .codex,
+          sessionID: "foreground-session",
+          workingDirectoryPath: "\(CodexHookFixtures.cwd)/"
+        )
+    )
+    #expect(presentation.workingDirectoryPath == "\(CodexHookFixtures.cwd)/")
+    #expect(presentation.progressRows.isEmpty)
+    #expect(!harness.host.hasAgentSession(agent: .codex, sessionID: memorySessionID))
+  }
+  @Test
   func codexSamePaneSessionStartRoutesStopToNewestSession() throws {
     let harness = try makeClaudeHookHarness(windowActivity: .inactive)
 

--- a/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
@@ -88,7 +88,8 @@ func agentHookRequest(
   sessionID: String,
   hookEventName: SupatermAgentHookEventName,
   context: SupatermCLIContext? = nil,
-  lastAssistantMessage: String? = nil
+  lastAssistantMessage: String? = nil,
+  processID: Int32? = nil
 ) -> SupatermAgentHookRequest {
   SupatermAgentHookRequest(
     agent: agent,
@@ -99,7 +100,8 @@ func agentHookRequest(
       lastAssistantMessage: lastAssistantMessage,
       sessionID: sessionID,
       transcriptPath: agent == .codex ? CodexHookFixtures.transcriptPath : nil
-    )
+    ),
+    processID: processID
   )
 }
 

--- a/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorTestSupport.swift
@@ -97,7 +97,8 @@ func agentHookRequest(
       cwd: CodexHookFixtures.cwd,
       hookEventName: hookEventName,
       lastAssistantMessage: lastAssistantMessage,
-      sessionID: sessionID
+      sessionID: sessionID,
+      transcriptPath: agent == .codex ? CodexHookFixtures.transcriptPath : nil
     )
   )
 }


### PR DESCRIPTION
## Why

Codex's internal memory consolidation inherits the active pane's Supaterm context and emits hooks under its own session ID from `~/.codex/memories`. Those hooks have no transcript path, but Supaterm previously admitted the unseen session through ambient pane context, promoted it to foreground, and replaced the real terminal session's workspace and progress.

## What changed

Suppress an unknown transcriptless Codex session only when its process already owns the pane's foreground Codex session. This identifies inherited internal workers while preserving transcriptless recovery when `SessionStart` was missed.

> [!NOTE]
> Other agents, already-owned Codex sessions, and first-hook recovery when no foreground session exists are unchanged.

## Verification

One regression establishes a foreground session, replays same-process transcriptless memory-worker session and plan events, then verifies that the original workspace remains visible, progress stays untouched, and the internal session is never stored. A second starts with a transcriptless `PostToolUse` plan event and verifies that the documented missed-session recovery path still binds the session and presents its progress.

```text
Suite TerminalCommandExecutorAgentHookTests passed
Test Succeeded
* No unused code detected.
```

`make mac-check`, the full `make mac-test` suite, and all pre-push macOS and web gates completed successfully.
