### PR TITLE
agent-panel: show assigned subagent tasks

### DIFF
--- a/apps/mac/supaterm/App/AgentMonitorSnapshot.swift
+++ b/apps/mac/supaterm/App/AgentMonitorSnapshot.swift
@@ -5,6 +5,7 @@ struct AgentMonitorSnapshot: Equatable {
   var detail: String?
   var hoverMessages: [String] = []
   var progressRows: [PaneAgentProgressRow] = []
+  var childTasks: [String: String] = [:]
 }
 
 nonisolated struct AgentTranscriptUpdate: Sendable {

--- a/apps/mac/supaterm/App/ClaudeProgressMonitor.swift
+++ b/apps/mac/supaterm/App/ClaudeProgressMonitor.swift
@@ -281,21 +281,44 @@ private struct ClaudeTranscriptTaskState: Equatable {
   }
 }
 
+private struct ClaudeTranscriptChildState: Equatable {
+  var tasks: [String: String] = [:]
+
+  mutating func apply(_ objects: [JSONObject]) {
+    for object in objects {
+      guard object["type"]?.stringValue == "user",
+        let result = object["toolUseResult"]?.objectValue,
+        let agentID = AgentProgressParsing.normalizedTitle(result["agentId"]?.stringValue),
+        let task = AgentProgressParsing.normalizedTitle(result["description"]?.stringValue)
+      else {
+        continue
+      }
+      tasks[agentID] = task
+    }
+  }
+}
+
 @MainActor
 final class ClaudePanelMonitor: AgentPanelMonitor {
+  private var childState = ClaudeTranscriptChildState()
   private var transcriptState = ClaudeTranscriptTaskState()
   private var transcriptRows: [PaneAgentProgressRow] = []
   private var currentSnapshot: AgentMonitorSnapshot?
 
   func consume(_ update: AgentTranscriptUpdate) -> AgentMonitorSnapshot? {
     if update.didReset {
+      childState = ClaudeTranscriptChildState()
       transcriptState = ClaudeTranscriptTaskState()
       transcriptRows = []
     }
+    childState.apply(update.objects)
     if let rows = apply(update.objects) {
       transcriptRows = rows
     }
-    let nextSnapshot = AgentMonitorSnapshot(progressRows: transcriptRows)
+    let nextSnapshot = AgentMonitorSnapshot(
+      progressRows: transcriptRows,
+      childTasks: childState.tasks
+    )
     guard nextSnapshot != currentSnapshot else { return nil }
     currentSnapshot = nextSnapshot
     return nextSnapshot

--- a/apps/mac/supaterm/App/TerminalAgentEvent.swift
+++ b/apps/mac/supaterm/App/TerminalAgentEvent.swift
@@ -48,7 +48,7 @@ nonisolated struct TerminalAgentEvent: Equatable, Sendable {
     case sessionStarted(transcriptPath: String?)
     case subagentStarted(nickname: String?, role: String?, transcriptPath: String? = nil)
     case subagentStopped
-    case subagentTaskUpdated(String)
+    case subagentTasksUpdated([String: String])
     case turnCompleted(message: String?)
     case turnRunning(detail: String?)
     case turnStarted

--- a/apps/mac/supaterm/App/TerminalAgentEvent.swift
+++ b/apps/mac/supaterm/App/TerminalAgentEvent.swift
@@ -48,6 +48,7 @@ nonisolated struct TerminalAgentEvent: Equatable, Sendable {
     case sessionStarted(transcriptPath: String?)
     case subagentStarted(nickname: String?, role: String?, transcriptPath: String? = nil)
     case subagentStopped
+    case subagentTaskUpdated(String)
     case turnCompleted(message: String?)
     case turnRunning(detail: String?)
     case turnStarted

--- a/apps/mac/supaterm/App/TerminalAgentEventTranslator.swift
+++ b/apps/mac/supaterm/App/TerminalAgentEventTranslator.swift
@@ -78,7 +78,9 @@ nonisolated enum TerminalAgentEventTranslator {
         message: request.event.message
       )
     case .postToolUse:
-      return attentionResolutionEvents(for: request, scope: scope) + [
+      let resolutionEvents = attentionResolutionEvents(for: request, scope: scope)
+      guard scope.subagentID == nil else { return resolutionEvents }
+      return resolutionEvents + [
         event(
           request,
           scope: scope,
@@ -86,6 +88,7 @@ nonisolated enum TerminalAgentEventTranslator {
         )
       ]
     case .preToolUse:
+      guard scope.subagentID == nil else { return [] }
       action = .turnRunning(detail: request.event.toolName)
     case .sessionEnd:
       action = .sessionEnded

--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -133,6 +133,22 @@ extension TerminalCommandExecutor {
       )
       didChange = terminal.applyAgentEvent(event).changed || didChange
     }
+    if scope.subagentID == nil {
+      for (subagentID, task) in snapshot.childTasks.sorted(by: { $0.key < $1.key }) {
+        let event = TerminalAgentEvent(
+          scope: TerminalAgentEvent.Scope(
+            agent: scope.agent,
+            sessionID: scope.sessionID,
+            turnID: turnID,
+            subagentID: subagentID
+          ),
+          context: context,
+          action: .subagentTaskUpdated(task),
+          origin: .transcript
+        )
+        didChange = terminal.applyAgentEvent(event).changed || didChange
+      }
+    }
     if didChange {
       terminal.sessionDidChange()
     }

--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -117,6 +117,7 @@ extension TerminalCommandExecutor {
     if scope.subagentID == nil {
       actions.append(.hoverMessagesUpdated(snapshot.hoverMessages))
       actions.append(.progressUpdated(snapshot.progressRows, source: .transcript))
+      actions.append(.subagentTasksUpdated(snapshot.childTasks))
     }
     var didChange = false
     for action in actions {
@@ -132,22 +133,6 @@ extension TerminalCommandExecutor {
         origin: .transcript
       )
       didChange = terminal.applyAgentEvent(event).changed || didChange
-    }
-    if scope.subagentID == nil {
-      for (subagentID, task) in snapshot.childTasks.sorted(by: { $0.key < $1.key }) {
-        let event = TerminalAgentEvent(
-          scope: TerminalAgentEvent.Scope(
-            agent: scope.agent,
-            sessionID: scope.sessionID,
-            turnID: turnID,
-            subagentID: subagentID
-          ),
-          context: context,
-          action: .subagentTaskUpdated(task),
-          origin: .transcript
-        )
-        didChange = terminal.applyAgentEvent(event).changed || didChange
-      }
     }
     if didChange {
       terminal.sessionDidChange()

--- a/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
@@ -24,6 +24,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
   let nickname: String?
   let role: String?
   let transcriptPath: String?
+  let task: String?
   let phase: AgentActivityPhase
   let detail: String?
   let attentionRequestID: String?
@@ -33,6 +34,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
     nickname: String?,
     role: String?,
     transcriptPath: String? = nil,
+    task: String? = nil,
     phase: AgentActivityPhase,
     detail: String?,
     attentionRequestID: String? = nil
@@ -41,6 +43,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
     self.nickname = nickname
     self.role = role
     self.transcriptPath = transcriptPath
+    self.task = task
     self.phase = phase
     self.detail = detail
     self.attentionRequestID = attentionRequestID
@@ -49,6 +52,7 @@ nonisolated struct TerminalAgentActiveChild: Codable, Equatable, Identifiable, S
   var subagentID: String { id.subagentID }
   var sessionID: String { id.sessionID }
   var turnID: String? { id.turnID }
+  var displayDetail: String? { detail ?? task }
 }
 
 nonisolated struct TerminalAgentStatePresentation: Equatable, Sendable {
@@ -197,7 +201,7 @@ nonisolated struct TerminalAgentStateStore {
         && (state.attentionRequestID == nil || state.attentionRequestID == requestID)
     case .hoverMessagesUpdated, .progressUpdated(_, source: .transcript):
       return acceptsTranscriptProjection(turnID: event.scope.turnID, state: state)
-    case .subagentStarted, .subagentStopped:
+    case .subagentStarted, .subagentStopped, .subagentTaskUpdated:
       return false
     }
   }
@@ -210,7 +214,7 @@ nonisolated struct TerminalAgentStateStore {
     if case .subagentStarted = event.action { return true }
     guard let child = state.activeChildren[key] else { return false }
     switch event.action {
-    case .subagentStopped, .attentionRequested, .turnStarted, .turnCompleted:
+    case .subagentStopped, .subagentTaskUpdated, .attentionRequested, .turnStarted, .turnCompleted:
       return true
     case .attentionResolved(let requestID):
       return child.phase == .needsInput
@@ -306,7 +310,7 @@ nonisolated struct TerminalAgentStateStore {
       updateHoverMessages(messages, turnID: event.scope.turnID, state: &state)
     case .progressUpdated(let rows, let source):
       updateProgress(rows, source: source, turnID: event.scope.turnID, state: &state)
-    case .sessionEnded, .subagentStarted, .subagentStopped:
+    case .sessionEnded, .subagentStarted, .subagentStopped, .subagentTaskUpdated:
       break
     }
   }
@@ -333,12 +337,16 @@ nonisolated struct TerminalAgentStateStore {
           nickname: nickname,
           role: role,
           transcriptPath: transcriptPath,
+          task: nil,
           phase: .running,
           detail: nil
         )
       }
     case .subagentStopped:
       state.activeChildren.removeValue(forKey: childKey)
+    case .subagentTaskUpdated(let task):
+      guard let child = state.activeChildren[childKey] else { return }
+      state.activeChildren[childKey] = child.updating(task: task)
     default:
       updateChild(event.action, key: childKey, state: &state)
     }
@@ -541,7 +549,7 @@ nonisolated struct TerminalAgentStateStore {
     let detail =
       state.phase == phase
       ? state.detail
-      : activeChildren.first(where: { $0.phase == phase })?.detail
+      : activeChildren.first(where: { $0.phase == phase })?.displayDetail
     return TerminalAgentStatePresentation(
       agent: agent,
       sessionID: sessionID,
@@ -766,6 +774,20 @@ extension TerminalAgentActiveChild {
       nickname: nickname ?? self.nickname,
       role: role ?? self.role,
       transcriptPath: transcriptPath ?? self.transcriptPath,
+      task: task,
+      phase: phase,
+      detail: detail,
+      attentionRequestID: attentionRequestID
+    )
+  }
+
+  fileprivate nonisolated func updating(task: String) -> Self {
+    Self(
+      id: id,
+      nickname: nickname,
+      role: role,
+      transcriptPath: transcriptPath,
+      task: task,
       phase: phase,
       detail: detail,
       attentionRequestID: attentionRequestID
@@ -782,6 +804,7 @@ extension TerminalAgentActiveChild {
       nickname: nickname,
       role: role,
       transcriptPath: transcriptPath,
+      task: task,
       phase: phase,
       detail: detail,
       attentionRequestID: attentionRequestID

--- a/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalAgentStateStore.swift
@@ -118,6 +118,7 @@ nonisolated struct TerminalAgentStateStore {
 
   private struct SessionState: Equatable {
     var activeChildren: [TerminalAgentActiveChild.Identity: TerminalAgentActiveChild] = [:]
+    var pendingChildTasks: [String: String] = [:]
     var detail: String?
     var attentionRequestID: String?
     var hoverMessages: [String] = []
@@ -199,9 +200,9 @@ nonisolated struct TerminalAgentStateStore {
       return targetsActiveTurn(event.scope.turnID, state: state)
         && state.phase == .needsInput
         && (state.attentionRequestID == nil || state.attentionRequestID == requestID)
-    case .hoverMessagesUpdated, .progressUpdated(_, source: .transcript):
+    case .hoverMessagesUpdated, .progressUpdated(_, source: .transcript), .subagentTasksUpdated:
       return acceptsTranscriptProjection(turnID: event.scope.turnID, state: state)
-    case .subagentStarted, .subagentStopped, .subagentTaskUpdated:
+    case .subagentStarted, .subagentStopped:
       return false
     }
   }
@@ -214,7 +215,7 @@ nonisolated struct TerminalAgentStateStore {
     if case .subagentStarted = event.action { return true }
     guard let child = state.activeChildren[key] else { return false }
     switch event.action {
-    case .subagentStopped, .subagentTaskUpdated, .attentionRequested, .turnStarted, .turnCompleted:
+    case .subagentStopped, .attentionRequested, .turnStarted, .turnCompleted:
       return true
     case .attentionResolved(let requestID):
       return child.phase == .needsInput
@@ -222,7 +223,7 @@ nonisolated struct TerminalAgentStateStore {
     case .turnRunning:
       return child.phase != .needsInput
     case .hoverMessagesUpdated, .progressUpdated, .sessionEnded, .sessionResumed, .sessionStarted,
-      .subagentStarted:
+      .subagentStarted, .subagentTasksUpdated:
       return false
     }
   }
@@ -310,7 +311,9 @@ nonisolated struct TerminalAgentStateStore {
       updateHoverMessages(messages, turnID: event.scope.turnID, state: &state)
     case .progressUpdated(let rows, let source):
       updateProgress(rows, source: source, turnID: event.scope.turnID, state: &state)
-    case .sessionEnded, .subagentStarted, .subagentStopped, .subagentTaskUpdated:
+    case .subagentTasksUpdated(let tasks):
+      updateChildTasks(tasks, state: &state)
+    case .sessionEnded, .subagentStarted, .subagentStopped:
       break
     }
   }
@@ -322,34 +325,47 @@ nonisolated struct TerminalAgentStateStore {
     guard let childKey = Self.childKey(for: event) else { return }
     switch event.action {
     case .subagentStarted(let nickname, let role, let transcriptPath):
+      let task = state.pendingChildTasks.removeValue(forKey: childKey.subagentID)
       state.activeChildren = state.activeChildren.filter {
         $0.key.subagentID != childKey.subagentID || $0.key == childKey
       }
       if let child = state.activeChildren[childKey] {
-        state.activeChildren[childKey] = child.updating(
+        let child = child.updating(
           nickname: nickname,
           role: role,
           transcriptPath: transcriptPath
         )
+        state.activeChildren[childKey] = task.map(child.updating(task:)) ?? child
       } else {
         state.activeChildren[childKey] = TerminalAgentActiveChild(
           id: childKey,
           nickname: nickname,
           role: role,
           transcriptPath: transcriptPath,
-          task: nil,
+          task: task,
           phase: .running,
           detail: nil
         )
       }
     case .subagentStopped:
+      if let task = state.activeChildren[childKey]?.task {
+        state.pendingChildTasks[childKey.subagentID] = task
+      }
       state.activeChildren.removeValue(forKey: childKey)
-    case .subagentTaskUpdated(let task):
-      guard let child = state.activeChildren[childKey] else { return }
-      state.activeChildren[childKey] = child.updating(task: task)
     default:
       updateChild(event.action, key: childKey, state: &state)
     }
+  }
+
+  private func updateChildTasks(
+    _ tasks: [String: String],
+    state: inout SessionState
+  ) {
+    let activeIDs = Set(state.activeChildren.keys.map(\.subagentID))
+    for (key, child) in state.activeChildren {
+      state.activeChildren[key] = child.updating(task: tasks[key.subagentID])
+    }
+    state.pendingChildTasks = tasks.filter { !activeIDs.contains($0.key) }
   }
 
   private func updateChild(
@@ -386,6 +402,7 @@ nonisolated struct TerminalAgentStateStore {
     state: inout SessionState
   ) {
     state.activeChildren = state.activeChildren.filter { $0.key.turnID == turnID }
+    state.pendingChildTasks = [:]
     state.turnLifecycle = .active(turnID)
     state.isActionable = true
     state.phase = .running
@@ -781,7 +798,7 @@ extension TerminalAgentActiveChild {
     )
   }
 
-  fileprivate nonisolated func updating(task: String) -> Self {
+  fileprivate nonisolated func updating(task: String?) -> Self {
     Self(
       id: id,
       nickname: nickname,

--- a/apps/mac/supaterm/Features/Terminal/Views/AgentPanelView.swift
+++ b/apps/mac/supaterm/Features/Terminal/Views/AgentPanelView.swift
@@ -168,7 +168,7 @@ struct AgentPanelView: View {
   }
 
   static func childDetail(_ child: TerminalAgentActiveChild) -> String {
-    child.detail ?? "Working…"
+    child.displayDetail ?? "Working…"
   }
 
   private static func normalizedChildLabel(_ value: String?) -> String? {

--- a/apps/mac/supatermTests/ClaudeProgressFixtures.swift
+++ b/apps/mac/supatermTests/ClaudeProgressFixtures.swift
@@ -142,6 +142,25 @@ enum ClaudeProgressFixtures {
     )
   }
 
+  static func appendAsyncAgentResult(
+    agentID: String,
+    description: String,
+    to transcriptURL: URL
+  ) throws {
+    try appendLine(
+      [
+        "type": "user",
+        "toolUseResult": [
+          "isAsync": true,
+          "status": "async_launched",
+          "agentId": agentID,
+          "description": description,
+        ],
+      ],
+      to: transcriptURL
+    )
+  }
+
   static func appendTaskReminder(
     _ tasks: [[String: Any]],
     to transcriptURL: URL

--- a/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
+++ b/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
@@ -174,6 +174,26 @@ struct ClaudeProgressMonitorTests {
   }
 
   @Test
+  func transcriptResetClearsChildTasks() throws {
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    try ClaudeProgressFixtures.appendAsyncAgentResult(
+      agentID: "child-1",
+      description: "Explore UI test infrastructure",
+      to: transcriptURL
+    )
+    let monitor = ClaudePanelMonitor()
+    let tick = try #require(AgentTranscriptTailer.start(at: transcriptURL.path))
+    _ = try #require(monitor.consume(AgentTranscriptUpdate(tick)))
+
+    let snapshot = try #require(
+      monitor.consume(AgentTranscriptUpdate(objects: [], didReset: true))
+    )
+
+    #expect(snapshot.childTasks.isEmpty)
+  }
+
+  @Test
   func taskCreateAndUpdateTranscriptProducesProgressRows() throws {
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }

--- a/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
+++ b/apps/mac/supatermTests/ClaudeProgressMonitorTests.swift
@@ -158,6 +158,22 @@ struct ClaudeProgressMonitorTests {
   }
 
   @Test
+  func asyncAgentResultProducesChildTask() throws {
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    try ClaudeProgressFixtures.appendAsyncAgentResult(
+      agentID: "child-1",
+      description: " Explore UI test infrastructure ",
+      to: transcriptURL
+    )
+
+    let tick = try #require(AgentTranscriptTailer.start(at: transcriptURL.path))
+    let snapshot = try #require(ClaudePanelMonitor().consume(AgentTranscriptUpdate(tick)))
+
+    #expect(snapshot.childTasks == ["child-1": "Explore UI test infrastructure"])
+  }
+
+  @Test
   func taskCreateAndUpdateTranscriptProducesProgressRows() throws {
     let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
     defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }

--- a/apps/mac/supatermTests/TerminalAgentEventTranslatorTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentEventTranslatorTests.swift
@@ -410,7 +410,7 @@ struct TerminalAgentEventTranslatorTests {
   }
 
   @Test
-  func scopedChildActivityDoesNotSynthesizeLifecycle() throws {
+  func claudeChildToolActivityDoesNotReplaceTask() throws {
     let request = try request(
       agent: .claude,
       json: #"""
@@ -426,9 +426,7 @@ struct TerminalAgentEventTranslatorTests {
 
     let events = TerminalAgentEventTranslator.events(for: request)
 
-    #expect(events.map(\.scope.sessionID) == ["root-1"])
-    #expect(events.map(\.scope.subagentID) == ["child-1"])
-    #expect(events.map(\.action) == [.turnRunning(detail: "Bash")])
+    #expect(events.isEmpty)
   }
 
   private func request(

--- a/apps/mac/supatermTests/TerminalAgentPanelTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentPanelTests.swift
@@ -25,7 +25,16 @@ struct TerminalAgentPanelTests {
   func childDetailFallsBackWhileWaitingForFirstMessage() {
     #expect(AgentPanelView.childDetail(child()) == "Working…")
     #expect(
-      AgentPanelView.childDetail(child(detail: "Tracing persistence failure behavior"))
+      AgentPanelView.childDetail(child(task: "Explore UI test infrastructure"))
+        == "Explore UI test infrastructure"
+    )
+    #expect(
+      AgentPanelView.childDetail(
+        child(
+          task: "Explore UI test infrastructure",
+          detail: "Tracing persistence failure behavior"
+        )
+      )
         == "Tracing persistence failure behavior"
     )
   }
@@ -33,6 +42,7 @@ struct TerminalAgentPanelTests {
   private func child(
     nickname: String? = nil,
     role: String? = nil,
+    task: String? = nil,
     detail: String? = nil
   ) -> TerminalAgentActiveChild {
     TerminalAgentActiveChild(
@@ -43,6 +53,7 @@ struct TerminalAgentPanelTests {
       ),
       nickname: nickname,
       role: role,
+      task: task,
       phase: .running,
       detail: detail
     )

--- a/apps/mac/supatermTests/TerminalAgentStateStoreChildTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentStateStoreChildTests.swift
@@ -266,6 +266,38 @@ extension TerminalAgentStateStoreTests {
   }
 
   @Test
+  func resolvedChildAttentionFallsBackToTask() throws {
+    let fixture = startedStore()
+    let surfaceID = fixture.surfaceID
+    let context = fixture.context
+    var store = fixture.store
+
+    for action in [
+      TerminalAgentEvent.Action.subagentStarted(nickname: nil, role: "Explore"),
+      .subagentTaskUpdated("Explore UI test infrastructure"),
+      .attentionRequested(requestID: "tool:Bash", message: "Approve command"),
+      .attentionResolved(requestID: "tool:Bash"),
+    ] {
+      store.apply(
+        event(
+          sessionID: "session-1",
+          turnID: "turn-1",
+          subagentID: "child-1",
+          context: context,
+          action: action
+        )
+      )
+    }
+
+    let child = try #require(
+      store.presentation(for: surfaceID, agent: .codex)?.activeChildren.first
+    )
+    #expect(child.phase == .running)
+    #expect(child.detail == nil)
+    #expect(child.displayDetail == "Explore UI test infrastructure")
+  }
+
+  @Test
   func staleChildStopCannotRemoveNewerChildScope() throws {
     let fixture = startedStore()
     let surfaceID = fixture.surfaceID

--- a/apps/mac/supatermTests/TerminalAgentStateStoreChildTests.swift
+++ b/apps/mac/supatermTests/TerminalAgentStateStoreChildTests.swift
@@ -272,12 +272,28 @@ extension TerminalAgentStateStoreTests {
     let context = fixture.context
     var store = fixture.store
 
-    for action in [
-      TerminalAgentEvent.Action.subagentStarted(nickname: nil, role: "Explore"),
-      .subagentTaskUpdated("Explore UI test infrastructure"),
+    store.apply(
+      event(
+        sessionID: "session-1",
+        turnID: "turn-1",
+        subagentID: "child-1",
+        context: context,
+        action: .subagentStarted(nickname: nil, role: "Explore")
+      )
+    )
+    store.apply(
+      event(
+        sessionID: "session-1",
+        turnID: "turn-1",
+        context: context,
+        action: .subagentTasksUpdated(["child-1": "Explore UI test infrastructure"])
+      )
+    )
+    let attentionActions: [TerminalAgentEvent.Action] = [
       .attentionRequested(requestID: "tool:Bash", message: "Approve command"),
       .attentionResolved(requestID: "tool:Bash"),
-    ] {
+    ]
+    for action in attentionActions {
       store.apply(
         event(
           sessionID: "session-1",
@@ -295,6 +311,48 @@ extension TerminalAgentStateStoreTests {
     #expect(child.phase == .running)
     #expect(child.detail == nil)
     #expect(child.displayDetail == "Explore UI test infrastructure")
+  }
+
+  @Test
+  func childTaskProjectionWaitsForChildAndClearsMissingTasks() throws {
+    let fixture = startedStore()
+    let surfaceID = fixture.surfaceID
+    let context = fixture.context
+    var store = fixture.store
+
+    store.apply(
+      event(
+        sessionID: "session-1",
+        turnID: "turn-1",
+        context: context,
+        action: .subagentTasksUpdated(["child-1": "Explore UI test infrastructure"])
+      )
+    )
+    store.apply(
+      event(
+        sessionID: "session-1",
+        turnID: "turn-1",
+        subagentID: "child-1",
+        context: context,
+        action: .subagentStarted(nickname: nil, role: "Explore")
+      )
+    )
+
+    #expect(
+      store.presentation(for: surfaceID, agent: .codex)?.activeChildren.first?.task
+        == "Explore UI test infrastructure"
+    )
+
+    store.apply(
+      event(
+        sessionID: "session-1",
+        turnID: "turn-1",
+        context: context,
+        action: .subagentTasksUpdated([:])
+      )
+    )
+
+    #expect(store.presentation(for: surfaceID, agent: .codex)?.activeChildren.first?.task == nil)
   }
 
   @Test

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -144,6 +144,71 @@ struct TerminalCommandExecutorAgentHookTests {
     #expect(harness.host.agentActivity(for: harness.tabID) == .claude(.running))
   }
   @Test
+  func claudeChildTaskMatchesAgentManagerAndSurvivesToolHooks() async throws {
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          cwd: ClaudeHookFixtures.cwd,
+          hookEventName: .sessionStart,
+          sessionID: ClaudeHookFixtures.sessionID,
+          transcriptPath: transcriptURL.path
+        )
+      )
+    )
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          agentType: "Explore",
+          hookEventName: .subagentStart,
+          sessionID: ClaudeHookFixtures.sessionID,
+          transcriptPath: transcriptURL.path,
+          agentID: "child-1"
+        )
+      )
+    )
+    try ClaudeProgressFixtures.appendAsyncAgentResult(
+      agentID: "child-1",
+      description: "Explore UI test infrastructure",
+      to: transcriptURL
+    )
+
+    let didLoadTask = await waitUntil {
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?
+        .activeChildren.first?.task == "Explore UI test infrastructure"
+    }
+    #expect(didLoadTask)
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          agentType: "Explore",
+          hookEventName: .preToolUse,
+          sessionID: ClaudeHookFixtures.sessionID,
+          toolName: "Bash",
+          transcriptPath: transcriptURL.path,
+          agentID: "child-1"
+        )
+      )
+    )
+
+    let child = try #require(
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?
+        .activeChildren.first
+    )
+    #expect(AgentPanelView.childTitle(child) == "Explore")
+    #expect(AgentPanelView.childDetail(child) == "Explore UI test infrastructure")
+  }
+  @Test
   func commandFinishedClearsAgentActivityAndStoredSessionRouting() throws {
     let harness = try makeClaudeHookHarness()
 

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -122,7 +122,7 @@ The app binds Claude sessions to pane surfaces, tracks the foreground session fo
 - `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided.
 - While the tab is `running`, transcript file events re-arm the running timeout, so long tool calls and streaming responses do not flip the tab to `idle` between hooks.
 - `SessionEnd` clears the tab activity and drops the stored session state.
-- `SubagentStart` and `SubagentStop` add and remove scoped child-agent rows without allowing a child to replace the foreground root session.
+- `SubagentStart` and `SubagentStop` add and remove scoped child-agent rows without allowing a child to replace the foreground root session. Async agent results supply the same task descriptions Claude shows in its agent manager, and child tool hooks cannot replace them with tool names.
 - A command-finished signal from the shell clears pane-bound agent state and transcript observation.
 
 The panel monitor reads Claude task progress from the hook `transcript_path`. File-system events trigger incremental reads; partial JSON lines, truncation, replacement, and oversized records are handled without polling the file once per second.


### PR DESCRIPTION

## Why

Active Agents replaces a subagent's assigned task with its latest tool name, so two exploration agents appear as `Bash` and `Read` instead of describing their work. The session transcript already contains the task description in async agent results, making that the single authoritative source.

## What changed

The transcript monitor projects each child task into the matching subagent row and preserves it separately from transient response or attention detail. Child tool hooks no longer overwrite the row, so resolving attention falls back to the assigned task.

## Verification

Before:

```text
Explore  Bash
Explore  Read
```

After:

```text
Explore  Explore UI test infrastructure
Explore  Explore session restoration code
```

`make mac-check`, `make mac-test`, and `make mac-scan-dead-code` passed. Repository pre-push checks also passed.

> [!NOTE]
> This intentionally does not add elapsed-time or token counters.
