### PR TITLE
agent-hooks: suppress active goal completion notifications

### DIFF
--- a/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
+++ b/apps/mac/supaterm/App/TerminalCommandExecutor+AgentHooks.swift
@@ -41,6 +41,12 @@ extension TerminalCommandExecutor {
     else {
       return TerminalAgentHookResult(desktopNotification: nil)
     }
+    let suppressesCompletionNotification =
+      request.agent == .claude
+      && terminal.agentSessionHasActiveGoal(
+        agent: request.agent,
+        sessionID: events[0].scope.sessionID
+      )
 
     var didChange = false
     var didAccept = false
@@ -61,7 +67,11 @@ extension TerminalCommandExecutor {
       else {
         continue
       }
-      if let notification = notification(for: event, request: request) {
+      if let notification = notification(
+        for: event,
+        request: request,
+        suppressesCompletion: suppressesCompletionNotification
+      ) {
         result = try handleAgentEventNotification(
           event.scope.agent,
           event: request.event,
@@ -207,7 +217,8 @@ extension TerminalCommandExecutor {
 
   private func notification(
     for event: TerminalAgentEvent,
-    request: SupatermAgentHookRequest
+    request: SupatermAgentHookRequest,
+    suppressesCompletion: Bool
   ) -> AgentHookNotification? {
     let body: String?
     let semantic: TerminalHostState.NotificationSemantic
@@ -217,6 +228,8 @@ extension TerminalCommandExecutor {
       body = message ?? request.event.notificationMessage()
       semantic = .attention
       subtitle = request.event.title ?? "Attention"
+    case .turnCompleted where suppressesCompletion:
+      return nil
     case .turnCompleted(let message):
       body = message
       semantic = .completion

--- a/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
+++ b/apps/mac/supaterm/Features/Terminal/TerminalHostState+Agents.swift
@@ -354,6 +354,18 @@ extension TerminalHostState {
     agentStateStore.isForeground(agent: agent, sessionID: sessionID)
   }
 
+  func agentSessionHasActiveGoal(agent: SupatermAgentKind, sessionID: String) -> Bool {
+    guard let surfaceID = agentStateStore.surfaceID(agent: agent, sessionID: sessionID),
+      let presentation = agentStateStore.presentation(for: surfaceID, agent: agent),
+      presentation.sessionID == sessionID
+    else {
+      return false
+    }
+    return presentation.progressRows.contains {
+      $0.kind == .goal && $0.status == .running
+    }
+  }
+
   func agentTranscriptTargets() -> [TerminalAgentTranscriptTarget] {
     liveSurfaceIDs().flatMap { surfaceID -> [TerminalAgentTranscriptTarget] in
       guard let context = agentContext(for: surfaceID) else { return [] }

--- a/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
+++ b/apps/mac/supatermTests/TerminalCommandExecutorAgentHookTests.swift
@@ -131,6 +131,50 @@ struct TerminalCommandExecutorAgentHookTests {
     #expect(didLoadProgress)
   }
   @Test
+  func claudeStopWithActiveGoalDoesNotMarkPaneUnread() async throws {
+    let transcriptURL = try ClaudeProgressFixtures.makeTranscript()
+    defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+    try ClaudeProgressFixtures.appendGoalStatus(
+      condition: "CI passes, tests are valid",
+      met: false,
+      to: transcriptURL
+    )
+    let harness = try makeClaudeHookHarness()
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      SupatermAgentHookRequest(
+        agent: .claude,
+        context: harness.context,
+        event: SupatermAgentHookEvent(
+          cwd: ClaudeHookFixtures.cwd,
+          hookEventName: .sessionStart,
+          sessionID: ClaudeHookFixtures.sessionID,
+          transcriptPath: transcriptURL.path
+        )
+      )
+    )
+    let didLoadGoal = await waitUntil {
+      harness.host.agentPanelPresentation(for: harness.context.surfaceID)?.progressRows == [
+        PaneAgentProgressRow(
+          id: "claude-goal:CI passes, tests are valid",
+          title: "Goal: CI passes, tests are valid",
+          status: .running,
+          kind: .goal
+        )
+      ]
+    }
+    #expect(didLoadGoal)
+    _ = try harness.commandExecutor.handleAgentHook(
+      ClaudeHookFixtures.request(ClaudeHookFixtures.preToolUse, context: harness.context)
+    )
+
+    _ = try harness.commandExecutor.handleAgentHook(
+      ClaudeHookFixtures.request(ClaudeHookFixtures.stop)
+    )
+
+    #expect(harness.host.unreadNotificationCount(for: harness.tabID) == 0)
+  }
+  @Test
   func claudePreToolUseMarksTabRunning() throws {
     let harness = try makeClaudeHookHarness()
 

--- a/docs/coding-agents-integration.md
+++ b/docs/coding-agents-integration.md
@@ -119,7 +119,7 @@ The app binds Claude sessions to pane surfaces, tracks the foreground session fo
 - `Notification` marks the tab as `needs input` only for `permission_prompt`, `idle_prompt`, and `elicitation_dialog`.
 - `UserPromptSubmit` marks the tab as `running`.
 - `PreToolUse`, `PostToolUse`, and `UserPromptSubmit` recover the pane binding when `SessionStart` was missed or announced a different session ID, which is what `claude --fork-session --resume` does: its `SessionStart` reports the parent session ID and every later hook carries the forked one.
-- `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided.
+- `Stop` marks the tab as `idle` and stores the final assistant message as the latest tab notification when one is provided, unless the transcript still reports an active goal.
 - While the tab is `running`, transcript file events re-arm the running timeout, so long tool calls and streaming responses do not flip the tab to `idle` between hooks.
 - `SessionEnd` clears the tab activity and drops the stored session state.
 - `SubagentStart` and `SubagentStop` add and remove scoped child-agent rows without allowing a child to replace the foreground root session.


### PR DESCRIPTION

## Why

While `/goal` is active, the transcript can still report `met: false` when a `Stop` hook fires between goal iterations. Supaterm translated every `Stop` into a completed-turn notification, stored it as unread, and lit the pane ring even though the goal remained active and no actionable notification occurred.

The goal monitor already projects the transcript's running goal into session state. Reading that projection before applying `Stop` distinguishes a provisional completion from a real one without adding another source of truth or delaying the lifecycle transition.

## What changed

For the foreground session, `Stop` still marks the tab idle, but its completion notification is skipped while the existing transcript projection contains a running goal. Attention notifications and ordinary completed turns are unchanged.

## Verification

The new `claudeStopWithActiveGoalDoesNotMarkPaneUnread` regression test failed before the implementation because the unread count became `1`; it passes after the fix with the active goal row still present. `make mac-test-xcodebuild` finishes with `Test Succeeded`, SwiftLint exits cleanly, and Periphery reports `No unused code detected`.

> [!NOTE]
> This does not change goal enforcement, integration settings, or CLI behavior. It suppresses only the completion notification while a running goal is already derived from the same session transcript.
