### PR TITLE
mac: cover session restore with a UI test, fix default space identity

### DIFF
--- a/apps/mac/supaterm/Features/Terminal/Models/TerminalSpaceID.swift
+++ b/apps/mac/supaterm/Features/Terminal/Models/TerminalSpaceID.swift
@@ -90,7 +90,7 @@ nonisolated struct TerminalSpaceCatalog: Equatable, Codable, Sendable {
 
   private static func makeDefault() -> Self {
     let space = PersistedTerminalSpace(
-      id: TerminalSpaceID(),
+      id: TerminalSpaceID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!),
       name: "1"
     )
     return Self(

--- a/apps/mac/supatermTests/TerminalSpaceCatalogTests.swift
+++ b/apps/mac/supatermTests/TerminalSpaceCatalogTests.swift
@@ -29,6 +29,14 @@ struct TerminalSpaceCatalogTests {
   }
 
   @Test
+  func defaultSpaceIdentityIsStableAcrossLaunches() {
+    #expect(
+      TerminalSpaceCatalog.default.defaultSelectedSpaceID
+        == TerminalSpaceID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    )
+  }
+
+  @Test
   func sanitizedFallsBackToDefaultCatalogWhenCatalogIsMissingOrInvalid() {
     let invalidSpace = PersistedTerminalSpace(name: "   ")
 

--- a/apps/mac/supatermUITests/SearchPasteUITests.swift
+++ b/apps/mac/supatermUITests/SearchPasteUITests.swift
@@ -8,23 +8,10 @@ final class SearchPasteUITests: XCTestCase {
 
   @MainActor
   func testUserCanPasteIntoSearchAfterReactivatingApp() async throws {
-    let token = UUID().uuidString
-    let stateHome = FileManager.default.temporaryDirectory
-      .appendingPathComponent("supaterm-ui-\(token)", isDirectory: true)
-    let home = stateHome.appendingPathComponent("home", isDirectory: true)
-    let zmx = stateHome.appendingPathComponent("zmx", isDirectory: true)
+    let harness = try SupatermUITestApp.makeIsolated()
+    let app = harness.app
+    let stateHome = harness.stateHome
     let pasteboardItems = pasteboardSnapshot()
-    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-    try FileManager.default.createDirectory(at: zmx, withIntermediateDirectories: true)
-
-    let app = XCUIApplication()
-    app.launchArguments = ["-ApplePersistenceIgnoreState", "YES"]
-    app.launchEnvironment = [
-      "HOME": home.path,
-      "SUPATERM_INSTANCE_NAME": "ui-\(token)",
-      "SUPATERM_STATE_HOME": stateHome.path,
-      "ZMX_DIR": zmx.path,
-    ]
     addTeardownBlock {
       app.terminate()
       NSPasteboard.general.clearContents()
@@ -32,11 +19,7 @@ final class SearchPasteUITests: XCTestCase {
       try? FileManager.default.removeItem(at: stateHome)
     }
 
-    app.launch()
-    app.activate()
-    XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
-    let terminal = app.textViews.firstMatch
-    XCTAssertTrue(terminal.waitForExistence(timeout: 30))
+    let terminal = harness.launchAndWaitForTerminal()
     terminal.click()
 
     let readinessText = "search focus ready"

--- a/apps/mac/supatermUITests/SessionRestoreUITests.swift
+++ b/apps/mac/supatermUITests/SessionRestoreUITests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import XCTest
+
+final class SessionRestoreUITests: XCTestCase {
+  override func setUp() {
+    continueAfterFailure = false
+  }
+
+  @MainActor
+  func testLayoutAndSessionsSurviveQuitAndRelaunch() async throws {
+    let harness = try SupatermUITestApp.makeIsolated()
+    let app = harness.app
+    let stateHome = harness.stateHome
+    addTeardownBlock {
+      app.terminate()
+      try? FileManager.default.removeItem(at: stateHome)
+    }
+
+    let terminal = harness.launchAndWaitForTerminal()
+    terminal.click()
+
+    app.typeKey("d", modifierFlags: .command)
+    try await waitForPaneCount(app, 2)
+    app.typeKey("d", modifierFlags: [.command, .shift])
+    try await waitForPaneCount(app, 3)
+
+    app.typeKey("t", modifierFlags: .command)
+    try await waitForPaneCount(app, 1)
+    app.typeKey("d", modifierFlags: .command)
+    try await waitForPaneCount(app, 2)
+
+    let token = UUID().uuidString
+    let marker = "restore-\(token)"
+    try await Task.sleep(for: .milliseconds(500))
+    app.typeText("echo \"re\"store-\(token)\n")
+    try await waitForPaneValue(app, containing: marker)
+
+    let savedLayout = try await waitForSessionLayout(at: harness.sessionFileURL) { layout in
+      layout.selectedTabIndex == 1
+        && layout.tabs.count == 2
+        && layout.tabs[0].leafIDs.count == 3
+        && layout.tabs[1].leafIDs.count == 2
+    }
+
+    quit(app, returnModifiers: [])
+
+    app.launch()
+    app.activate()
+    XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
+    try await waitForPaneCount(app, 2)
+    try await waitForPaneValue(app, containing: marker)
+    try await waitForSessionLayout(at: harness.sessionFileURL) { $0 == savedLayout }
+
+    quit(app, returnModifiers: .shift)
+  }
+
+  @MainActor
+  private func quit(
+    _ app: XCUIApplication,
+    returnModifiers: XCUIElement.KeyModifierFlags
+  ) {
+    app.typeKey("q", modifierFlags: .command)
+    XCTAssertTrue(app.buttons["Quit"].waitForExistence(timeout: 10))
+    app.typeKey(.return, modifierFlags: returnModifiers)
+    XCTAssertTrue(app.wait(for: .notRunning, timeout: 30))
+  }
+
+  @MainActor
+  private func waitForPaneCount(
+    _ app: XCUIApplication,
+    _ expected: Int,
+    timeout: TimeInterval = 30
+  ) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if app.textViews.count == expected { return }
+      try await Task.sleep(for: .milliseconds(200))
+    }
+    XCTAssertEqual(app.textViews.count, expected)
+  }
+
+  @MainActor
+  private func waitForPaneValue(
+    _ app: XCUIApplication,
+    containing marker: String,
+    timeout: TimeInterval = 30
+  ) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      let values = app.textViews.allElementsBoundByIndex.compactMap { $0.value as? String }
+      if values.contains(where: { $0.contains(marker) }) { return }
+      try await Task.sleep(for: .milliseconds(200))
+    }
+    XCTFail("No pane shows \(marker)")
+  }
+
+  @discardableResult
+  private func waitForSessionLayout(
+    at url: URL,
+    timeout: TimeInterval = 30,
+    matching predicate: (SessionLayout) -> Bool
+  ) async throws -> SessionLayout {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if let layout = sessionLayout(at: url), predicate(layout) {
+        return layout
+      }
+      try await Task.sleep(for: .milliseconds(200))
+    }
+    let lastLayout = sessionLayout(at: url)
+    return try XCTUnwrap(
+      lastLayout.flatMap { predicate($0) ? $0 : nil },
+      "Timed out waiting for session layout, last saw \(String(describing: lastLayout))"
+    )
+  }
+
+  private func sessionLayout(at url: URL) -> SessionLayout? {
+    guard
+      let data = try? Data(contentsOf: url),
+      let catalog = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let windows = catalog["windows"] as? [[String: Any]],
+      windows.count == 1,
+      let spaces = windows[0]["spaces"] as? [[String: Any]],
+      spaces.count == 1,
+      let tabs = spaces[0]["tabs"] as? [[String: Any]]
+    else { return nil }
+    return SessionLayout(
+      selectedTabIndex: spaces[0]["selectedTabIndex"] as? Int,
+      tabs: tabs.compactMap { tab in
+        guard let root = tab["root"] as? [String: Any] else { return nil }
+        var leafIDs: [String] = []
+        var splitDirections: [String] = []
+        flatten(root, into: &leafIDs, &splitDirections)
+        return SessionTabLayout(leafIDs: leafIDs, splitDirections: splitDirections)
+      }
+    )
+  }
+
+  private func flatten(
+    _ node: [String: Any],
+    into leafIDs: inout [String],
+    _ splitDirections: inout [String]
+  ) {
+    if let leaf = node["leaf"] as? [String: Any], let id = leaf["id"] as? String {
+      leafIDs.append(id)
+    }
+    guard let split = node["split"] as? [String: Any] else { return }
+    splitDirections.append(split["direction"] as? String ?? "")
+    if let left = split["left"] as? [String: Any] {
+      flatten(left, into: &leafIDs, &splitDirections)
+    }
+    if let right = split["right"] as? [String: Any] {
+      flatten(right, into: &leafIDs, &splitDirections)
+    }
+  }
+}
+
+private struct SessionLayout: Equatable {
+  let selectedTabIndex: Int?
+  let tabs: [SessionTabLayout]
+}
+
+private struct SessionTabLayout: Equatable {
+  let leafIDs: [String]
+  let splitDirections: [String]
+}

--- a/apps/mac/supatermUITests/SupatermUITestApp.swift
+++ b/apps/mac/supatermUITests/SupatermUITestApp.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+
+struct SupatermUITestApp {
+  let app: XCUIApplication
+  let stateHome: URL
+
+  var sessionFileURL: URL {
+    stateHome.appendingPathComponent("session.json")
+  }
+
+  static func makeIsolated() throws -> SupatermUITestApp {
+    let token = UUID().uuidString
+    let stateHome = FileManager.default.temporaryDirectory
+      .appendingPathComponent("supaterm-ui-\(token)", isDirectory: true)
+    let home = stateHome.appendingPathComponent("home", isDirectory: true)
+    let zmx = stateHome.appendingPathComponent("zmx", isDirectory: true)
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: zmx, withIntermediateDirectories: true)
+    try Data("0".utf8).write(to: stateHome.appendingPathComponent("launch-state.json"))
+
+    let app = XCUIApplication()
+    app.launchArguments = ["-ApplePersistenceIgnoreState", "YES"]
+    app.launchEnvironment = [
+      "HOME": home.path,
+      "SUPATERM_INSTANCE_NAME": "ui-\(token)",
+      "SUPATERM_STATE_HOME": stateHome.path,
+      "ZMX_DIR": zmx.path,
+    ]
+    return SupatermUITestApp(app: app, stateHome: stateHome)
+  }
+
+  @MainActor
+  func launchAndWaitForTerminal() -> XCUIElement {
+    app.launch()
+    app.activate()
+    XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
+    let terminal = app.textViews.firstMatch
+    XCTAssertTrue(terminal.waitForExistence(timeout: 30))
+    return terminal
+  }
+}


### PR DESCRIPTION

## Why

Session-restore coverage lived entirely in the socket-driven E2E suite, which builds layouts through socket commands and quits through the socket bypass — never through the UI a user actually touches. Driving the same flow with keyboard shortcuts and the real ⌘Q confirmation panel immediately surfaced a real bug: a vanilla session, with only the untouched default space, silently loses its entire layout on every relaunch.

Root cause: `spaces.json` is only written when spaces are mutated (create, rename, delete, or change the default selection), and `TerminalSpaceCatalog.makeDefault()` minted a random space ID per process. On relaunch the persisted window's space ID never matched the freshly minted catalog, so `restore(from:)` pruned every space (`reason=emptyAfterPrune`) and fell back to a fresh window. The E2E restore tests mask this because creating a space via socket writes `spaces.json`. A fixed default space ID makes every launch reconstruct the same catalog without persisting anything derivable.

## What changed

- `SessionRestoreUITests` builds three panes in one tab (⌘D, ⌘⇧D), a second tab with a split (⌘T, ⌘D), echoes a marker, quits through the confirmation panel preserving sessions, relaunches, and asserts the restored pane layout, the marker back on screen via zmx re-attach, and an identical `session.json` structure including pane UUIDs.
- The isolated-launch boilerplate moved from `SearchPasteUITests` into a shared `SupatermUITestApp` harness, which now also pre-seeds `launch-state.json` so tests skip onboarding.
- `TerminalSpaceCatalog.makeDefault()` uses a fixed space ID, with a regression unit test pinning it.

## Verification

The new UI test failed on CI before the fix — the relaunched app came back with a single fresh tab instead of the built layout (run 29366915924, video artifact shows the fresh "Terminal 1" tab) — and the restored layout survives with the fix, where the failure-time hierarchy shows both tabs and the two-pane split restored (run 29368179770). The `mac-test-ui` workflow on this branch runs both UI tests green end to end.

> [!NOTE]
> The UI test asserts restoration of the selected tab, pane tree, and scrollback. It deliberately does not exercise multi-space or pinned-tab restoration — the E2E suite already covers those paths via socket.
